### PR TITLE
fix(dockerfile): normalize wwwroot permissions so the non-root runtime user can read static files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,10 @@ RUN groupadd --system listenarr \
 
 COPY --from=build /app/publish .
 
+# Normalize frontend asset permissions so the non-root runtime user can read static files.
+RUN find /app/wwwroot -type d -exec chmod 755 {} \; \
+	&& find /app/wwwroot -type f -exec chmod 644 {} \;
+
 # Ensure config directory exists
 RUN mkdir -p /app/config/database
 

--- a/listenarr.api/Dockerfile.runtime
+++ b/listenarr.api/Dockerfile.runtime
@@ -52,6 +52,10 @@ RUN groupadd --system listenarr \
 # The workflows publish into listenarr.api/publish, so copy that directory into the image root.
 COPY listenarr.api/publish/ /app/
 
+# Normalize frontend asset permissions so the non-root runtime user can read static files.
+RUN find /app/wwwroot -type d -exec chmod 755 {} \; \
+	&& find /app/wwwroot -type f -exec chmod 644 {} \;
+
 # Explicitly copy tools directory from source if not already in publish output
 # This ensures the Discord bot and any other tools are available at runtime
 # Tools were moved into the listenarr.api directory; prefer that path


### PR DESCRIPTION
## Summary

Drafted for visibility per the pacing note on #590 — happy to leave this in draft until you have time.

The Docker final stage copies `/app/publish` from the build stage but doesn't normalize permissions on `/app/wwwroot/*`. Depending on the build host's umask and the source files' modes, the non-root runtime user (`listenarr`) can hit `EACCES` reading individual static assets — typically manifests itself as 403/404 on a subset of bundled FE files (e.g., a single chunk fails to load and the SPA boots into a blank screen).

Fix: add a single Dockerfile step right after `COPY --from=build /app/publish .` that walks `/app/wwwroot` and sets directories to `755` and files to `644`. Matches the conventional mode for served static content and is no-op on most build hosts.

```dockerfile
# Normalize frontend asset permissions so the non-root runtime user can read static files.
RUN find /app/wwwroot -type d -exec chmod 755 {} \; \
    && find /app/wwwroot -type f -exec chmod 644 {} \;
```

## Test plan

- [x] Image builds clean on linux/amd64
- [x] Verified on a downstream deploy: a previously-403'd `assets/*.js` chunk now serves correctly under the listenarr user without root override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)