### PR TITLE
fix(nzbget): preserve Basic auth across same-host non-downgrade redirects

### DIFF
--- a/listenarr.application/Security/OutboundRequestSecurity.cs
+++ b/listenarr.application/Security/OutboundRequestSecurity.cs
@@ -206,5 +206,22 @@ public static class OutboundRequestSecurity
                || statusCode == HttpStatusCode.TemporaryRedirect
                || (int)statusCode == 308;
     }
+
+    /// <summary>
+    /// True when both URIs target the same host (case-insensitive) and port. Used to decide
+    /// whether credentials may be safely re-applied across a redirect without leaking them to
+    /// a different origin.
+    /// </summary>
+    public static bool IsSameHostAndPort(Uri from, Uri to) =>
+        string.Equals(from.Host, to.Host, StringComparison.OrdinalIgnoreCase)
+        && from.Port == to.Port;
+
+    /// <summary>
+    /// True when a redirect moves from an HTTPS origin to a plaintext HTTP one — a downgrade
+    /// that would expose any forwarded credentials in the clear.
+    /// </summary>
+    public static bool IsHttpsToHttpDowngrade(Uri from, Uri to) =>
+        string.Equals(from.Scheme, "https", StringComparison.OrdinalIgnoreCase)
+        && string.Equals(to.Scheme, "http", StringComparison.OrdinalIgnoreCase);
 }
 

--- a/listenarr.infrastructure/Adapters/NzbgetAdapter.cs
+++ b/listenarr.infrastructure/Adapters/NzbgetAdapter.cs
@@ -78,6 +78,14 @@ namespace Listenarr.Infrastructure.Adapters
 
                 return (true, "NZBGet: connected");
             }
+            catch (NzbgetSafeRedirectException redirectEx)
+            {
+                // Surface the handler's descriptive message verbatim — it tells the user exactly
+                // which redirect was refused and why, so they can fix their reverse-proxy config
+                // instead of staring at a generic "Unauthorized" or "network error".
+                _logger.LogWarning(redirectEx, "NZBGet safe-redirect refused for client {ClientId}", LogRedaction.SanitizeText(client.Id ?? client.Name ?? client.Type));
+                return (false, redirectEx.Message);
+            }
             catch (HttpRequestException httpEx) when (httpEx.StatusCode == HttpStatusCode.Unauthorized || httpEx.StatusCode == HttpStatusCode.Forbidden)
             {
                 _logger.LogDebug(httpEx, "NZBGet authentication failed for client {ClientId}", LogRedaction.SanitizeText(client.Id ?? client.Name ?? client.Type));
@@ -861,10 +869,15 @@ namespace Listenarr.Infrastructure.Adapters
 
         private async Task<XElement> CallXmlRpcAsync(DownloadClientConfiguration client, string methodName, params object[] parameters)
         {
+            // Authenticate via the HTTP Basic Authorization header set below. The named "nzbget"
+            // HttpClient runs with AllowAutoRedirect=false and our own NzbgetSafeRedirectHandler,
+            // which validates that any 30x redirect stays on the same host and does not downgrade
+            // HTTPS to HTTP before re-applying the Authorization header. This lets reverse-proxy
+            // setups (HTTPS upgrade, trailing-slash normalization) keep working without leaking
+            // credentials to unexpected hosts the way URL-embedded user:pass would.
             var baseUrl = DownloadClientUriBuilder.BuildUri(client, "/xmlrpc").ToString();
             var httpClient = _httpClientFactory.CreateClient(ClientType);
 
-            // Build XML-RPC request
             var methodCall = new XElement("methodCall",
                 new XElement("methodName", methodName),
                 new XElement("params",

--- a/listenarr.infrastructure/Adapters/NzbgetSafeRedirectException.cs
+++ b/listenarr.infrastructure/Adapters/NzbgetSafeRedirectException.cs
@@ -1,0 +1,29 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace Listenarr.Infrastructure.Adapters
+{
+    /// <summary>
+    /// Thrown by <see cref="NzbgetSafeRedirectHandler"/> when a redirect is refused (cross-host,
+    /// HTTPS->HTTP downgrade, missing Location, or loop). Carries a descriptive message that
+    /// the adapter surfaces to the user instead of the generic "network error" fallback.
+    /// </summary>
+    public sealed class NzbgetSafeRedirectException : HttpRequestException
+    {
+        public NzbgetSafeRedirectException(string message) : base(message) { }
+    }
+}

--- a/listenarr.infrastructure/Adapters/NzbgetSafeRedirectHandler.cs
+++ b/listenarr.infrastructure/Adapters/NzbgetSafeRedirectHandler.cs
@@ -1,0 +1,231 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Net;
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Infrastructure.Adapters
+{
+    /// <summary>
+    /// Thrown by <see cref="NzbgetSafeRedirectHandler"/> when a redirect is refused (cross-host,
+    /// HTTPS->HTTP downgrade, missing Location, or loop). Carries a descriptive message that
+    /// the adapter surfaces to the user instead of the generic "network error" fallback.
+    /// </summary>
+    public sealed class NzbgetSafeRedirectException : HttpRequestException
+    {
+        public NzbgetSafeRedirectException(string message) : base(message) { }
+    }
+
+    /// <summary>
+    /// Manual redirect handler for the NZBGet HttpClient.
+    ///
+    /// The named "nzbget" HttpClient is configured with <c>AllowAutoRedirect = false</c> because
+    /// .NET's default redirect-follower strips <c>Authorization</c> headers across hops to prevent
+    /// credential leakage to unintended hosts. That protection breaks NZBGet setups where a reverse
+    /// proxy in front of NZBGet issues a 30x (typical cases: a Caddy/Nginx HTTPS upgrade, or
+    /// trailing-slash normalization on a configured base URL) — the redirect succeeds but the
+    /// subsequent request hits NZBGet without auth and returns 401 Unauthorized.
+    ///
+    /// This handler re-applies the <c>Authorization</c> header on a redirect, but only when both
+    /// safety rules pass:
+    ///   1. The redirect target is the same host:port as the original request.
+    ///   2. The redirect does not downgrade from HTTPS to HTTP.
+    ///
+    /// On any rule violation the handler throws a descriptive <see cref="HttpRequestException"/>
+    /// instead of silently dropping auth, so misconfigured proxies surface as actionable errors
+    /// rather than mysterious "Unauthorized" failures.
+    /// </summary>
+    public sealed class NzbgetSafeRedirectHandler : DelegatingHandler
+    {
+        internal const int MaxRedirects = 5;
+
+        private readonly ILogger<NzbgetSafeRedirectHandler>? _logger;
+
+        public NzbgetSafeRedirectHandler()
+        {
+        }
+
+        public NzbgetSafeRedirectHandler(ILogger<NzbgetSafeRedirectHandler> logger)
+        {
+            _logger = logger;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // Buffer request content once so we can replay POST bodies across 307/308 redirects.
+            if (request.Content != null)
+            {
+                await request.Content.LoadIntoBufferAsync().ConfigureAwait(false);
+            }
+
+            var currentRequest = request;
+            HttpRequestMessage? clonedRequest = null;
+            var hops = 0;
+
+            try
+            {
+                while (true)
+                {
+                    var response = await base.SendAsync(currentRequest, cancellationToken).ConfigureAwait(false);
+
+                    if (!IsRedirectStatus(response.StatusCode))
+                    {
+                        return response;
+                    }
+
+                    if (hops >= MaxRedirects)
+                    {
+                        var sanitized = SanitizeUri(currentRequest.RequestUri);
+                        response.Dispose();
+                        throw new NzbgetSafeRedirectException(
+                            $"NZBGet request to {sanitized} hit the redirect cap of {MaxRedirects} hops. " +
+                            "This likely indicates a redirect loop in your reverse-proxy or NZBGet base-URL configuration.");
+                    }
+
+                    var location = response.Headers.Location;
+                    if (location == null)
+                    {
+                        var sanitized = SanitizeUri(currentRequest.RequestUri);
+                        var status = response.StatusCode;
+                        response.Dispose();
+                        throw new NzbgetSafeRedirectException(
+                            $"NZBGet responded {(int)status} {status} to {sanitized} but did not include a Location header. " +
+                            "Cannot follow the redirect; check the NZBGet (or proxy) server logs.");
+                    }
+
+                    var nextUri = location.IsAbsoluteUri
+                        ? location
+                        : new Uri(currentRequest.RequestUri!, location);
+
+                    if (!IsSameOriginHost(currentRequest.RequestUri!, nextUri))
+                    {
+                        var fromUri = SanitizeUri(currentRequest.RequestUri);
+                        var toUri = SanitizeUri(nextUri);
+                        response.Dispose();
+                        throw new NzbgetSafeRedirectException(
+                            $"NZBGet redirected from {fromUri} to a different host ({toUri}). " +
+                            "Authorization credentials would be forwarded to an unexpected host, so the redirect was blocked. " +
+                            "Fix the NZBGet base URL or reverse-proxy rewrite so the response is returned directly.");
+                    }
+
+                    if (IsSchemeDowngrade(currentRequest.RequestUri!, nextUri))
+                    {
+                        var fromUri = SanitizeUri(currentRequest.RequestUri);
+                        var toUri = SanitizeUri(nextUri);
+                        response.Dispose();
+                        throw new NzbgetSafeRedirectException(
+                            $"NZBGet redirected from HTTPS ({fromUri}) to HTTP ({toUri}). " +
+                            "Credentials would be sent in clear, so the redirect was blocked. " +
+                            "Configure NZBGet (or its reverse proxy) to serve only HTTPS.");
+                    }
+
+                    var nextRequest = BuildRedirectedRequest(currentRequest, response.StatusCode, nextUri);
+                    _logger?.LogDebug(
+                        "NZBGet redirect {Status} {From} -> {To} (hop {Hop}/{Cap})",
+                        (int)response.StatusCode,
+                        SanitizeUri(currentRequest.RequestUri),
+                        SanitizeUri(nextUri),
+                        hops + 1,
+                        MaxRedirects);
+
+                    response.Dispose();
+                    if (clonedRequest != null)
+                    {
+                        clonedRequest.Dispose();
+                    }
+                    clonedRequest = nextRequest;
+                    currentRequest = nextRequest;
+                    hops++;
+                }
+            }
+            catch
+            {
+                clonedRequest?.Dispose();
+                throw;
+            }
+        }
+
+        private static HttpRequestMessage BuildRedirectedRequest(
+            HttpRequestMessage previous,
+            HttpStatusCode redirectStatus,
+            Uri nextUri)
+        {
+            // RFC 7231 §6.4: 301/302/303 may change the method to GET (303 must); 307/308 preserve method+body.
+            // Matches HttpClientHandler's default behavior.
+            bool preserveMethodAndBody =
+                redirectStatus == HttpStatusCode.TemporaryRedirect ||
+                redirectStatus == HttpStatusCode.PermanentRedirect;
+
+            var nextMethod = preserveMethodAndBody ? previous.Method : HttpMethod.Get;
+            var nextContent = preserveMethodAndBody ? previous.Content : null;
+
+            var next = new HttpRequestMessage(nextMethod, nextUri)
+            {
+                Version = previous.Version,
+                VersionPolicy = previous.VersionPolicy,
+            };
+
+            if (nextContent != null)
+            {
+                next.Content = nextContent;
+            }
+
+            // Re-apply the Authorization header — this handler's whole reason for existing.
+            if (previous.Headers.Authorization != null)
+            {
+                next.Headers.Authorization = previous.Headers.Authorization;
+            }
+
+            // Carry over the rest of the request headers (Accept, User-Agent, etc.), skipping
+            // Authorization (already copied above) and Host (must derive from the new URI).
+            foreach (var header in previous.Headers)
+            {
+                if (string.Equals(header.Key, "Authorization", StringComparison.OrdinalIgnoreCase)) continue;
+                if (string.Equals(header.Key, "Host", StringComparison.OrdinalIgnoreCase)) continue;
+                next.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            return next;
+        }
+
+        private static bool IsRedirectStatus(HttpStatusCode code) => code switch
+        {
+            HttpStatusCode.MovedPermanently => true,   // 301
+            HttpStatusCode.Found => true,              // 302
+            HttpStatusCode.SeeOther => true,           // 303
+            HttpStatusCode.TemporaryRedirect => true,  // 307
+            HttpStatusCode.PermanentRedirect => true,  // 308
+            _ => false
+        };
+
+        private static bool IsSameOriginHost(Uri from, Uri to) =>
+            string.Equals(from.Host, to.Host, StringComparison.OrdinalIgnoreCase) &&
+            from.Port == to.Port;
+
+        private static bool IsSchemeDowngrade(Uri from, Uri to) =>
+            string.Equals(from.Scheme, "https", StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(to.Scheme, "http", StringComparison.OrdinalIgnoreCase);
+
+        private static string SanitizeUri(Uri? uri)
+        {
+            if (uri == null) return "(null)";
+            if (string.IsNullOrEmpty(uri.UserInfo)) return uri.ToString();
+            var builder = new UriBuilder(uri) { UserName = string.Empty, Password = string.Empty };
+            return builder.Uri.ToString();
+        }
+    }
+}

--- a/listenarr.infrastructure/Adapters/NzbgetSafeRedirectHandler.cs
+++ b/listenarr.infrastructure/Adapters/NzbgetSafeRedirectHandler.cs
@@ -16,20 +16,11 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 using System.Net;
+using Listenarr.Application.Security;
 using Microsoft.Extensions.Logging;
 
 namespace Listenarr.Infrastructure.Adapters
 {
-    /// <summary>
-    /// Thrown by <see cref="NzbgetSafeRedirectHandler"/> when a redirect is refused (cross-host,
-    /// HTTPS->HTTP downgrade, missing Location, or loop). Carries a descriptive message that
-    /// the adapter surfaces to the user instead of the generic "network error" fallback.
-    /// </summary>
-    public sealed class NzbgetSafeRedirectException : HttpRequestException
-    {
-        public NzbgetSafeRedirectException(string message) : base(message) { }
-    }
-
     /// <summary>
     /// Manual redirect handler for the NZBGet HttpClient.
     ///
@@ -45,24 +36,13 @@ namespace Listenarr.Infrastructure.Adapters
     ///   1. The redirect target is the same host:port as the original request.
     ///   2. The redirect does not downgrade from HTTPS to HTTP.
     ///
-    /// On any rule violation the handler throws a descriptive <see cref="HttpRequestException"/>
+    /// On any rule violation the handler throws a descriptive <see cref="NzbgetSafeRedirectException"/>
     /// instead of silently dropping auth, so misconfigured proxies surface as actionable errors
     /// rather than mysterious "Unauthorized" failures.
     /// </summary>
-    public sealed class NzbgetSafeRedirectHandler : DelegatingHandler
+    public sealed class NzbgetSafeRedirectHandler(ILogger<NzbgetSafeRedirectHandler> logger) : DelegatingHandler
     {
         internal const int MaxRedirects = 5;
-
-        private readonly ILogger<NzbgetSafeRedirectHandler>? _logger;
-
-        public NzbgetSafeRedirectHandler()
-        {
-        }
-
-        public NzbgetSafeRedirectHandler(ILogger<NzbgetSafeRedirectHandler> logger)
-        {
-            _logger = logger;
-        }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
@@ -74,83 +54,77 @@ namespace Listenarr.Infrastructure.Adapters
 
             var currentRequest = request;
             HttpRequestMessage? clonedRequest = null;
-            var hops = 0;
 
             try
             {
-                while (true)
+                // hops in [0, MaxRedirects] => up to MaxRedirects + 1 requests sent. The original
+                // request plus MaxRedirects follows; falling out of the loop means every allowed
+                // hop was still a redirect, i.e. a loop or misconfiguration.
+                for (var hops = 0; hops <= MaxRedirects; hops++)
                 {
                     var response = await base.SendAsync(currentRequest, cancellationToken).ConfigureAwait(false);
 
-                    if (!IsRedirectStatus(response.StatusCode))
+                    if (!OutboundRequestSecurity.IsRedirectStatusCode(response.StatusCode))
                     {
+                        // Terminal response — hand it back to the caller, who owns its disposal.
                         return response;
                     }
 
-                    if (hops >= MaxRedirects)
+                    // A redirect we won't return: scope its disposal to this iteration.
+                    using (response)
                     {
-                        var sanitized = SanitizeUri(currentRequest.RequestUri);
-                        response.Dispose();
-                        throw new NzbgetSafeRedirectException(
-                            $"NZBGet request to {sanitized} hit the redirect cap of {MaxRedirects} hops. " +
-                            "This likely indicates a redirect loop in your reverse-proxy or NZBGet base-URL configuration.");
+                        var location = response.Headers.Location;
+                        if (location == null)
+                        {
+                            var sanitized = LogRedaction.SanitizeUrl(currentRequest.RequestUri?.ToString());
+                            throw new NzbgetSafeRedirectException(
+                                $"NZBGet responded {(int)response.StatusCode} {response.StatusCode} to {sanitized} but did not include a Location header. " +
+                                "Cannot follow the redirect; check the NZBGet (or proxy) server logs.");
+                        }
+
+                        var nextUri = location.IsAbsoluteUri
+                            ? location
+                            : new Uri(currentRequest.RequestUri!, location);
+
+                        if (!OutboundRequestSecurity.IsSameHostAndPort(currentRequest.RequestUri!, nextUri))
+                        {
+                            var fromUri = LogRedaction.SanitizeUrl(currentRequest.RequestUri?.ToString());
+                            var toUri = LogRedaction.SanitizeUrl(nextUri.ToString());
+                            throw new NzbgetSafeRedirectException(
+                                $"NZBGet redirected from {fromUri} to a different host ({toUri}). " +
+                                "Authorization credentials would be forwarded to an unexpected host, so the redirect was blocked. " +
+                                "Fix the NZBGet base URL or reverse-proxy rewrite so the response is returned directly.");
+                        }
+
+                        if (OutboundRequestSecurity.IsHttpsToHttpDowngrade(currentRequest.RequestUri!, nextUri))
+                        {
+                            var fromUri = LogRedaction.SanitizeUrl(currentRequest.RequestUri?.ToString());
+                            var toUri = LogRedaction.SanitizeUrl(nextUri.ToString());
+                            throw new NzbgetSafeRedirectException(
+                                $"NZBGet redirected from HTTPS ({fromUri}) to HTTP ({toUri}). " +
+                                "Credentials would be sent in clear, so the redirect was blocked. " +
+                                "Configure NZBGet (or its reverse proxy) to serve only HTTPS.");
+                        }
+
+                        var nextRequest = BuildRedirectedRequest(currentRequest, response.StatusCode, nextUri);
+                        logger.LogDebug(
+                            "NZBGet redirect {Status} {From} -> {To} (hop {Hop}/{Cap})",
+                            (int)response.StatusCode,
+                            LogRedaction.SanitizeUrl(currentRequest.RequestUri?.ToString()),
+                            LogRedaction.SanitizeUrl(nextUri.ToString()),
+                            hops + 1,
+                            MaxRedirects);
+
+                        clonedRequest?.Dispose();
+                        clonedRequest = nextRequest;
+                        currentRequest = nextRequest;
                     }
-
-                    var location = response.Headers.Location;
-                    if (location == null)
-                    {
-                        var sanitized = SanitizeUri(currentRequest.RequestUri);
-                        var status = response.StatusCode;
-                        response.Dispose();
-                        throw new NzbgetSafeRedirectException(
-                            $"NZBGet responded {(int)status} {status} to {sanitized} but did not include a Location header. " +
-                            "Cannot follow the redirect; check the NZBGet (or proxy) server logs.");
-                    }
-
-                    var nextUri = location.IsAbsoluteUri
-                        ? location
-                        : new Uri(currentRequest.RequestUri!, location);
-
-                    if (!IsSameOriginHost(currentRequest.RequestUri!, nextUri))
-                    {
-                        var fromUri = SanitizeUri(currentRequest.RequestUri);
-                        var toUri = SanitizeUri(nextUri);
-                        response.Dispose();
-                        throw new NzbgetSafeRedirectException(
-                            $"NZBGet redirected from {fromUri} to a different host ({toUri}). " +
-                            "Authorization credentials would be forwarded to an unexpected host, so the redirect was blocked. " +
-                            "Fix the NZBGet base URL or reverse-proxy rewrite so the response is returned directly.");
-                    }
-
-                    if (IsSchemeDowngrade(currentRequest.RequestUri!, nextUri))
-                    {
-                        var fromUri = SanitizeUri(currentRequest.RequestUri);
-                        var toUri = SanitizeUri(nextUri);
-                        response.Dispose();
-                        throw new NzbgetSafeRedirectException(
-                            $"NZBGet redirected from HTTPS ({fromUri}) to HTTP ({toUri}). " +
-                            "Credentials would be sent in clear, so the redirect was blocked. " +
-                            "Configure NZBGet (or its reverse proxy) to serve only HTTPS.");
-                    }
-
-                    var nextRequest = BuildRedirectedRequest(currentRequest, response.StatusCode, nextUri);
-                    _logger?.LogDebug(
-                        "NZBGet redirect {Status} {From} -> {To} (hop {Hop}/{Cap})",
-                        (int)response.StatusCode,
-                        SanitizeUri(currentRequest.RequestUri),
-                        SanitizeUri(nextUri),
-                        hops + 1,
-                        MaxRedirects);
-
-                    response.Dispose();
-                    if (clonedRequest != null)
-                    {
-                        clonedRequest.Dispose();
-                    }
-                    clonedRequest = nextRequest;
-                    currentRequest = nextRequest;
-                    hops++;
                 }
+
+                var sanitizedLast = LogRedaction.SanitizeUrl(currentRequest.RequestUri?.ToString());
+                throw new NzbgetSafeRedirectException(
+                    $"NZBGet request to {sanitizedLast} hit the redirect cap of {MaxRedirects} hops. " +
+                    "This likely indicates a redirect loop in your reverse-proxy or NZBGet base-URL configuration.");
             }
             catch
             {
@@ -200,32 +174,6 @@ namespace Listenarr.Infrastructure.Adapters
             }
 
             return next;
-        }
-
-        private static bool IsRedirectStatus(HttpStatusCode code) => code switch
-        {
-            HttpStatusCode.MovedPermanently => true,   // 301
-            HttpStatusCode.Found => true,              // 302
-            HttpStatusCode.SeeOther => true,           // 303
-            HttpStatusCode.TemporaryRedirect => true,  // 307
-            HttpStatusCode.PermanentRedirect => true,  // 308
-            _ => false
-        };
-
-        private static bool IsSameOriginHost(Uri from, Uri to) =>
-            string.Equals(from.Host, to.Host, StringComparison.OrdinalIgnoreCase) &&
-            from.Port == to.Port;
-
-        private static bool IsSchemeDowngrade(Uri from, Uri to) =>
-            string.Equals(from.Scheme, "https", StringComparison.OrdinalIgnoreCase) &&
-            string.Equals(to.Scheme, "http", StringComparison.OrdinalIgnoreCase);
-
-        private static string SanitizeUri(Uri? uri)
-        {
-            if (uri == null) return "(null)";
-            if (string.IsNullOrEmpty(uri.UserInfo)) return uri.ToString();
-            var builder = new UriBuilder(uri) { UserName = string.Empty, Password = string.Empty };
-            return builder.Uri.ToString();
         }
     }
 }

--- a/listenarr.infrastructure/Extensions/ServiceRegistrationExtensions.cs
+++ b/listenarr.infrastructure/Extensions/ServiceRegistrationExtensions.cs
@@ -123,6 +123,10 @@ namespace Listenarr.Infrastructure.Extensions
                 .AddPolicyHandler(circuitBreakerPolicy)
                 .AddPolicyHandler(retryPolicy);
 
+            // See NzbgetSafeRedirectHandler — AllowAutoRedirect=false + a custom safe-redirect handler
+            // so the Authorization header is re-applied on same-host non-downgrade 30x responses
+            // (typical for reverse-proxy setups in front of NZBGet).
+            services.AddTransient<NzbgetSafeRedirectHandler>();
             services.AddHttpClient("nzbget")
                 .ConfigureHttpClient(client =>
                 {
@@ -131,8 +135,10 @@ namespace Listenarr.Infrastructure.Extensions
                 .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
                 {
                     AutomaticDecompression = DecompressionMethods.All,
-                    UseCookies = false
+                    UseCookies = false,
+                    AllowAutoRedirect = false
                 })
+                .AddHttpMessageHandler<NzbgetSafeRedirectHandler>()
                 .SetHandlerLifetime(TimeSpan.FromMinutes(5))
                 .AddPolicyHandler(circuitBreakerPolicy)
                 .AddPolicyHandler(retryPolicy);

--- a/tests/Features/Infrastructure/Adapters/NzbgetAdapterTests.cs
+++ b/tests/Features/Infrastructure/Adapters/NzbgetAdapterTests.cs
@@ -16,6 +16,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
 using Listenarr.Application.Interfaces;
 using Listenarr.Domain.Models;
 using Listenarr.Infrastructure.Adapters;
@@ -28,6 +30,12 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
 {
     public class NzbgetAdapterTests
     {
+        private const string VersionResponseXml =
+            "<?xml version=\"1.0\"?><methodResponse><params><param><value><string>26.1</string></value></param></params></methodResponse>";
+
+        private const string EmptyArrayResponseXml =
+            "<?xml version=\"1.0\"?><methodResponse><params><param><value><array><data></data></array></value></param></params></methodResponse>";
+
         private sealed class TestHttpClientFactory : IHttpClientFactory
         {
             private readonly HttpClient _client;
@@ -40,26 +48,42 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
             public HttpClient CreateClient(string name) => _client;
         }
 
+        // Wrap the safe-redirect handler around a DelegatingHandlerMock so unit tests exercise
+        // the production redirect pipeline. Matches how the named "nzbget" HttpClient is configured
+        // in Program.cs / ServiceRegistrationExtensions.
+        private static HttpClient BuildNzbgetClient(DelegatingHandlerMock leaf)
+        {
+            var redirectHandler = new NzbgetSafeRedirectHandler { InnerHandler = leaf };
+            return new HttpClient(redirectHandler);
+        }
+
+        private static NzbgetAdapter BuildAdapter(HttpClient http) =>
+            new(new TestHttpClientFactory(http), Mock.Of<INzbUrlResolver>(), NullLogger<NzbgetAdapter>.Instance);
+
+        private static HttpResponseMessage OkXml(string body) => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body)
+        };
+
+        private static HttpResponseMessage Redirect(HttpStatusCode status, string location)
+        {
+            var response = new HttpResponseMessage(status);
+            response.Headers.Location = new Uri(location);
+            return response;
+        }
+
         [Fact]
         public async Task TestConnectionAsync_NormalizesHostWithSchemeAndPath()
         {
             Uri? capturedUri = null;
-            using var response = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(
-                    "<?xml version=\"1.0\"?><methodResponse><params><param><value><string>25.4</string></value></param></params></methodResponse>")
-            };
-            var handler = new DelegatingHandlerMock((req, _) =>
+            var leaf = new DelegatingHandlerMock((req, _) =>
             {
                 capturedUri = req.RequestUri;
-                return Task.FromResult(response);
+                return Task.FromResult(OkXml(VersionResponseXml));
             });
 
-            using var http = new HttpClient(handler);
-            var adapter = new NzbgetAdapter(
-                new TestHttpClientFactory(http),
-                Mock.Of<INzbUrlResolver>(),
-                NullLogger<NzbgetAdapter>.Instance);
+            using var http = BuildNzbgetClient(leaf);
+            var adapter = BuildAdapter(http);
 
             var client = new DownloadClientConfiguration
             {
@@ -85,22 +109,14 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
         public async Task TestConnectionAsync_PrefersExplicitPortAndSslOverEmbeddedHostUri()
         {
             Uri? capturedUri = null;
-            using var response = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(
-                    "<?xml version=\"1.0\"?><methodResponse><params><param><value><string>25.4</string></value></param></params></methodResponse>")
-            };
-            var handler = new DelegatingHandlerMock((req, _) =>
+            var leaf = new DelegatingHandlerMock((req, _) =>
             {
                 capturedUri = req.RequestUri;
-                return Task.FromResult(response);
+                return Task.FromResult(OkXml(VersionResponseXml));
             });
 
-            using var http = new HttpClient(handler);
-            var adapter = new NzbgetAdapter(
-                new TestHttpClientFactory(http),
-                Mock.Of<INzbUrlResolver>(),
-                NullLogger<NzbgetAdapter>.Instance);
+            using var http = BuildNzbgetClient(leaf);
+            var adapter = BuildAdapter(http);
 
             var client = new DownloadClientConfiguration
             {
@@ -123,22 +139,14 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
         public async Task GetQueueAsync_NormalizesHostWithSchemeAndPath()
         {
             Uri? capturedUri = null;
-            using var response = new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent(
-                    "<?xml version=\"1.0\"?><methodResponse><params><param><value><array><data></data></array></value></param></params></methodResponse>")
-            };
-            var handler = new DelegatingHandlerMock((req, _) =>
+            var leaf = new DelegatingHandlerMock((req, _) =>
             {
                 capturedUri = req.RequestUri;
-                return Task.FromResult(response);
+                return Task.FromResult(OkXml(EmptyArrayResponseXml));
             });
 
-            using var http = new HttpClient(handler);
-            var adapter = new NzbgetAdapter(
-                new TestHttpClientFactory(http),
-                Mock.Of<INzbUrlResolver>(),
-                NullLogger<NzbgetAdapter>.Instance);
+            using var http = BuildNzbgetClient(leaf);
+            var adapter = BuildAdapter(http);
 
             var client = new DownloadClientConfiguration
             {
@@ -158,6 +166,223 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
             Assert.Equal("192.168.50.111", capturedUri.Host);
             Assert.Equal(6789, capturedUri.Port);
             Assert.Equal("/xmlrpc", capturedUri.AbsolutePath);
+        }
+
+        // The XML-RPC URL must not embed credentials in UserInfo — the Authorization header is
+        // the canonical auth path, and the NzbgetSafeRedirectHandler re-applies it on safe
+        // redirects. URL-embedded creds would forward credentials through cross-host redirects
+        // and bypass the redirect-stripping security control. See PR #580 review by T4g1.
+        [Fact]
+        public async Task TestConnectionAsync_DoesNotEmbedCredentialsInUrl()
+        {
+            HttpRequestMessage? capturedRequest = null;
+            var leaf = new DelegatingHandlerMock((req, _) =>
+            {
+                capturedRequest = req;
+                return Task.FromResult(OkXml(VersionResponseXml));
+            });
+
+            using var http = BuildNzbgetClient(leaf);
+            var adapter = BuildAdapter(http);
+
+            var client = new DownloadClientConfiguration
+            {
+                Host = "http://192.168.50.111",
+                Port = 6789,
+                UseSSL = false,
+                Username = "nzbuser",
+                Password = "n!zbP@ss"
+            };
+
+            var (success, _) = await adapter.TestConnectionAsync(client);
+
+            Assert.True(success);
+            Assert.NotNull(capturedRequest);
+            Assert.True(
+                string.IsNullOrEmpty(capturedRequest!.RequestUri!.UserInfo),
+                "XML-RPC URL must not embed user:pass — Authorization header is the canonical auth path.");
+        }
+
+        [Fact]
+        public async Task TestConnectionAsync_SendsBasicAuthorizationHeader()
+        {
+            HttpRequestMessage? capturedRequest = null;
+            string? capturedBody = null;
+            var leaf = new DelegatingHandlerMock(async (req, ct) =>
+            {
+                capturedRequest = req;
+                if (req.Content != null)
+                {
+                    capturedBody = await req.Content.ReadAsStringAsync(ct);
+                }
+                return OkXml(VersionResponseXml);
+            });
+
+            using var http = BuildNzbgetClient(leaf);
+            var adapter = BuildAdapter(http);
+
+            var client = new DownloadClientConfiguration
+            {
+                Host = "http://192.168.50.111",
+                Port = 6789,
+                UseSSL = false,
+                Username = "nzbuser",
+                Password = "nzbpass"
+            };
+
+            var (success, _) = await adapter.TestConnectionAsync(client);
+
+            Assert.True(success);
+            Assert.NotNull(capturedRequest);
+
+            var auth = capturedRequest!.Headers.Authorization;
+            Assert.NotNull(auth);
+            Assert.Equal("Basic", auth!.Scheme);
+            Assert.False(string.IsNullOrEmpty(auth.Parameter));
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(auth.Parameter!));
+            Assert.Equal("nzbuser:nzbpass", decoded);
+
+            Assert.Equal("text/xml", capturedRequest.Content?.Headers.ContentType?.MediaType);
+            Assert.NotNull(capturedBody);
+            Assert.Contains("<methodName>version</methodName>", capturedBody!);
+        }
+
+        // Regression: when a reverse proxy in front of NZBGet issues a same-host 301/302 (e.g.
+        // trailing-slash normalization), the default HttpClientHandler follows the redirect but
+        // strips Authorization, so NZBGet rejects the request with 401 Unauthorized even though
+        // creds are correct. NzbgetSafeRedirectHandler must re-apply the header on safe redirects.
+        [Theory]
+        [InlineData(HttpStatusCode.MovedPermanently)]   // 301
+        [InlineData(HttpStatusCode.Found)]              // 302
+        [InlineData(HttpStatusCode.SeeOther)]           // 303
+        [InlineData(HttpStatusCode.TemporaryRedirect)]  // 307
+        [InlineData(HttpStatusCode.PermanentRedirect)]  // 308
+        public async Task TestConnectionAsync_ReAppliesAuthHeaderOnSameHostRedirect(HttpStatusCode redirectStatus)
+        {
+            var authsSeen = new List<AuthenticationHeaderValue?>();
+            var pathsSeen = new List<string>();
+            var hops = 0;
+            var leaf = new DelegatingHandlerMock((req, _) =>
+            {
+                pathsSeen.Add(req.RequestUri!.AbsolutePath);
+                authsSeen.Add(req.Headers.Authorization);
+                hops++;
+                if (hops == 1)
+                {
+                    return Task.FromResult(Redirect(redirectStatus, "http://192.168.50.111:6789/xmlrpc/"));
+                }
+                return Task.FromResult(OkXml(VersionResponseXml));
+            });
+
+            using var http = BuildNzbgetClient(leaf);
+            var adapter = BuildAdapter(http);
+
+            var client = new DownloadClientConfiguration
+            {
+                Host = "http://192.168.50.111",
+                Port = 6789,
+                UseSSL = false,
+                Username = "nzbuser",
+                Password = "nzbpass"
+            };
+
+            var (success, _) = await adapter.TestConnectionAsync(client);
+
+            Assert.True(success, "Adapter should follow the same-host redirect and succeed");
+            Assert.Equal(2, hops);
+            Assert.Equal("/xmlrpc", pathsSeen[0]);
+            Assert.Equal("/xmlrpc/", pathsSeen[1]);
+            Assert.NotNull(authsSeen[0]);
+            Assert.NotNull(authsSeen[1]);
+            Assert.Equal("Basic", authsSeen[1]!.Scheme);
+            var decoded = Encoding.UTF8.GetString(Convert.FromBase64String(authsSeen[1]!.Parameter!));
+            Assert.Equal("nzbuser:nzbpass", decoded);
+        }
+
+        // Security: if NZBGet (or a misconfigured proxy) redirects to a different host, we must
+        // NOT forward Authorization there. Throw with a clear message instead of silently dropping
+        // auth so the misconfiguration surfaces obviously rather than as "Unauthorized".
+        [Fact]
+        public async Task TestConnectionAsync_BlocksCrossHostRedirectWithClearError()
+        {
+            var leaf = new DelegatingHandlerMock((req, _) =>
+            {
+                return Task.FromResult(Redirect(HttpStatusCode.Found, "http://attacker.example/xmlrpc"));
+            });
+
+            using var http = BuildNzbgetClient(leaf);
+            var adapter = BuildAdapter(http);
+
+            var client = new DownloadClientConfiguration
+            {
+                Host = "http://192.168.50.111",
+                Port = 6789,
+                UseSSL = false,
+                Username = "nzbuser",
+                Password = "nzbpass"
+            };
+
+            var (success, message) = await adapter.TestConnectionAsync(client);
+
+            Assert.False(success);
+            Assert.Contains("different host", message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Security: an HTTPS->HTTP downgrade redirect would leak Basic creds in the clear.
+        // Block with a clear message instead of following.
+        [Fact]
+        public async Task TestConnectionAsync_BlocksHttpsToHttpDowngradeRedirectWithClearError()
+        {
+            var leaf = new DelegatingHandlerMock((req, _) =>
+            {
+                return Task.FromResult(Redirect(HttpStatusCode.Found, "http://192.168.50.111:6789/xmlrpc"));
+            });
+
+            using var http = BuildNzbgetClient(leaf);
+            var adapter = BuildAdapter(http);
+
+            var client = new DownloadClientConfiguration
+            {
+                Host = "https://192.168.50.111",
+                Port = 6789,
+                UseSSL = true,
+                Username = "nzbuser",
+                Password = "nzbpass"
+            };
+
+            var (success, message) = await adapter.TestConnectionAsync(client);
+
+            Assert.False(success);
+            Assert.Contains("HTTPS", message);
+            Assert.Contains("HTTP", message);
+        }
+
+        // Defence against a redirect loop in a misconfigured proxy — bail after the cap with a
+        // clear error so the user knows what to investigate.
+        [Fact]
+        public async Task TestConnectionAsync_BailsOutOnRedirectLoopWithClearError()
+        {
+            var leaf = new DelegatingHandlerMock((req, _) =>
+            {
+                return Task.FromResult(Redirect(HttpStatusCode.Found, "http://192.168.50.111:6789/xmlrpc"));
+            });
+
+            using var http = BuildNzbgetClient(leaf);
+            var adapter = BuildAdapter(http);
+
+            var client = new DownloadClientConfiguration
+            {
+                Host = "http://192.168.50.111",
+                Port = 6789,
+                UseSSL = false,
+                Username = "nzbuser",
+                Password = "nzbpass"
+            };
+
+            var (success, message) = await adapter.TestConnectionAsync(client);
+
+            Assert.False(success);
+            Assert.Contains("redirect", message, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/tests/Features/Infrastructure/Adapters/NzbgetAdapterTests.cs
+++ b/tests/Features/Infrastructure/Adapters/NzbgetAdapterTests.cs
@@ -53,17 +53,15 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
         // in Program.cs / ServiceRegistrationExtensions.
         private static HttpClient BuildNzbgetClient(DelegatingHandlerMock leaf)
         {
-            var redirectHandler = new NzbgetSafeRedirectHandler { InnerHandler = leaf };
+            var redirectHandler = new NzbgetSafeRedirectHandler(NullLogger<NzbgetSafeRedirectHandler>.Instance)
+            {
+                InnerHandler = leaf
+            };
             return new HttpClient(redirectHandler);
         }
 
         private static NzbgetAdapter BuildAdapter(HttpClient http) =>
             new(new TestHttpClientFactory(http), Mock.Of<INzbUrlResolver>(), NullLogger<NzbgetAdapter>.Instance);
-
-        private static HttpResponseMessage OkXml(string body) => new(HttpStatusCode.OK)
-        {
-            Content = new StringContent(body)
-        };
 
         private static HttpResponseMessage Redirect(HttpStatusCode status, string location)
         {
@@ -79,7 +77,7 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
             var leaf = new DelegatingHandlerMock((req, _) =>
             {
                 capturedUri = req.RequestUri;
-                return Task.FromResult(OkXml(VersionResponseXml));
+                return Task.FromResult(MockUtils.GetCannedResponse(VersionResponseXml, "text/xml"));
             });
 
             using var http = BuildNzbgetClient(leaf);
@@ -112,7 +110,7 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
             var leaf = new DelegatingHandlerMock((req, _) =>
             {
                 capturedUri = req.RequestUri;
-                return Task.FromResult(OkXml(VersionResponseXml));
+                return Task.FromResult(MockUtils.GetCannedResponse(VersionResponseXml, "text/xml"));
             });
 
             using var http = BuildNzbgetClient(leaf);
@@ -142,7 +140,7 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
             var leaf = new DelegatingHandlerMock((req, _) =>
             {
                 capturedUri = req.RequestUri;
-                return Task.FromResult(OkXml(EmptyArrayResponseXml));
+                return Task.FromResult(MockUtils.GetCannedResponse(EmptyArrayResponseXml, "text/xml"));
             });
 
             using var http = BuildNzbgetClient(leaf);
@@ -179,7 +177,7 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
             var leaf = new DelegatingHandlerMock((req, _) =>
             {
                 capturedRequest = req;
-                return Task.FromResult(OkXml(VersionResponseXml));
+                return Task.FromResult(MockUtils.GetCannedResponse(VersionResponseXml, "text/xml"));
             });
 
             using var http = BuildNzbgetClient(leaf);
@@ -215,7 +213,7 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
                 {
                     capturedBody = await req.Content.ReadAsStringAsync(ct);
                 }
-                return OkXml(VersionResponseXml);
+                return MockUtils.GetCannedResponse(VersionResponseXml, "text/xml");
             });
 
             using var http = BuildNzbgetClient(leaf);
@@ -271,7 +269,7 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
                 {
                     return Task.FromResult(Redirect(redirectStatus, "http://192.168.50.111:6789/xmlrpc/"));
                 }
-                return Task.FromResult(OkXml(VersionResponseXml));
+                return Task.FromResult(MockUtils.GetCannedResponse(VersionResponseXml, "text/xml"));
             });
 
             using var http = BuildNzbgetClient(leaf);
@@ -362,8 +360,10 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
         [Fact]
         public async Task TestConnectionAsync_BailsOutOnRedirectLoopWithClearError()
         {
+            var requestCount = 0;
             var leaf = new DelegatingHandlerMock((req, _) =>
             {
+                requestCount++;
                 return Task.FromResult(Redirect(HttpStatusCode.Found, "http://192.168.50.111:6789/xmlrpc"));
             });
 
@@ -383,6 +383,10 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
 
             Assert.False(success);
             Assert.Contains("redirect", message, StringComparison.OrdinalIgnoreCase);
+            // The original request plus MaxRedirects (5) follows are sent before bailing — i.e.
+            // the handler follows the 5th redirect rather than stopping a hop short. Pins the
+            // loop-guard bound so a <-vs-<= regression is caught.
+            Assert.Equal(6, requestCount);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adding NZBGet as a download client could fail with `NZBGet XML-RPC error: Unauthorized` even when the same credentials worked from a manual `curl`. The trigger is a reverse proxy in front of NZBGet (Caddy/Nginx/Traefik HTTPS upgrade, trailing-slash normalization, etc.) returning a 30x — .NET's default `HttpClientHandler` follows the redirect but strips `Authorization` to prevent credential leakage to unintended hosts, so NZBGet sees the follow-up without auth and 401s.

## Approach

Revised after [@T4g1's review](https://github.com/Listenarrs/Listenarr/pull/580#issuecomment-...) — the original commit on this branch (URL-embedded `user:pass@host`) was abandoned because it would also forward credentials across cross-host or HTTPS→HTTP redirects, defeating the very security control it was working around.

The new approach treats this as a redirect-handling concern rather than an auth-encoding concern:

* The named `"nzbget"` HttpClient is now configured with `AllowAutoRedirect = false` and a custom `NzbgetSafeRedirectHandler` in its delegating-handler chain.
* On 301/302/303/307/308, the handler validates that the next URL is **(a)** the same host:port as the previous request and **(b)** not an HTTPS→HTTP downgrade. Only then does it re-apply the `Authorization` header on the next request.
* 307/308 preserve method and (buffered) body per RFC 7231; 301/302/303 change to GET, matching `HttpClientHandler`'s defaults.
* Hop cap of 5 to defend against redirect loops.
* On any rule violation (cross-host, scheme downgrade, missing `Location`, redirect loop), the handler throws a typed `NzbgetSafeRedirectException` with a descriptive message. `TestConnectionAsync` surfaces that message verbatim so users see the actual misconfiguration instead of a generic `"Authentication failed"` / `"network error"`.

The handler is wired into both `Program.cs` and the equivalent `ServiceRegistrationExtensions.AddListenarrHttpClients` registration, so every code path that uses the named `"nzbget"` HttpClient is covered — including `FetchDownloadsAsync` which calls `/jsonrpc` (the JSON-RPC gap T4g1 flagged in the same review). `AddViaJsonRpcAsync` delegates through `CallXmlRpcAsync` and is covered transitively.

The Authorization header is now the sole auth path. NZBGet's own `WebServer.cpp` accepts `Authorization: Basic` natively (see `daemon/remote/WebServer.cpp` `ParseHeaders()`), so URL-embedded credentials were never required.

## Why not let `HttpClientHandler` handle redirects with its built-in safety?

Considered, but `HttpClientHandler.AllowAutoRedirect = true` is exactly what causes the original bug: it strips `Authorization` on every hop, unconditionally, so any 30x kills auth. The framework has no per-host re-apply hook. A `DelegatingHandler` with `AllowAutoRedirect = false` is the established pattern in this codebase (used in `TransmissionAdapter`, `TorrentFileDownloader`, `ImageCacheService`, `MyAnonamouseHelper`, all with similar comments about preserving auth/cookies across redirects).

## Test plan

* [x] `dotnet test --filter "FullyQualifiedName~NzbgetAdapterTests"` passes locally (13 tests including new redirect-flow coverage)
* [x] Full suite green: `dotnet test` → 641 passed, 0 failed
* [ ] Manual: configure NZBGet as a download client in Listenarr against an instance behind a reverse proxy that issues a same-host HTTPS upgrade; "Test" returns connected
* [ ] Manual: point at an attacker.example URL and confirm the cross-host error message surfaces correctly