### PR TITLE
fix(images): swallow RuntimeBinderException in cover-lookup fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Cover-image lookup no longer 500s when one upstream metadata source returns a partial envelope:** `ImagesController.GetImage`'s fallback metadata-driven cover path accesses `env.metadata` on `GetMetadataAsync`'s `object?` return via the C# `dynamic` binder. When the returned envelope shape lacks a `metadata` property — which happens when one of the upstream sources (e.g., Audnexus) 500s and the service still returns a partial envelope — the binder throws `RuntimeBinderException`. That exception wasn't in `IsRecoverableImageLookupException`'s whitelist, so it bypassed the inner catch and the entire image endpoint returned 500. Adding `RuntimeBinderException` to the recoverable list lets the inner catch swallow the bad envelope and the lookup falls through to the next candidate URL or a placeholder, matching how the other recoverable failures behave.
+
 ## [0.2.71] - 2026-04-17
 
 ### Added

--- a/listenarr.api/Controllers/ImagesController.cs
+++ b/listenarr.api/Controllers/ImagesController.cs
@@ -1040,7 +1040,16 @@ namespace Listenarr.Api.Controllers
                 or FormatException
                 or UriFormatException
                 or System.Net.Http.HttpRequestException
-                or System.Text.Json.JsonException;
+                or System.Text.Json.JsonException
+                // GetMetadataAsync returns object?, and the fallback metadata path
+                // accesses fields via dynamic. When the returned envelope shape
+                // lacks the expected `metadata` property (e.g., when one of the
+                // upstream sources like Audnexus 500s and the service still
+                // returns a partial envelope), the C# dynamic binder throws
+                // RuntimeBinderException. Without this in the recoverable filter,
+                // a single bad envelope shape bubbles up to the outer catch and
+                // turns the whole image lookup into a 500.
+                or Microsoft.CSharp.RuntimeBinder.RuntimeBinderException;
         }
 
         private static string ResolvePathWithOptionalBase(string? basePath, string candidatePath)


### PR DESCRIPTION
## Summary

`ImagesController.GetImage`'s fallback metadata-driven cover path accesses fields via `dynamic` on the `object?` returned by `GetMetadataAsync`. When the returned envelope shape lacks the expected `metadata` property — which happens when one of the upstream sources (e.g., Audnexus) 500s and the service still returns a partial envelope — the C# dynamic binder throws `RuntimeBinderException`.

That exception type isn't in `IsRecoverableImageLookupException`'s whitelist, so it bypasses the surrounding `catch when` filter and bubbles to the outer handler. The whole image endpoint then returns 500 instead of falling through to the next candidate URL (OpenLibrary ISBN cover, etc.) or the placeholder.

## Repro

In live logs after a metadata-backfill modal search, six candidates returned 500 from `/api/v1/images/{asin}` for ASINs B0DPMHF5HN, B009S8FKUU, B0H23C15LQ, B002VEU2PQ, B0DPMFLQPH, B0DPMCLFLD. Each is preceded by `[WRN] [Listenarr.Application.Metadata.AudnexusService] Audnexus API returned status code InternalServerError for ASIN ...` and `[INF] Successfully fetched metadata from Audible for ASIN: ...` — the Audible response succeeds, but the envelope shape doesn't have a `metadata` member. Each then logs:

```
[ERR] [Listenarr.Api.Controllers.ImagesController] Error retrieving image for identifier: <ASIN>
   at Listenarr.Api.Controllers.ImagesController.GetImage(String identifier) in /src/listenarr.api/Controllers/ImagesController.cs:line 610
```

Line 610 is `object? mdObj = env.metadata;` — the `dynamic` access. UI-side: those candidates render with the browser's broken-image icon in the metadata-backfill modal candidate list.

## Fix

Add `Microsoft.CSharp.RuntimeBinder.RuntimeBinderException` to `IsRecoverableImageLookupException`. The dynamic access stays — this just makes its failure mode match the existing "log debug and continue" pattern used for `IOException` / `JsonException` / `HttpRequestException` etc. The lookup falls through to the next candidate URL or the placeholder, same as any other recoverable failure.

A larger refactor that replaces the `dynamic` access with a strongly-typed shape would be cleaner but is out of scope for this defensive patch.

## Test plan

- [x] Backend builds clean
- [ ] After deploy, re-trigger the failing scenario from the live log and confirm: no 500 from `/api/v1/images/{asin}`, log shows `[DBG] Failed to parse fallback metadata envelope for {Identifier}` and the lookup falls through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)