### PR TITLE
Fix M4B re-grab loop: emit codec-prefixed quality labels

### DIFF
--- a/listenarr.api/Services/AudiobookStatusEvaluator.cs
+++ b/listenarr.api/Services/AudiobookStatusEvaluator.cs
@@ -34,6 +34,10 @@ namespace Listenarr.Api.Services
         public const string QualityMismatch = "quality-mismatch";
         public const string QualityMatch = "quality-match";
 
+        // Bitrate rungs seeded by QualityProfileService.EnsureProfileHasRequiredQualitiesAsync.
+        // Ordered high → low so BucketBitrate returns the largest rung the file meets.
+        private static readonly int[] BitrateBuckets = { 320, 256, 192, 128, 64 };
+
         public static string ComputeStatus(
             bool isDownloading,
             bool hasAnyFile,
@@ -135,55 +139,153 @@ namespace Listenarr.Api.Services
 
         private static string DeriveQualityLabel(AudiobookFileStatusInfo? file, string? audiobookQuality)
         {
-            var normalizedAudiobookQuality = Normalize(audiobookQuality);
-            if (normalizedAudiobookQuality.Length > 0)
+            // Only trust the audiobookQuality hint if it already matches a production QP key
+            // shape (e.g. "MP3 320kbps", "AAC 64kbps", "FLAC"). Legacy values like "M4B" must
+            // fall through so we re-derive from the file's codec/container/bitrate fields and
+            // produce a label that can actually round-trip with QualityProfile.Qualities keys.
+            var hint = Normalize(audiobookQuality);
+            if (IsCodecPrefixedLabel(hint))
             {
-                return normalizedAudiobookQuality;
+                return hint;
             }
 
-            if (file?.Bitrate is int bitrate)
-            {
-                var bitrateKbps = bitrate >= 1000 ? bitrate / 1000d : bitrate;
+            var codec = DetectCodec(file);
 
-                if (bitrateKbps >= 320)
-                {
-                    return "320kbps";
-                }
-
-                if (bitrateKbps >= 256)
-                {
-                    return "256kbps";
-                }
-
-                if (bitrateKbps >= 192)
-                {
-                    return "192kbps";
-                }
-
-                return $"{Math.Round(bitrateKbps)}kbps";
-            }
-
-            var container = Normalize(file?.Container);
-            var codec = Normalize(file?.Codec);
-            if (container.Contains("flac", StringComparison.Ordinal)
-                || codec.Contains("flac", StringComparison.Ordinal)
-                || container.Contains("alac", StringComparison.Ordinal)
-                || codec.Contains("alac", StringComparison.Ordinal)
-                || container.Contains("aiff", StringComparison.Ordinal)
-                || codec.Contains("aiff", StringComparison.Ordinal)
-                || container.Contains("ape", StringComparison.Ordinal)
-                || codec.Contains("ape", StringComparison.Ordinal)
-                || container.Contains("dsd", StringComparison.Ordinal)
-                || codec.Contains("dsd", StringComparison.Ordinal)
-                || container.Contains("wv", StringComparison.Ordinal)
-                || codec.Contains("wv", StringComparison.Ordinal)
-                || container.Contains("wav", StringComparison.Ordinal)
-                || codec.Contains("wav", StringComparison.Ordinal))
+            if (IsLosslessCodec(codec))
             {
                 return "lossless";
             }
 
+            if (codec.Length > 0 && file?.Bitrate is int bitrate)
+            {
+                var bitrateKbps = bitrate >= 1000 ? bitrate / 1000d : bitrate;
+                var bucket = BucketBitrate(bitrateKbps);
+                if (bucket > 0)
+                {
+                    return $"{codec} {bucket}kbps";
+                }
+            }
+
             return Normalize(file?.Format);
+        }
+
+        private static string DetectCodec(AudiobookFileStatusInfo? file)
+        {
+            var codec = Normalize(file?.Codec);
+            var container = Normalize(file?.Container);
+            var format = Normalize(file?.Format);
+
+            if (codec.Contains("mp3", StringComparison.Ordinal)
+                || container.Contains("mp3", StringComparison.Ordinal)
+                || format == "mp3")
+            {
+                return "mp3";
+            }
+
+            if (codec.Contains("flac", StringComparison.Ordinal)
+                || container.Contains("flac", StringComparison.Ordinal)
+                || format == "flac")
+            {
+                return "flac";
+            }
+
+            if (codec.Contains("alac", StringComparison.Ordinal)
+                || container.Contains("alac", StringComparison.Ordinal))
+            {
+                return "alac";
+            }
+
+            if (codec.Contains("opus", StringComparison.Ordinal)
+                || container.Contains("opus", StringComparison.Ordinal)
+                || format == "opus")
+            {
+                return "opus";
+            }
+
+            if (codec.Contains("vorbis", StringComparison.Ordinal)
+                || container.Contains("ogg", StringComparison.Ordinal)
+                || format == "ogg")
+            {
+                return "vorbis";
+            }
+
+            if (codec.Contains("aac", StringComparison.Ordinal)
+                || codec.Contains("mp4a", StringComparison.Ordinal))
+            {
+                return "aac";
+            }
+
+            if (codec.Contains("aiff", StringComparison.Ordinal)
+                || container.Contains("aiff", StringComparison.Ordinal))
+            {
+                return "aiff";
+            }
+
+            if (codec.Contains("ape", StringComparison.Ordinal)
+                || container.Contains("ape", StringComparison.Ordinal))
+            {
+                return "ape";
+            }
+
+            if (codec.Contains("dsd", StringComparison.Ordinal)
+                || container.Contains("dsd", StringComparison.Ordinal))
+            {
+                return "dsd";
+            }
+
+            if (codec.Contains("wavpack", StringComparison.Ordinal)
+                || container == "wv")
+            {
+                return "wavpack";
+            }
+
+            if (codec.Contains("wav", StringComparison.Ordinal)
+                || container == "wav"
+                || format == "wav")
+            {
+                return "wav";
+            }
+
+            // M4B/M4A/MP4 containers carry AAC for virtually all audiobooks.
+            if (container is "m4b" or "m4a" or "mp4"
+                || format is "m4b" or "m4a" or "mp4")
+            {
+                return "aac";
+            }
+
+            return string.Empty;
+        }
+
+        private static bool IsLosslessCodec(string codec)
+        {
+            return codec is "flac" or "alac" or "wav" or "aiff" or "ape" or "dsd" or "wavpack";
+        }
+
+        private static int BucketBitrate(double bitrateKbps)
+        {
+            foreach (var bucket in BitrateBuckets)
+            {
+                if (bitrateKbps >= bucket)
+                {
+                    return bucket;
+                }
+            }
+            // Below the lowest seeded rung — map to it so we don't trigger
+            // a perpetual re-grab loop for unusually low-bitrate sources.
+            return BitrateBuckets[^1];
+        }
+
+        private static bool IsCodecPrefixedLabel(string normalizedLabel)
+        {
+            if (normalizedLabel.Length == 0)
+            {
+                return false;
+            }
+
+            return normalizedLabel.StartsWith("mp3 ", StringComparison.Ordinal)
+                || normalizedLabel.StartsWith("aac ", StringComparison.Ordinal)
+                || normalizedLabel == "mp3 vbr"
+                || normalizedLabel == "flac";
         }
 
         private static string Normalize(string? value)

--- a/listenarr.api/Services/AudiobookStatusEvaluator.cs
+++ b/listenarr.api/Services/AudiobookStatusEvaluator.cs
@@ -156,7 +156,7 @@ namespace Listenarr.Api.Services
                 return "lossless";
             }
 
-            if (codec.Length > 0 && file?.Bitrate is int bitrate)
+            if (!string.IsNullOrEmpty(codec) && file?.Bitrate is int bitrate)
             {
                 var bitrateKbps = bitrate >= 1000 ? bitrate / 1000d : bitrate;
                 var bucket = BucketBitrate(bitrateKbps);
@@ -277,7 +277,7 @@ namespace Listenarr.Api.Services
 
         private static bool IsCodecPrefixedLabel(string normalizedLabel)
         {
-            if (normalizedLabel.Length == 0)
+            if (string.IsNullOrEmpty(normalizedLabel))
             {
                 return false;
             }

--- a/tests/Features/Api/Services/AudiobookStatusEvaluatorTests.cs
+++ b/tests/Features/Api/Services/AudiobookStatusEvaluatorTests.cs
@@ -24,6 +24,19 @@ namespace Listenarr.Tests.Features.Api.Services
     public class AudiobookStatusEvaluatorTests
     {
         [Fact]
+        public void ComputeStatus_ReturnsDownloading_WhenIsDownloading()
+        {
+            var status = AudiobookStatusEvaluator.ComputeStatus(
+                isDownloading: true,
+                hasAnyFile: false,
+                audiobookQuality: null,
+                qualityProfile: null,
+                files: null);
+
+            Assert.Equal(AudiobookStatusEvaluator.Downloading, status);
+        }
+
+        [Fact]
         public void ComputeStatus_ReturnsNoFile_WhenHasNoFiles()
         {
             var status = AudiobookStatusEvaluator.ComputeStatus(
@@ -37,9 +50,22 @@ namespace Listenarr.Tests.Features.Api.Services
         }
 
         [Fact]
+        public void ComputeStatus_ReturnsQualityMatch_WhenProfileIsNull()
+        {
+            var files = new List<AudiobookFileStatusInfo>
+            {
+                new() { Format = "mp3", Bitrate = 128000 }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, null, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
+        [Fact]
         public void ComputeStatus_ReturnsQualityMismatch_WhenNoFilesMatchPreferredFormats()
         {
-            var profile = CreateProfile(cutoffQuality: "256kbps", preferredFormats: new List<string> { "m4b" });
+            var profile = CreateDefaultProfile(cutoffQuality: "MP3 256kbps", preferredFormats: new List<string> { "m4b" });
             var files = new List<AudiobookFileStatusInfo>
             {
                 new() { Format = "mp3", Bitrate = 320000 }
@@ -53,10 +79,10 @@ namespace Listenarr.Tests.Features.Api.Services
         [Fact]
         public void ComputeStatus_ReturnsQualityMatch_WhenDerivedQualityMeetsCutoffBoundary()
         {
-            var profile = CreateProfile(cutoffQuality: "256kbps", preferredFormats: new List<string> { "m4b" });
+            var profile = CreateDefaultProfile(cutoffQuality: "MP3 256kbps", preferredFormats: new List<string> { "mp3" });
             var files = new List<AudiobookFileStatusInfo>
             {
-                new() { Format = "m4b", Bitrate = 256000 }
+                new() { Format = "mp3", Codec = "mp3", Bitrate = 256000 }
             };
 
             var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
@@ -67,10 +93,10 @@ namespace Listenarr.Tests.Features.Api.Services
         [Fact]
         public void ComputeStatus_ReturnsQualityMismatch_WhenDerivedQualityIsBelowCutoff()
         {
-            var profile = CreateProfile(cutoffQuality: "256kbps", preferredFormats: new List<string> { "m4b" });
+            var profile = CreateDefaultProfile(cutoffQuality: "MP3 256kbps", preferredFormats: new List<string> { "mp3" });
             var files = new List<AudiobookFileStatusInfo>
             {
-                new() { Format = "m4b", Bitrate = 192000 }
+                new() { Format = "mp3", Codec = "mp3", Bitrate = 128000 }
             };
 
             var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
@@ -81,9 +107,136 @@ namespace Listenarr.Tests.Features.Api.Services
         [Fact]
         public void ComputeStatus_ReturnsQualityMatch_WhenOnlyLegacyFileSummaryExists()
         {
-            var profile = CreateProfile(cutoffQuality: "256kbps", preferredFormats: new List<string> { "m4b" });
+            var profile = CreateDefaultProfile(cutoffQuality: "MP3 256kbps", preferredFormats: new List<string> { "m4b" });
 
             var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files: null);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
+        // Regression: an M4B file at the cutoff bitrate must satisfy the AAC rung — the
+        // bug behind https://github.com/Listenarrs/Listenarr/issues/549 was that M4B
+        // files derived to the raw label "m4b" (or "64kbps"), which never matched any
+        // QualityProfile.Qualities key like "AAC 64kbps" and triggered an endless
+        // ~6h re-grab loop for monitored audiobooks with matching indexer releases.
+        [Fact]
+        public void ComputeStatus_ReturnsQualityMatch_ForM4BFileMeetingAacCutoff()
+        {
+            var profile = CreateDefaultProfile(cutoffQuality: "AAC 64kbps", preferredFormats: new List<string> { "m4b" });
+            var files = new List<AudiobookFileStatusInfo>
+            {
+                new() { Format = "m4b", Container = "m4b", Codec = "aac", Bitrate = 64000 }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
+        [Fact]
+        public void ComputeStatus_TreatsM4AContainerAsAac()
+        {
+            var profile = CreateDefaultProfile(cutoffQuality: "AAC 128kbps", preferredFormats: new List<string> { "m4a" });
+            var files = new List<AudiobookFileStatusInfo>
+            {
+                new() { Format = "m4a", Container = "m4a", Codec = "mp4a", Bitrate = 128000 }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
+        [Fact]
+        public void ComputeStatus_BucketsBitrateDownToNearestRung()
+        {
+            // 200kbps lives between the 192 and 256 rungs and must bucket DOWN to 192;
+            // otherwise a sub-cutoff file would be treated as if it met the cutoff.
+            var profile = CreateDefaultProfile(cutoffQuality: "MP3 256kbps", preferredFormats: new List<string> { "mp3" });
+            var files = new List<AudiobookFileStatusInfo>
+            {
+                new() { Format = "mp3", Codec = "mp3", Bitrate = 200000 }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMismatch, status);
+        }
+
+        [Fact]
+        public void ComputeStatus_AcceptsBitrateBelowLowestRungAsLowestRung()
+        {
+            // 32kbps is below the lowest seeded rung (64). It must still resolve to a
+            // known rung so that we don't trigger a perpetual re-grab loop for unusually
+            // low-bitrate sources whose cutoff happens to be the lowest rung.
+            var profile = CreateDefaultProfile(cutoffQuality: "MP3 64kbps", preferredFormats: new List<string> { "mp3" });
+            var files = new List<AudiobookFileStatusInfo>
+            {
+                new() { Format = "mp3", Codec = "mp3", Bitrate = 32000 }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
+        [Fact]
+        public void ComputeStatus_UsesAudiobookQualityHintWhenCodecPrefixed()
+        {
+            var profile = CreateDefaultProfile(cutoffQuality: "MP3 256kbps", preferredFormats: new List<string> { "mp3" });
+            var files = new List<AudiobookFileStatusInfo>
+            {
+                // File metadata says 64kbps, but the legacy hint says "MP3 320kbps".
+                // The codec-prefixed hint must be trusted as-is, overriding the bitrate.
+                new() { Format = "mp3", Codec = "mp3", Bitrate = 64000 }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, "MP3 320kbps", profile, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
+        [Fact]
+        public void ComputeStatus_IgnoresLegacyM4BHintAndRederivesFromFile()
+        {
+            // The legacy LibraryController hint returns "M4B" for m4b/m4a containers.
+            // "M4B" is not a production QP key, so it must NOT short-circuit the
+            // file-based derivation — otherwise the cutoff is never met (issue #549).
+            var profile = CreateDefaultProfile(cutoffQuality: "AAC 64kbps", preferredFormats: new List<string> { "m4b" });
+            var files = new List<AudiobookFileStatusInfo>
+            {
+                new() { Format = "m4b", Container = "m4b", Codec = "aac", Bitrate = 64000 }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, "M4B", profile, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
+        [Fact]
+        public void ComputeStatus_TreatsFlacAsLossless()
+        {
+            var profile = CreateLosslessProfile();
+            var files = new List<AudiobookFileStatusInfo>
+            {
+                new() { Format = "flac", Container = "flac", Codec = "flac" }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
+        [Fact]
+        public void ComputeStatus_TreatsAlacAsLossless()
+        {
+            var profile = CreateLosslessProfile();
+            var files = new List<AudiobookFileStatusInfo>
+            {
+                new() { Format = "m4a", Container = "m4a", Codec = "alac" }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
 
             Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
         }
@@ -91,16 +244,7 @@ namespace Listenarr.Tests.Features.Api.Services
         [Fact]
         public void ComputeStatus_TreatsWavPackAsLossless()
         {
-            var profile = new QualityProfile
-            {
-                Name = "Lossless Profile",
-                CutoffQuality = "lossless",
-                PreferredFormats = new List<string> { "wv" },
-                Qualities = new List<QualityDefinition>
-                {
-                    new() { Quality = "lossless", Priority = 0 }
-                }
-            };
+            var profile = CreateLosslessProfile();
             var files = new List<AudiobookFileStatusInfo>
             {
                 new() { Format = "wv", Container = "wv" }
@@ -111,18 +255,43 @@ namespace Listenarr.Tests.Features.Api.Services
             Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
         }
 
-        private static QualityProfile CreateProfile(string cutoffQuality, List<string> preferredFormats)
+        // Mirrors the production seed in QualityProfileService.EnsureProfileHasRequiredQualitiesAsync.
+        // Keeping this in sync is what guarantees DeriveQualityLabel output round-trips
+        // with the default QP.
+        private static QualityProfile CreateDefaultProfile(string cutoffQuality, List<string> preferredFormats)
         {
             return new QualityProfile
             {
-                Name = "Test Profile",
+                Name = "Default",
                 CutoffQuality = cutoffQuality,
                 PreferredFormats = preferredFormats,
                 Qualities = new List<QualityDefinition>
                 {
-                    new() { Quality = "320kbps", Priority = 0 },
-                    new() { Quality = "256kbps", Priority = 1 },
-                    new() { Quality = "192kbps", Priority = 2 }
+                    new() { Quality = "AAC 320kbps", Priority = 0, Allowed = true },
+                    new() { Quality = "AAC 256kbps", Priority = 1, Allowed = true },
+                    new() { Quality = "AAC 192kbps", Priority = 2, Allowed = true },
+                    new() { Quality = "AAC 128kbps", Priority = 3, Allowed = true },
+                    new() { Quality = "AAC 64kbps",  Priority = 4, Allowed = true },
+                    new() { Quality = "MP3 320kbps", Priority = 5, Allowed = true },
+                    new() { Quality = "MP3 256kbps", Priority = 6, Allowed = true },
+                    new() { Quality = "MP3 VBR",     Priority = 7, Allowed = true },
+                    new() { Quality = "MP3 192kbps", Priority = 8, Allowed = true },
+                    new() { Quality = "MP3 128kbps", Priority = 9, Allowed = true },
+                    new() { Quality = "MP3 64kbps",  Priority = 10, Allowed = true }
+                }
+            };
+        }
+
+        private static QualityProfile CreateLosslessProfile()
+        {
+            return new QualityProfile
+            {
+                Name = "Lossless Profile",
+                CutoffQuality = "lossless",
+                PreferredFormats = new List<string> { "flac", "m4a", "wv" },
+                Qualities = new List<QualityDefinition>
+                {
+                    new() { Quality = "lossless", Priority = 0, Allowed = true }
                 }
             };
         }


### PR DESCRIPTION
## Summary

Closes #549.

`AudiobookStatusEvaluator.DeriveQualityLabel` was emitting quality labels (`"M4B"`, `"lossless"`, `"320kbps"`, `"64kbps"`) that never matched the codec-prefixed keys seeded by `QualityProfileService.EnsureProfileHasRequiredQualitiesAsync` (`"AAC 320kbps"` ... `"AAC 64kbps"`, `"MP3 320kbps"` ... `"MP3 64kbps"`).

`ComputeStatus` looks up the derived label in a case-insensitive dictionary built from `QualityProfile.Qualities`. With no match, priority defaults to `int.MaxValue`, which is never `≤ cutoffPriority`, so the cutoff is reported as **not met** even when the file on disk is at or above the profile's cutoff. Combined with the ~6 h RSS cycle, any monitored audiobook with an `.m4b` on disk and a matching indexer release ends up re-downloaded every cycle — leaving a stack of `…(1) / (2) / (3) …` staging folders and duplicate metadata files in the library dir.

Today's repro on a current canary install (`Listenarr 0.3.1`):

```
[INF] Cutoff not met for "Artificial Condition" (id=179):
      cutoff met=False, best existing quality=M4B
```

Despite the file on disk being `m4b` / `aac` / `64 kbps`, matching `AAC 64kbps` in the default QP.

## Patch

`DeriveQualityLabel` now:

- detects the codec from `Codec` / `Container` / `Format`, including `m4b` / `m4a` / `mp4` → `aac` (audiobooks effectively always use AAC inside MP4 containers);
- buckets the file bitrate to the nearest seeded rung (`320 / 256 / 192 / 128 / 64`);
- emits `"<codec> <bucket>kbps"` (for example `"aac 64kbps"`), which matches `QualityProfile.Qualities` keys via the existing case-insensitive dictionary lookup;
- still emits `"lossless"` for `flac` / `alac` / `wav` / `aiff` / `ape` / `dsd` / `wavpack` so user-defined lossless rungs keep matching;
- only short-circuits to the `audiobookQuality` hint when the hint is already in codec-prefixed shape (`"MP3 320kbps"`, `"AAC 64kbps"`, `"FLAC"`, `"MP3 VBR"`). Legacy values such as `"M4B"` produced by `LibraryController.DeriveAudiobookQualityAsync` are now ignored so we re-derive from the actual file fields.

No public API change.

## Test plan

`tests/Features/Api/Services/AudiobookStatusEvaluatorTests.cs` was updated to use a production-shaped `QualityProfile` (the same 11-rung ladder seeded by `QualityProfileService`) and now also covers:

- `ComputeStatus_ReturnsDownloading_WhenIsDownloading`
- `ComputeStatus_ReturnsQualityMatch_WhenProfileIsNull`
- `ComputeStatus_ReturnsQualityMatch_ForM4BFileMeetingAacCutoff` — the issue #549 regression
- `ComputeStatus_TreatsM4AContainerAsAac`
- `ComputeStatus_BucketsBitrateDownToNearestRung` (200 kbps must bucket to 192, not 256)
- `ComputeStatus_AcceptsBitrateBelowLowestRungAsLowestRung` (< 64 kbps still resolves to a known rung so we don't re-introduce a perpetual re-grab loop)
- `ComputeStatus_UsesAudiobookQualityHintWhenCodecPrefixed`
- `ComputeStatus_IgnoresLegacyM4BHintAndRederivesFromFile`
- `ComputeStatus_TreatsFlacAsLossless`
- `ComputeStatus_TreatsAlacAsLossless`
- existing `ComputeStatus_TreatsWavPackAsLossless` retained, now backed by a profile shape consistent with the rest of the tests.

Local results (.NET SDK 10.0.203, `Release` configuration):

```
Passed!  - Failed:     0, Passed:    16, Skipped:     0, Total:    16   (evaluator tests)
Passed!  - Failed:     0, Passed:   623, Skipped:     0, Total:   623   (full suite)
dotnet format listenarr.slnx --verify-no-changes  → exit 0
```

## Things I deliberately did NOT change

- `LibraryController.DeriveAudiobookQualityAsync` still returns the legacy `"M4B"` string for the per-audiobook `Quality` column. That value is now harmless because the evaluator ignores hints that aren't in codec-prefixed shape, and changing the controller as well would require a DB-side rewrite of existing values. Happy to follow up if maintainers prefer it cleaned up in the same PR.
- No 96 kbps rung was added (none exists in the seed table) and VBR is not auto-detected (would require multi-sample probing) — files below 64 kbps map to the lowest rung so they still satisfy the lowest possible cutoff.