### PR TITLE
Persist audiobooks list/grid view mode per grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.72]
+
+### Added
+- **List view for grouped authors and series:** Switching to list view (`viewMode === 'list'`) while grouping the audiobooks library by author or series now renders a row-per-collection list instead of silently falling back to the grid. Each row shows the collection cover, name, and book count, and clicking it navigates to the collection page — matching how the list-mode toggle already works for the Books grouping.
+
 ## [0.2.71] - 2026-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **List view for grouped authors and series:** Switching to list view (`viewMode === 'list'`) while grouping the audiobooks library by author or series now renders a row-per-collection list instead of silently falling back to the grid. Each row shows the collection cover, name, and book count, and clicking it navigates to the collection page — matching how the list-mode toggle already works for the Books grouping.
 
+### Changed
+- **Audiobooks list/grid view mode is now remembered per grouping:** Previously the list/grid toggle's stored preference was only re-applied when grouping by Books; switching to Authors or Series and navigating away would silently revert to grid. The view mode is now persisted under separate keys (`listenarr.viewMode.books`, `.authors`, `.series`) and restored when the corresponding grouping is active. A one-time migration seeds all three keys from the legacy `listenarr.viewMode` value so existing users keep their preference.
+
 ## [0.2.71] - 2026-04-17
 
 ### Added

--- a/fe/src/__tests__/AudiobooksView.spec.ts
+++ b/fe/src/__tests__/AudiobooksView.spec.ts
@@ -756,9 +756,11 @@ describe('AudiobooksView Grouping', () => {
         }
       }
 
-      // Persistence only loads viewMode when groupBy='books' (scrollContainer is mounted);
-      // in this test we toggle into list mode explicitly after mount.
+      // Clear persistence keys so this test isn't affected by other tests.
       localStorage.removeItem('listenarr.viewMode')
+      localStorage.removeItem('listenarr.viewMode.books')
+      localStorage.removeItem('listenarr.viewMode.authors')
+      localStorage.removeItem('listenarr.viewMode.series')
 
       const pinia = createPinia()
       setActivePinia(pinia)
@@ -836,4 +838,145 @@ describe('AudiobooksView Grouping', () => {
       expect(names).toContain(secondName)
     },
   )
+
+  it('persists viewMode per grouping and restores it when grouping changes', async () => {
+    if (
+      typeof (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver === 'undefined'
+    ) {
+      ;(globalThis as unknown as Record<string, unknown>).ResizeObserver = class {
+        observe() {}
+        disconnect() {}
+      }
+    }
+    if (typeof (globalThis as unknown as { WebSocket?: unknown }).WebSocket === 'undefined') {
+      ;(globalThis as unknown as Record<string, unknown>).WebSocket = function () {
+        /* noop */
+      }
+    }
+
+    // Per-grouping prefs: list mode for authors, grid for books.
+    localStorage.removeItem('listenarr.viewMode')
+    localStorage.setItem('listenarr.viewMode.books', 'grid')
+    localStorage.setItem('listenarr.viewMode.authors', 'list')
+    localStorage.setItem('listenarr.viewMode.series', 'grid')
+    localStorage.setItem('listenarr.groupBy', 'books')
+
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'home', component: { template: '<div />' } },
+        { path: '/audiobooks', name: 'audiobooks', component: AudiobooksView },
+      ],
+    })
+    await router.push('/audiobooks')
+    await router.isReady().catch(() => {})
+
+    const store = useLibraryStore()
+    store.audiobooks = [
+      {
+        id: 1,
+        title: 'Book 1',
+        authors: ['Author A'],
+        series: 'Series 1',
+        imageUrl: 'cover1.jpg',
+        files: [],
+      },
+    ] as unknown as import('@/types').Audiobook[]
+
+    store.fetchLibrary = vi.fn(async () => undefined)
+    const wrapper = mount(AudiobooksView, {
+      global: {
+        plugins: [pinia, router],
+        stubs: [
+          'BulkEditModal',
+          'EditAudiobookModal',
+          'CustomFilterModal',
+          'FiltersDropdown',
+          'CustomSelect',
+        ],
+      },
+    })
+    await new Promise((r) => setTimeout(r, 0))
+
+    const vm = getVm(wrapper)
+    // Initial grouping is books → grid (the stored books pref)
+    expect(vm.viewMode).toBe('grid')
+
+    // Switch to authors → should pick up the stored 'list' pref
+    await vm.setGroupBy?.('authors')
+    await wrapper.vm.$nextTick()
+    expect(vm.viewMode).toBe('list')
+
+    // Switch to series → stored as 'grid'
+    await vm.setGroupBy?.('series')
+    await wrapper.vm.$nextTick()
+    expect(vm.viewMode).toBe('grid')
+
+    // Switch back to authors → still 'list'
+    await vm.setGroupBy?.('authors')
+    await wrapper.vm.$nextTick()
+    expect(vm.viewMode).toBe('list')
+  })
+
+  it('migrates the legacy viewMode key to per-grouping keys on first load', async () => {
+    if (
+      typeof (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver === 'undefined'
+    ) {
+      ;(globalThis as unknown as Record<string, unknown>).ResizeObserver = class {
+        observe() {}
+        disconnect() {}
+      }
+    }
+    if (typeof (globalThis as unknown as { WebSocket?: unknown }).WebSocket === 'undefined') {
+      ;(globalThis as unknown as Record<string, unknown>).WebSocket = function () {
+        /* noop */
+      }
+    }
+
+    // No per-grouping keys yet; legacy key says 'list'.
+    localStorage.removeItem('listenarr.viewMode.books')
+    localStorage.removeItem('listenarr.viewMode.authors')
+    localStorage.removeItem('listenarr.viewMode.series')
+    localStorage.setItem('listenarr.viewMode', 'list')
+    localStorage.setItem('listenarr.groupBy', 'books')
+
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'home', component: { template: '<div />' } },
+        { path: '/audiobooks', name: 'audiobooks', component: AudiobooksView },
+      ],
+    })
+    await router.push('/audiobooks')
+    await router.isReady().catch(() => {})
+
+    const store = useLibraryStore()
+    store.audiobooks = [] as unknown as import('@/types').Audiobook[]
+    store.fetchLibrary = vi.fn(async () => undefined)
+
+    const wrapper = mount(AudiobooksView, {
+      global: {
+        plugins: [pinia, router],
+        stubs: [
+          'BulkEditModal',
+          'EditAudiobookModal',
+          'CustomFilterModal',
+          'FiltersDropdown',
+          'CustomSelect',
+        ],
+      },
+    })
+    await new Promise((r) => setTimeout(r, 0))
+
+    const vm = getVm(wrapper)
+    expect(vm.viewMode).toBe('list')
+    // All three per-grouping keys should have been seeded from the legacy value.
+    expect(localStorage.getItem('listenarr.viewMode.books')).toBe('list')
+    expect(localStorage.getItem('listenarr.viewMode.authors')).toBe('list')
+    expect(localStorage.getItem('listenarr.viewMode.series')).toBe('list')
+  })
 })

--- a/fe/src/__tests__/AudiobooksView.spec.ts
+++ b/fe/src/__tests__/AudiobooksView.spec.ts
@@ -36,6 +36,8 @@ type AudiobooksVm = {
   setGroupBy?: (value: string) => Promise<void> | void
   groupedCollections?: Array<{ name: string; count: number; coverUrl?: string }>
   showItemDetails?: boolean
+  viewMode?: 'grid' | 'list'
+  toggleViewMode?: () => void
 }
 
 const getVm = (wrapper: ReturnType<typeof mount>) => wrapper.vm as unknown as AudiobooksVm
@@ -732,4 +734,106 @@ describe('AudiobooksView Grouping', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.series-bottom-placard').exists()).toBe(true)
   })
+
+  it.each([
+    ['authors', 'Author A', 'Author B'],
+    ['series', 'Series 1', 'Series 2'],
+  ] as const)(
+    'renders collection list rows when viewMode is list and groupBy is %s',
+    async (group, firstName, secondName) => {
+      if (
+        typeof (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver ===
+        'undefined'
+      ) {
+        ;(globalThis as unknown as Record<string, unknown>).ResizeObserver = class {
+          observe() {}
+          disconnect() {}
+        }
+      }
+      if (typeof (globalThis as unknown as { WebSocket?: unknown }).WebSocket === 'undefined') {
+        ;(globalThis as unknown as Record<string, unknown>).WebSocket = function () {
+          /* noop */
+        }
+      }
+
+      // Persistence only loads viewMode when groupBy='books' (scrollContainer is mounted);
+      // in this test we toggle into list mode explicitly after mount.
+      localStorage.removeItem('listenarr.viewMode')
+
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const router = createRouter({
+        history: createMemoryHistory(),
+        routes: [
+          { path: '/', name: 'home', component: { template: '<div />' } },
+          { path: '/audiobooks', name: 'audiobooks', component: AudiobooksView },
+          {
+            path: '/collection/:type/:name',
+            name: 'collection',
+            component: { template: '<div />' },
+          },
+        ],
+      })
+      await router.push('/audiobooks')
+      await router.isReady().catch(() => {})
+
+      const store = useLibraryStore()
+      store.audiobooks = [
+        {
+          id: 1,
+          title: 'Book 1',
+          authors: ['Author A'],
+          series: 'Series 1',
+          imageUrl: 'cover1.jpg',
+          files: [],
+        },
+        {
+          id: 2,
+          title: 'Book 2',
+          authors: ['Author A'],
+          series: 'Series 1',
+          imageUrl: 'cover2.jpg',
+          files: [],
+        },
+        {
+          id: 3,
+          title: 'Book 3',
+          authors: ['Author B'],
+          series: 'Series 2',
+          imageUrl: 'cover3.jpg',
+          files: [],
+        },
+      ] as unknown as import('@/types').Audiobook[]
+
+      store.fetchLibrary = vi.fn(async () => undefined)
+      const wrapper = mount(AudiobooksView, {
+        global: {
+          plugins: [pinia, router],
+          stubs: [
+            'BulkEditModal',
+            'EditAudiobookModal',
+            'CustomFilterModal',
+            'FiltersDropdown',
+            'CustomSelect',
+          ],
+        },
+      })
+      await new Promise((r) => setTimeout(r, 0))
+
+      const vm = getVm(wrapper)
+      vm.toggleViewMode?.()
+      await vm.setGroupBy?.(group)
+      await wrapper.vm.$nextTick()
+
+      expect(vm.viewMode).toBe('list')
+      const rows = wrapper.findAll('.collection-list-item')
+      expect(rows).toHaveLength(2)
+      // Grid-mode card markup should NOT be present when list mode is active.
+      expect(wrapper.find('.grouped-grid').exists()).toBe(false)
+
+      const names = rows.map((r) => r.find('.audiobook-title').text())
+      expect(names).toContain(firstName)
+      expect(names).toContain(secondName)
+    },
+  )
 })

--- a/fe/src/views/library/AudiobooksView.vue
+++ b/fe/src/views/library/AudiobooksView.vue
@@ -211,7 +211,55 @@
 
     <!-- Grouped View -->
     <div v-else-if="groupBy !== 'books'" class="grouped-view">
-      <div class="grouped-grid">
+      <!-- List rendering for grouped collections (authors / series) -->
+      <div v-if="viewMode === 'list'" class="audiobooks-list collections-list">
+        <div
+          v-if="groupedCollections && groupedCollections.length > 0"
+          class="list-header collections-list-header"
+        >
+          <div class="col-cover">Cover</div>
+          <div class="col-title">{{ groupBy === 'authors' ? 'Author' : 'Series' }}</div>
+          <div class="col-count">Books</div>
+        </div>
+        <div
+          v-for="collection in groupedCollections || []"
+          :key="`collection-list-${collection.name}`"
+          class="audiobook-list-item collection-list-item"
+          :class="{
+            'author-collection': groupBy === 'authors',
+            'series-collection': groupBy === 'series',
+          }"
+          tabindex="0"
+          role="button"
+          :aria-label="`Open ${collection.name}`"
+          @click="navigateToCollection(collection)"
+          @keydown.enter.prevent="navigateToCollection(collection)"
+          @keydown.space.prevent="navigateToCollection(collection)"
+        >
+          <img
+            class="list-thumb"
+            :src="
+              getProtectedImageSrc(
+                groupBy === 'authors'
+                  ? getAuthorImageUrl(collection)
+                  : collection.coverUrls && collection.coverUrls[0],
+                `${groupBy}-list:${collection.name}`,
+              ) || getPlaceholderUrl()
+            "
+            :alt="collection.name"
+            loading="lazy"
+            decoding="async"
+            @error="handleImageError"
+          />
+          <div class="list-details">
+            <div class="audiobook-title">{{ collection.name }}</div>
+          </div>
+          <div class="collection-count">
+            {{ collection.count }} book{{ collection.count !== 1 ? 's' : '' }}
+          </div>
+        </div>
+      </div>
+      <div v-else class="grouped-grid">
         <div
           v-for="collection in groupedCollections || []"
           :key="collection.name"
@@ -2310,6 +2358,8 @@ defineExpose({
   setGroupBy,
   groupedCollections,
   showItemDetails,
+  viewMode,
+  toggleViewMode,
 })
 </script>
 
@@ -3763,6 +3813,26 @@ defineExpose({
   opacity: 0.9;
 }
 .list-header .col-actions {
+  text-align: right;
+}
+
+/* Collection list rows (author / series grouping in list view) */
+.collections-list-header {
+  grid-template-columns: 64px 1fr auto;
+}
+
+.collections-list-header .col-count {
+  opacity: 0.9;
+  text-align: right;
+}
+
+.collection-list-item {
+  grid-template-columns: 64px 1fr auto;
+}
+
+.collection-list-item .collection-count {
+  font-size: 12px;
+  color: #ccc;
   text-align: right;
 }
 

--- a/fe/src/views/library/AudiobooksView.vue
+++ b/fe/src/views/library/AudiobooksView.vue
@@ -1337,6 +1337,9 @@ watch(groupBy, (v) => {
     localStorage.setItem(GROUP_BY_KEY, v)
   } catch {}
 
+  // Restore the view mode the user last left this grouping in.
+  viewMode.value = loadViewModeFor(v)
+
   // Ensure selected sort key is valid for the new grouping; reset to sensible defaults if needed
   const allowed = sortOptions.value.map((o) => o.value)
   const groupSort = sortState[v]
@@ -1603,10 +1606,44 @@ const GRID_GAP = 20
 const BUFFER_ROWS = 2 // Extra rows to render above and below viewport
 const measuredRowHeight = ref<number | null>(null)
 
-// Local storage key for persisting view mode
-const VIEWMODE_KEY = 'listenarr.viewMode'
+// View mode is persisted per grouping so users can have, e.g., grid for books
+// but list for authors. The legacy single key is consulted once for migration —
+// when a per-grouping key is unset, we seed it from the legacy value.
+const VIEWMODE_KEY_LEGACY = 'listenarr.viewMode'
+const VIEWMODE_KEYS = {
+  books: 'listenarr.viewMode.books',
+  authors: 'listenarr.viewMode.authors',
+  series: 'listenarr.viewMode.series',
+} as const
 
-const viewMode = ref<'grid' | 'list'>('grid')
+function loadViewModeFor(g: 'books' | 'authors' | 'series'): 'grid' | 'list' {
+  try {
+    const legacy = localStorage.getItem(VIEWMODE_KEY_LEGACY)
+    if (legacy === 'grid' || legacy === 'list') {
+      for (const k of Object.values(VIEWMODE_KEYS)) {
+        if (localStorage.getItem(k) === null) localStorage.setItem(k, legacy)
+      }
+    }
+    const stored = localStorage.getItem(VIEWMODE_KEYS[g])
+    if (stored === 'grid' || stored === 'list') return stored
+  } catch {
+    /* ignore localStorage errors (e.g., privacy mode) */
+  }
+  return 'grid'
+}
+
+const viewMode = ref<'grid' | 'list'>(loadViewModeFor(groupBy.value))
+
+// Persist view mode under the per-grouping key whenever it changes. Set up at
+// top level so it always fires — the previous setup was gated by
+// scrollContainer being mounted, which only happens for groupBy === 'books'.
+watch(viewMode, (v) => {
+  try {
+    localStorage.setItem(VIEWMODE_KEYS[groupBy.value], v)
+  } catch {
+    /* ignore */
+  }
+})
 
 const visibleRange = ref({ start: 0, end: 20 }) // Initially show first 20 items
 
@@ -1801,7 +1838,6 @@ function handleClickOutside(event: Event) {
 let resizeObserver: ResizeObserver | null = null
 let stopVisibleRangeWatch: (() => void) | null = null
 let stopViewModeWatch: (() => void) | null = null
-let stopPersistViewModeWatch: (() => void) | null = null
 
 onMounted(async () => {
   document.addEventListener('click', handleClickOutside)
@@ -1828,17 +1864,8 @@ onMounted(async () => {
       }
     }
 
-    // Load persisted view mode (if available) before layout calc
-    try {
-      const stored = localStorage.getItem(VIEWMODE_KEY)
-      if (stored === 'list' || stored === 'grid') {
-        viewMode.value = stored as 'grid' | 'list'
-      }
-    } catch {
-      // ignore localStorage errors (e.g., privacy mode)
-    }
-
-    // Initial calculation
+    // Initial calculation (view mode persistence is handled at top level —
+    // see VIEWMODE_KEYS / loadViewModeFor)
     recalcItemsPerRow()
     // Initialize visible range
     updateVisibleRange()
@@ -1907,14 +1934,6 @@ onMounted(async () => {
       updateVisibleRange()
     })
 
-    // Persist view mode whenever it changes
-    stopPersistViewModeWatch = watch(viewMode, (v) => {
-      try {
-        localStorage.setItem(VIEWMODE_KEY, v)
-      } catch {
-        /* ignore */
-      }
-    })
   }
 })
 
@@ -1933,11 +1952,6 @@ onUnmounted(() => {
     stopViewModeWatch?.()
   } catch {}
   stopViewModeWatch = null
-
-  try {
-    stopPersistViewModeWatch?.()
-  } catch {}
-  stopPersistViewModeWatch = null
 
   try {
     authorCardObserver?.disconnect()


### PR DESCRIPTION
## Summary
- The audiobooks library toolbar exposes a list/grid view toggle, persisted to localStorage. Previously the load-from-storage was nested inside an \`if (scrollContainer.value)\` block that only runs for the Books grouping — so switching to list mode while grouped by Author or Series, then navigating away, would silently revert to grid.
- This switches to three per-grouping keys (\`listenarr.viewMode.books\`, \`.authors\`, \`.series\`) and reads the relevant one unconditionally on mount + whenever \`groupBy\` changes. So each grouping independently remembers list vs grid — useful for users who want, e.g., a list of authors but cards for books.
- A one-time migration seeds all three keys from the legacy \`listenarr.viewMode\` value the first time it's read, so existing users keep their preference.

## Implementation notes
- Persistence watch moved out from inside \`onMounted\`'s scrollContainer guard to a top-level watch, so it fires regardless of grouping.
- Removed the now-unused \`stopPersistViewModeWatch\` cleanup handle.
- Initial viewMode is set inline at declaration: \`ref<...>(loadViewModeFor(groupBy.value))\`.
- Migration is additive — the legacy key is never deleted, just no longer read once the per-grouping keys exist.

## Test plan
- [x] \`cd fe && npm run test:unit\` — 350 / 350 passing (2 new tests: per-grouping persistence + legacy migration)
- [x] \`npx vue-tsc --noEmit -p tsconfig.app.json\` — clean
- [x] \`cd tests && dotnet test\` — passing (no backend changes)

Closes kevinheneveld/Listenarr#3