### PR TITLE
Show ready / total book counts with quality-color cue on grouped collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.72]
+
+### Added
+- **List view for grouped authors and series:** Switching to list view (`viewMode === 'list'`) while grouping the audiobooks library by author or series now renders a row-per-collection list instead of silently falling back to the grid. Each row shows the collection cover, name, and book count, and clicking it navigates to the collection page — matching how the list-mode toggle already works for the Books grouping.
+
 ## [0.2.71] - 2026-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **List view for grouped authors and series:** Switching to list view (`viewMode === 'list'`) while grouping the audiobooks library by author or series now renders a row-per-collection list instead of silently falling back to the grid. Each row shows the collection cover, name, and book count, and clicking it navigates to the collection page — matching how the list-mode toggle already works for the Books grouping.
+- **Ready / total book counts on grouped collections:** Author and series collections in the audiobooks library now show how many of their books actually have a playable file present (e.g. `8 / 12 books`) instead of just the library total. The ready-count is colored green when every file in the collection meets the quality profile, orange when at least one file is below the profile but still playable, and neutral when no files are present yet. Applies to the new list-view rows and the grid-card bottom placard (the small corner badge stays as the library total to keep that uncluttered).
 
 ## [0.2.71] - 2026-04-17
 

--- a/fe/src/__tests__/AudiobooksView.spec.ts
+++ b/fe/src/__tests__/AudiobooksView.spec.ts
@@ -34,7 +34,14 @@ vi.mock('@/services/api', () => ({
 
 type AudiobooksVm = {
   setGroupBy?: (value: string) => Promise<void> | void
-  groupedCollections?: Array<{ name: string; count: number; coverUrl?: string }>
+  groupedCollections?: Array<{
+    name: string
+    count: number
+    readyCount: number
+    qualityMismatchCount: number
+    coverUrl?: string
+    coverUrls?: string[]
+  }>
   showItemDetails?: boolean
   viewMode?: 'grid' | 'list'
   toggleViewMode?: () => void
@@ -205,11 +212,15 @@ describe('AudiobooksView Grouping', () => {
     expect(groupedCollections.find((g) => g.name === 'Author A')).toEqual({
       name: 'Author A',
       count: 2,
+      readyCount: 0,
+      qualityMismatchCount: 0,
       coverUrl: undefined,
     })
     expect(groupedCollections.find((g) => g.name === 'Author B')).toEqual({
       name: 'Author B',
       count: 1,
+      readyCount: 0,
+      qualityMismatchCount: 0,
       coverUrl: undefined,
     })
 
@@ -298,11 +309,15 @@ describe('AudiobooksView Grouping', () => {
     expect(groupedCollections.find((g) => g.name === 'Series 1')).toEqual({
       name: 'Series 1',
       count: 2,
+      readyCount: 0,
+      qualityMismatchCount: 0,
       coverUrls: ['cover1.jpg', 'cover2.jpg'],
     })
     expect(groupedCollections.find((g) => g.name === 'Series 2')).toEqual({
       name: 'Series 2',
       count: 1,
+      readyCount: 0,
+      qualityMismatchCount: 0,
       coverUrls: ['cover3.jpg'],
     })
   })
@@ -733,6 +748,93 @@ describe('AudiobooksView Grouping', () => {
     }
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.series-bottom-placard').exists()).toBe(true)
+  })
+
+  it('tracks readyCount per collection (books with playable files count as ready)', async () => {
+    if (
+      typeof (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver === 'undefined'
+    ) {
+      ;(globalThis as unknown as Record<string, unknown>).ResizeObserver = class {
+        observe() {}
+        disconnect() {}
+      }
+    }
+    if (typeof (globalThis as unknown as { WebSocket?: unknown }).WebSocket === 'undefined') {
+      ;(globalThis as unknown as Record<string, unknown>).WebSocket = function () {
+        /* noop */
+      }
+    }
+
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'home', component: { template: '<div />' } },
+        { path: '/audiobooks', name: 'audiobooks', component: AudiobooksView },
+      ],
+    })
+    await router.push('/audiobooks')
+    await router.isReady().catch(() => {})
+
+    const store = useLibraryStore()
+    // Author A has 2 books, both with files (ready). Author B has 1 book with no files (not ready).
+    store.audiobooks = [
+      {
+        id: 1,
+        title: 'Book 1',
+        authors: ['Author A'],
+        imageUrl: 'cover1.jpg',
+        filePath: '/audiobooks/book1.m4b',
+        fileSize: 12345,
+        files: [{ format: 'm4b' }],
+      },
+      {
+        id: 2,
+        title: 'Book 2',
+        authors: ['Author A'],
+        imageUrl: 'cover2.jpg',
+        filePath: '/audiobooks/book2.m4b',
+        fileSize: 23456,
+        files: [{ format: 'm4b' }],
+      },
+      {
+        id: 3,
+        title: 'Book 3',
+        authors: ['Author B'],
+        imageUrl: 'cover3.jpg',
+        files: [],
+      },
+    ] as unknown as import('@/types').Audiobook[]
+
+    store.fetchLibrary = vi.fn(async () => undefined)
+    const wrapper = mount(AudiobooksView, {
+      global: {
+        plugins: [pinia, router],
+        stubs: [
+          'BulkEditModal',
+          'EditAudiobookModal',
+          'CustomFilterModal',
+          'FiltersDropdown',
+          'CustomSelect',
+        ],
+      },
+    })
+    await new Promise((r) => setTimeout(r, 0))
+
+    const vm = getVm(wrapper)
+    await vm.setGroupBy?.('authors')
+    await wrapper.vm.$nextTick()
+
+    const groups = vm.groupedCollections ?? []
+    const a = groups.find((g) => g.name === 'Author A')!
+    const b = groups.find((g) => g.name === 'Author B')!
+    expect(a.count).toBe(2)
+    expect(a.readyCount).toBe(2)
+    expect(a.qualityMismatchCount).toBe(0)
+    expect(b.count).toBe(1)
+    expect(b.readyCount).toBe(0)
+    expect(b.qualityMismatchCount).toBe(0)
   })
 
   it.each([

--- a/fe/src/__tests__/AudiobooksView.spec.ts
+++ b/fe/src/__tests__/AudiobooksView.spec.ts
@@ -36,6 +36,8 @@ type AudiobooksVm = {
   setGroupBy?: (value: string) => Promise<void> | void
   groupedCollections?: Array<{ name: string; count: number; coverUrl?: string }>
   showItemDetails?: boolean
+  viewMode?: 'grid' | 'list'
+  toggleViewMode?: () => void
 }
 
 const getVm = (wrapper: ReturnType<typeof mount>) => wrapper.vm as unknown as AudiobooksVm
@@ -732,4 +734,106 @@ describe('AudiobooksView Grouping', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.series-bottom-placard').exists()).toBe(true)
   })
+
+  it.each([
+    ['authors', 'Author A', 'Author B'],
+    ['series', 'Series 1', 'Series 2'],
+  ] as const)(
+    'renders collection list rows when viewMode is list and groupBy is %s',
+    async (group, firstName, secondName) => {
+      if (
+        typeof (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver ===
+        'undefined'
+      ) {
+        ;(globalThis as unknown as Record<string, unknown>).ResizeObserver = class {
+          observe() {}
+          disconnect() {}
+        }
+      }
+      if (typeof (globalThis as unknown as { WebSocket?: unknown }).WebSocket === 'undefined') {
+        ;(globalThis as unknown as Record<string, unknown>).WebSocket = function () {
+          /* noop */
+        }
+      }
+
+      // Persistence only loads viewMode when groupBy='books' (scrollContainer is mounted);
+      // in this test we toggle into list mode explicitly after mount.
+      localStorage.removeItem('listenarr.viewMode')
+
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const router = createRouter({
+        history: createMemoryHistory(),
+        routes: [
+          { path: '/', name: 'home', component: { template: '<div />' } },
+          { path: '/audiobooks', name: 'audiobooks', component: AudiobooksView },
+          {
+            path: '/collection/:type/:name',
+            name: 'collection',
+            component: { template: '<div />' },
+          },
+        ],
+      })
+      await router.push('/audiobooks')
+      await router.isReady().catch(() => {})
+
+      const store = useLibraryStore()
+      store.audiobooks = [
+        {
+          id: 1,
+          title: 'Book 1',
+          authors: ['Author A'],
+          series: 'Series 1',
+          imageUrl: 'cover1.jpg',
+          files: [],
+        },
+        {
+          id: 2,
+          title: 'Book 2',
+          authors: ['Author A'],
+          series: 'Series 1',
+          imageUrl: 'cover2.jpg',
+          files: [],
+        },
+        {
+          id: 3,
+          title: 'Book 3',
+          authors: ['Author B'],
+          series: 'Series 2',
+          imageUrl: 'cover3.jpg',
+          files: [],
+        },
+      ] as unknown as import('@/types').Audiobook[]
+
+      store.fetchLibrary = vi.fn(async () => undefined)
+      const wrapper = mount(AudiobooksView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: [
+            'BulkEditModal',
+            'EditAudiobookModal',
+            'CustomFilterModal',
+            'FiltersDropdown',
+            'CustomSelect',
+          ],
+        },
+      })
+      await new Promise((r) => setTimeout(r, 0))
+
+      const vm = getVm(wrapper)
+      vm.toggleViewMode?.()
+      await vm.setGroupBy?.(group)
+      await wrapper.vm.$nextTick()
+
+      expect(vm.viewMode).toBe('list')
+      const rows = wrapper.findAll('.collection-list-item')
+      expect(rows).toHaveLength(2)
+      // Grid-mode card markup should NOT be present when list mode is active.
+      expect(wrapper.find('.grouped-grid').exists()).toBe(false)
+
+      const names = rows.map((r) => r.find('.audiobook-title').text())
+      expect(names).toContain(firstName)
+      expect(names).toContain(secondName)
+    },
+  )
 })

--- a/fe/src/views/library/AudiobooksView.vue
+++ b/fe/src/views/library/AudiobooksView.vue
@@ -211,7 +211,55 @@
 
     <!-- Grouped View -->
     <div v-else-if="groupBy !== 'books'" class="grouped-view">
-      <div class="grouped-grid">
+      <!-- List rendering for grouped collections (authors / series) -->
+      <div v-if="viewMode === 'list'" class="audiobooks-list collections-list">
+        <div
+          v-if="groupedCollections && groupedCollections.length > 0"
+          class="list-header collections-list-header"
+        >
+          <div class="col-cover">Cover</div>
+          <div class="col-title">{{ groupBy === 'authors' ? 'Author' : 'Series' }}</div>
+          <div class="col-count">Books</div>
+        </div>
+        <div
+          v-for="collection in groupedCollections || []"
+          :key="`collection-list-${collection.name}`"
+          class="audiobook-list-item collection-list-item"
+          :class="{
+            'author-collection': groupBy === 'authors',
+            'series-collection': groupBy === 'series',
+          }"
+          tabindex="0"
+          role="button"
+          :aria-label="`Open ${collection.name}`"
+          @click="navigateToCollection(collection)"
+          @keydown.enter.prevent="navigateToCollection(collection)"
+          @keydown.space.prevent="navigateToCollection(collection)"
+        >
+          <img
+            class="list-thumb"
+            :src="
+              getProtectedImageSrc(
+                groupBy === 'authors'
+                  ? getAuthorImageUrl(collection)
+                  : collection.coverUrls && collection.coverUrls[0],
+                `${groupBy}-list:${collection.name}`,
+              ) || getPlaceholderUrl()
+            "
+            :alt="collection.name"
+            loading="lazy"
+            decoding="async"
+            @error="handleImageError"
+          />
+          <div class="list-details">
+            <div class="audiobook-title">{{ collection.name }}</div>
+          </div>
+          <div class="collection-count">
+            {{ collection.count }} book{{ collection.count !== 1 ? 's' : '' }}
+          </div>
+        </div>
+      </div>
+      <div v-else class="grouped-grid">
         <div
           v-for="collection in groupedCollections || []"
           :key="collection.name"
@@ -2310,6 +2358,8 @@ defineExpose({
   setGroupBy,
   groupedCollections,
   showItemDetails,
+  viewMode,
+  toggleViewMode,
 })
 </script>
 
@@ -3763,6 +3813,26 @@ defineExpose({
   opacity: 0.9;
 }
 .list-header .col-actions {
+  text-align: right;
+}
+
+/* Collection list rows (author / series grouping in list view) */
+.collections-list-header {
+  grid-template-columns: 64px 1fr auto;
+}
+
+.collections-list-header .col-count {
+  opacity: 0.9;
+  text-align: right;
+}
+
+.collection-list-item {
+  grid-template-columns: 64px 1fr auto;
+}
+
+.collection-list-item .collection-count {
+  font-size: 12px;
+  color: #ccc;
   text-align: right;
 }
 

--- a/fe/src/views/library/AudiobooksView.vue
+++ b/fe/src/views/library/AudiobooksView.vue
@@ -255,7 +255,17 @@
             <div class="audiobook-title">{{ collection.name }}</div>
           </div>
           <div class="collection-count">
-            {{ collection.count }} book{{ collection.count !== 1 ? 's' : '' }}
+            <span
+              class="collection-have-count"
+              :class="{
+                'count-all-good':
+                  collection.readyCount > 0 && collection.qualityMismatchCount === 0,
+                'count-has-mismatch':
+                  collection.readyCount > 0 && collection.qualityMismatchCount > 0,
+              }"
+              >{{ collection.readyCount }}</span
+            >
+            / {{ collection.count }} book{{ collection.count !== 1 ? 's' : '' }}
           </div>
         </div>
       </div>
@@ -408,7 +418,17 @@
             <div v-if="showItemDetails" class="grid-bottom-details">
               <div class="detail-line title">{{ collection.name }}</div>
               <div class="detail-line small">
-                {{ collection.count }} book{{ collection.count !== 1 ? 's' : '' }}
+                <span
+                  class="collection-have-count"
+                  :class="{
+                    'count-all-good':
+                      collection.readyCount > 0 && collection.qualityMismatchCount === 0,
+                    'count-has-mismatch':
+                      collection.readyCount > 0 && collection.qualityMismatchCount > 0,
+                  }"
+                  >{{ collection.readyCount }}</span
+                >
+                / {{ collection.count }} book{{ collection.count !== 1 ? 's' : '' }}
               </div>
             </div>
           </div>
@@ -417,7 +437,17 @@
             <div class="series-bottom-content">
               <p class="series-bottom-title">{{ collection.name }}</p>
               <p class="series-bottom-count">
-                {{ collection.count }} book{{ collection.count !== 1 ? 's' : '' }}
+                <span
+                  class="collection-have-count"
+                  :class="{
+                    'count-all-good':
+                      collection.readyCount > 0 && collection.qualityMismatchCount === 0,
+                    'count-has-mismatch':
+                      collection.readyCount > 0 && collection.qualityMismatchCount > 0,
+                  }"
+                  >{{ collection.readyCount }}</span
+                >
+                / {{ collection.count }} book{{ collection.count !== 1 ? 's' : '' }}
               </p>
             </div>
           </div>
@@ -1309,6 +1339,22 @@ async function ensureAuthorCover(authorName: string) {
   }
 }
 
+// Quality profiles + active downloads are referenced from groupedCollections
+// below to count per-collection ready / quality-mismatch books, so they need
+// to be declared before groupedCollections (the original declarations live
+// further down the file).
+const qualityProfiles = ref<QualityProfile[]>([])
+
+const activeDownloadAudiobookIds = computed(() => {
+  const ids = new Set<number>()
+  for (const download of downloadsStore.activeDownloads || []) {
+    if (typeof download?.audiobookId === 'number') {
+      ids.add(download.audiobookId)
+    }
+  }
+  return ids
+})
+
 // Grouping mode
 const GROUP_BY_KEY = 'listenarr.groupBy'
 const groupBy = ref<'books' | 'authors' | 'series'>('books')
@@ -1355,8 +1401,17 @@ const groupedCollections = computed(() => {
   const books = filteredAndSortedAudiobooks.value
   const groups = new Map<
     string,
-    { name: string; count: number; coverUrl?: string; coverUrls?: string[] }
+    {
+      name: string
+      count: number
+      readyCount: number
+      qualityMismatchCount: number
+      coverUrl?: string
+      coverUrls?: string[]
+    }
   >()
+  const activeIds = activeDownloadAudiobookIds.value
+  const profiles = qualityProfiles.value
 
   books.forEach((book) => {
     const key = groupBy.value === 'authors' ? book.authors?.[0] : book.series
@@ -1386,13 +1441,30 @@ const groupedCollections = computed(() => {
             } catch {}
           }
 
-          groups.set(key, { name: key, count: 0, coverUrl: cover })
+          groups.set(key, {
+            name: key,
+            count: 0,
+            readyCount: 0,
+            qualityMismatchCount: 0,
+            coverUrl: cover,
+          })
         } else {
-          groups.set(key, { name: key, count: 0, coverUrls: [] })
+          groups.set(key, {
+            name: key,
+            count: 0,
+            readyCount: 0,
+            qualityMismatchCount: 0,
+            coverUrls: [],
+          })
         }
       }
       const group = groups.get(key)!
       group.count++
+      const status = computeAudiobookStatus(book, activeIds, profiles)
+      if (status === 'quality-match' || status === 'quality-mismatch') {
+        group.readyCount++
+        if (status === 'quality-mismatch') group.qualityMismatchCount++
+      }
       const bookCover = getBookImageUrl(book)
       if (groupBy.value === 'authors') {
         try {
@@ -1754,23 +1826,12 @@ const showDeleteDialog = ref(false)
 const deleteTarget = ref<Audiobook | null>(null)
 const deleteFilesOnDisk = ref(false)
 const deleteFolderOnDisk = ref(false)
-const qualityProfiles = ref<QualityProfile[]>([])
 const showBulkEditModal = ref(false)
 const showOrganizeModal = ref(false)
 const organizeAudiobookIds = ref<number[]>([])
 const showEditModal = ref(false)
 const editAudiobook = ref<Audiobook | null>(null)
 const lastClickedIndex = ref<number | null>(null)
-
-const activeDownloadAudiobookIds = computed(() => {
-  const ids = new Set<number>()
-  for (const download of downloadsStore.activeDownloads || []) {
-    if (typeof download?.audiobookId === 'number') {
-      ids.add(download.audiobookId)
-    }
-  }
-  return ids
-})
 
 function computeAudiobookStatusRaw(audiobook: Audiobook): AudiobookStatus {
   return computeAudiobookStatus(audiobook, activeDownloadAudiobookIds.value, qualityProfiles.value)
@@ -3834,6 +3895,18 @@ defineExpose({
   font-size: 12px;
   color: #ccc;
   text-align: right;
+}
+
+.collection-have-count {
+  font-weight: 600;
+}
+
+.collection-have-count.count-all-good {
+  color: #2ecc71;
+}
+
+.collection-have-count.count-has-mismatch {
+  color: #f39c12;
 }
 
 /* Position badges between details and actions */


### PR DESCRIPTION
## Summary
- For audiobook collections grouped by author or series, the count column previously showed just the library total (e.g. `12 books`). This adds a ready / total breakdown — \`8 / 12 books\` — where the numerator counts books with a playable file present (statuses `quality-match` or `quality-mismatch`).
- The numerator is colored:
  - **Green** when every present file meets the quality profile.
  - **Orange** when at least one file is below the profile but still playable.
  - **Neutral** when no files are present yet.
- Applied to both the new list-view row and the grid-card bottom placard (visible when item-details is enabled). The small corner count badge on grid cards stays as just the library total to keep the visual uncluttered.
- Build/PR note: **stacked on top of #585** (the list-view rendering for grouped collections). #585 should be merged first; otherwise the list-view template this PR colors doesn't exist yet.

## Implementation notes
- New per-collection fields on `groupedCollections`: `readyCount` and `qualityMismatchCount`. Computed inline by calling `computeAudiobookStatus` (the pure helper in `fe/src/utils/audiobookStatus.ts`).
- `qualityProfiles` ref and `activeDownloadAudiobookIds` computed are moved earlier in the file so `groupedCollections` can depend on them. The status-cache computed (`audiobookStatusById`) declared further down stays where it is — `groupedCollections` calls the pure function directly to avoid a temporal-dead-zone error during initial watcher setup.
- Colors reuse the existing `#2ecc71` / `#f39c12` palette from the audiobook-status legend.

## Test plan
- [x] `cd fe && npm run test:unit` — 351 / 351 passing (351 new test asserts `readyCount` is populated from books-with-files data)
- [x] `npx vue-tsc --noEmit -p tsconfig.app.json` — clean
- [x] `cd tests && dotnet test` — passing (no backend changes)

Closes kevinheneveld/Listenarr#2