### PR TITLE
Add {SeriesNumber:00} zero-padding support (#522)

### DIFF
--- a/fe/src/components/settings/FileManagementSection.vue
+++ b/fe/src/components/settings/FileManagementSection.vue
@@ -152,7 +152,7 @@
               <li><code>{Asin}</code> - Audible ASIN</li>
               <li>
                 <code>{SeriesNumber}</code> or <code>{SeriesNumber:00}</code> - Position in series (00 =
-                zero-padded)
+                zero-padded; decimal positions like 4.5 are not padded)
               </li>
               <li><code>{Year}</code> - Publication year</li>
             </ul>
@@ -175,7 +175,7 @@
               <li><code>{Asin}</code> - Audible ASIN</li>
               <li>
                 <code>{SeriesNumber}</code> or <code>{SeriesNumber:00}</code> - Position in series (00 =
-                zero-padded)
+                zero-padded; decimal positions like 4.5 are not padded)
               </li>
               <li>
                 <code>{DiskNumber}</code> or <code>{DiskNumber:00}</code> - Disk/part number (00 =
@@ -253,7 +253,7 @@ function applyPattern(
   // Replace all variables with sample values
   for (const [key, value] of Object.entries(sampleVariables)) {
     if (key === 'DiskNumber' || key === 'ChapterNumber' || key === 'SeriesNumber') {
-      // Handle zero-padding for disk and chapter numbers using the sample value
+      // Handle zero-padding for disk, chapter, and series numbers using the sample value
       const paddedRegex = new RegExp(`\\{${key}:00\\}`, 'g')
       const paddedSample = value.toString().padStart(2, '0')
       result = result.replace(paddedRegex, paddedSample)

--- a/fe/src/components/settings/FileManagementSection.vue
+++ b/fe/src/components/settings/FileManagementSection.vue
@@ -150,7 +150,10 @@
               <li><code>{Publisher}</code> - Publisher name</li>
               <li><code>{Language}</code> - Metadata language</li>
               <li><code>{Asin}</code> - Audible ASIN</li>
-              <li><code>{SeriesNumber}</code> - Position in series</li>
+              <li>
+                <code>{SeriesNumber}</code> or <code>{SeriesNumber:00}</code> - Position in series (00 =
+                zero-padded)
+              </li>
               <li><code>{Year}</code> - Publication year</li>
             </ul>
             <p class="example"><strong>Example:</strong> <code>{Author}/{Series}/{Title}</code></p>
@@ -170,7 +173,10 @@
               <li><code>{Publisher}</code> - Publisher name</li>
               <li><code>{Language}</code> - Metadata language</li>
               <li><code>{Asin}</code> - Audible ASIN</li>
-              <li><code>{SeriesNumber}</code> - Position in series</li>
+              <li>
+                <code>{SeriesNumber}</code> or <code>{SeriesNumber:00}</code> - Position in series (00 =
+                zero-padded)
+              </li>
               <li>
                 <code>{DiskNumber}</code> or <code>{DiskNumber:00}</code> - Disk/part number (00 =
                 zero-padded)
@@ -246,7 +252,7 @@ function applyPattern(
 
   // Replace all variables with sample values
   for (const [key, value] of Object.entries(sampleVariables)) {
-    if (key === 'DiskNumber' || key === 'ChapterNumber') {
+    if (key === 'DiskNumber' || key === 'ChapterNumber' || key === 'SeriesNumber') {
       // Handle zero-padding for disk and chapter numbers using the sample value
       const paddedRegex = new RegExp(`\\{${key}:00\\}`, 'g')
       const paddedSample = value.toString().padStart(2, '0')

--- a/tests/Features/Api/Services/Import_PatternIntegrationTests.cs
+++ b/tests/Features/Api/Services/Import_PatternIntegrationTests.cs
@@ -443,6 +443,7 @@ namespace Listenarr.Tests.Features.Api.Services
             // Assert - no series number, so the variable and surrounding separator should be cleaned up
             Assert.Contains("Standalone Book", result);
             Assert.DoesNotContain("00", result);
+            Assert.DoesNotContain(" - .", result);
         }
 
         [Fact]

--- a/tests/Features/Api/Services/Import_PatternIntegrationTests.cs
+++ b/tests/Features/Api/Services/Import_PatternIntegrationTests.cs
@@ -318,5 +318,163 @@ namespace Listenarr.Tests.Features.Api.Services
             Assert.Contains("D02", result);
             Assert.Contains("C05", result);
         }
+
+        [Fact]
+        public async Task FileNamingService_SeriesNumberWithZeroPadding_PadsCorrectly()
+        {
+            // Arrange
+            var mockConfig = new Mock<IConfigurationService>();
+            mockConfig.Setup(c => c.GetApplicationSettingsAsync())
+                .ReturnsAsync(new ApplicationSettings
+                {
+                    OutputPath = "/audiobooks",
+                    FolderNamingPattern = "{Author}/{Series}",
+                    FileNamingPattern = "{Series} - {SeriesNumber:00} - {Title}",
+                    MultiFileNamingPattern = "{Title}-{DiskNumber:00}"
+                });
+
+            var service = new FileNamingService(mockConfig.Object, Mock.Of<ILogger<FileNamingService>>());
+
+            var metadata = new AudioMetadata
+            {
+                Title = "The Gunslinger",
+                Artist = "Stephen King",
+                Series = "The Dark Tower",
+                SeriesPosition = 1
+            };
+
+            // Act - single file audiobook with zero-padded series number
+            var result = await service.GenerateFilePathAsync(metadata, ".m4b");
+
+            // Assert - SeriesNumber should be zero-padded to "01"
+            Assert.Contains("The Dark Tower - 01 - The Gunslinger", result);
+        }
+
+        [Fact]
+        public async Task FileNamingService_SeriesNumberWithZeroPadding_TwoDigitNumberUnchanged()
+        {
+            // Arrange
+            var mockConfig = new Mock<IConfigurationService>();
+            mockConfig.Setup(c => c.GetApplicationSettingsAsync())
+                .ReturnsAsync(new ApplicationSettings
+                {
+                    OutputPath = "/audiobooks",
+                    FolderNamingPattern = "{Author}/{Series}",
+                    FileNamingPattern = "{Series} - {SeriesNumber:00} - {Title}",
+                    MultiFileNamingPattern = "{Title}-{DiskNumber:00}"
+                });
+
+            var service = new FileNamingService(mockConfig.Object, Mock.Of<ILogger<FileNamingService>>());
+
+            var metadata = new AudioMetadata
+            {
+                Title = "Wizard and Glass",
+                Artist = "Stephen King",
+                Series = "The Dark Tower",
+                SeriesPosition = 14
+            };
+
+            // Act
+            var result = await service.GenerateFilePathAsync(metadata, ".m4b");
+
+            // Assert - two-digit number should remain "14"
+            Assert.Contains("The Dark Tower - 14 - Wizard and Glass", result);
+        }
+
+        [Fact]
+        public async Task FileNamingService_SeriesNumberWithZeroPadding_DecimalPositionNotTruncated()
+        {
+            // Arrange
+            var mockConfig = new Mock<IConfigurationService>();
+            mockConfig.Setup(c => c.GetApplicationSettingsAsync())
+                .ReturnsAsync(new ApplicationSettings
+                {
+                    OutputPath = "/audiobooks",
+                    FolderNamingPattern = "{Author}/{Series}",
+                    FileNamingPattern = "{Series} - {SeriesNumber:00} - {Title}",
+                    MultiFileNamingPattern = "{Title}-{DiskNumber:00}"
+                });
+
+            var service = new FileNamingService(mockConfig.Object, Mock.Of<ILogger<FileNamingService>>());
+
+            var metadata = new AudioMetadata
+            {
+                Title = "The Wind Through the Keyhole",
+                Artist = "Stephen King",
+                Series = "The Dark Tower",
+                SeriesPosition = 4.5m
+            };
+
+            // Act
+            var result = await service.GenerateFilePathAsync(metadata, ".m4b");
+
+            // Assert - decimal position can't be int-parsed, so format is ignored and raw value used
+            Assert.Contains("4.5", result);
+            Assert.Contains("The Wind Through the Keyhole", result);
+        }
+
+        [Fact]
+        public async Task FileNamingService_SeriesNumberWithZeroPadding_NullPositionOmitted()
+        {
+            // Arrange
+            var mockConfig = new Mock<IConfigurationService>();
+            mockConfig.Setup(c => c.GetApplicationSettingsAsync())
+                .ReturnsAsync(new ApplicationSettings
+                {
+                    OutputPath = "/audiobooks",
+                    FolderNamingPattern = "{Author}",
+                    FileNamingPattern = "{Title} - {SeriesNumber:00}",
+                    MultiFileNamingPattern = "{Title}-{DiskNumber:00}"
+                });
+
+            var service = new FileNamingService(mockConfig.Object, Mock.Of<ILogger<FileNamingService>>());
+
+            var metadata = new AudioMetadata
+            {
+                Title = "Standalone Book",
+                Artist = "Some Author",
+                Series = null,
+                SeriesPosition = null
+            };
+
+            // Act
+            var result = await service.GenerateFilePathAsync(metadata, ".m4b");
+
+            // Assert - no series number, so the variable and surrounding separator should be cleaned up
+            Assert.Contains("Standalone Book", result);
+            Assert.DoesNotContain("00", result);
+        }
+
+        [Fact]
+        public async Task FileNamingService_SeriesNumberWithoutFormat_NoZeroPadding()
+        {
+            // Arrange
+            var mockConfig = new Mock<IConfigurationService>();
+            mockConfig.Setup(c => c.GetApplicationSettingsAsync())
+                .ReturnsAsync(new ApplicationSettings
+                {
+                    OutputPath = "/audiobooks",
+                    FolderNamingPattern = "{Author}/{Series}",
+                    FileNamingPattern = "{Series} - {SeriesNumber} - {Title}",
+                    MultiFileNamingPattern = "{Title}-{DiskNumber:00}"
+                });
+
+            var service = new FileNamingService(mockConfig.Object, Mock.Of<ILogger<FileNamingService>>());
+
+            var metadata = new AudioMetadata
+            {
+                Title = "The Gunslinger",
+                Artist = "Stephen King",
+                Series = "The Dark Tower",
+                SeriesPosition = 1
+            };
+
+            // Act
+            var result = await service.GenerateFilePathAsync(metadata, ".m4b");
+
+            // Assert - without :00 format, should use raw value "1" not "01"
+            Assert.Contains("The Dark Tower - 1 - The Gunslinger", result);
+            Assert.DoesNotContain(" 01 ", result);
+        }
     }
 }


### PR DESCRIPTION
 ## Summary
 
 Add `{SeriesNumber:00}` zero-padding support to file naming patterns, 
 matching the existing `{DiskNumber:00}` and `{ChapterNumber:00}` behavior.
 Fixes #522
 
 ## Changes
 
 ### Added
 - `{SeriesNumber:00}` documented in Settings help text (folder and file pattern modals)
 - 5 backend tests for SeriesNumber zero-padding (single digit, two-digit, decimal, null, unformatted)
 
 ### Changed
 - Frontend preview logic now handles SeriesNumber zero-padding alongside DiskNumber/ChapterNumber
 
 ## Testing
 
 - Backend: `dotnet test --filter "FileNamingService_SeriesNumber"` — 5/5 pass
 - Manual: Verified backend formatting engine already supports `{SeriesNumber:00}` generically — no backend code 
changes needed, only frontend help text and preview
 
 ## Notes
 
 - No backend changes required — `FileNamingService.ApplyNamingPattern` already handles any `{Variable:format}` via 
`int.TryParse` + `ToString(format)`
 - Decimal series positions (e.g., 4.5) use the raw value since they can't be int-parsed — consistent with 
DiskNumber/ChapterNumber behavior