### PR TITLE
Preserve qBittorrent content path for imports

### DIFF
--- a/listenarr.application/Downloads/DownloadItemService.cs
+++ b/listenarr.application/Downloads/DownloadItemService.cs
@@ -43,7 +43,8 @@ namespace Listenarr.Application.Downloads
                 Title = download.Title ?? "Unknown",
                 Status = "completed",
                 DownloadClientId = client.Id,
-                LocalPath = download.DownloadPath
+                LocalPath = download.DownloadPath,
+                ContentPath = GetClientContentPath(download)
             };
 
             if (!client.IsEnabled)
@@ -59,6 +60,11 @@ namespace Listenarr.Application.Downloads
                 download,
                 queueItem,
                 ct);
+        }
+
+        private static string? GetClientContentPath(Download download)
+        {
+            return download.GetMetadataString("ClientContentPath");
         }
     }
 }

--- a/tests/Features/Application/Downloads/DownloadItemServiceTests.cs
+++ b/tests/Features/Application/Downloads/DownloadItemServiceTests.cs
@@ -1,0 +1,53 @@
+using Listenarr.Application.Downloads;
+using Listenarr.Application.Interfaces;
+using Listenarr.Domain.Models;
+using Listenarr.Tests.Builders;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Listenarr.Tests.Features.Application.Downloads
+{
+    [Trait("Name", "DownloadItemServiceTests")]
+    [Trait("Category", "DownloadItemService")]
+    public class DownloadItemServiceTests
+    {
+        [Fact]
+        [Trait("Method", "GetImportItemAsync")]
+        [Trait("Scenario", "Passes saved client content path to download client gateway")]
+        public async Task GetImportItemAsync_PassesClientContentPath()
+        {
+            var client = new DownloadClientConfigurationBuilder().Build();
+            var contentPath = "/downloads/books/Example Book";
+            var download = new DownloadBuilder()
+                .WithDownloadClientConfiguration(client)
+                .WithTorrentHash("ABC123")
+                .WithTitle("Example Book")
+                .Build();
+            download.Metadata["ClientContentPath"] = contentPath;
+
+            QueueItem? capturedQueueItem = null;
+            var configurationService = new Mock<IConfigurationService>();
+            configurationService
+                .Setup(s => s.GetDownloadClientConfigurationAsync(client.Id))
+                .ReturnsAsync(client);
+
+            var gateway = new Mock<IDownloadClientGateway>();
+            gateway
+                .Setup(g => g.GetQueueItemAsync(client, download, It.IsAny<QueueItem>(), It.IsAny<CancellationToken>()))
+                .Callback<DownloadClientConfiguration, Download, QueueItem, CancellationToken>((configuredClient, matchedDownload, queueItem, cancellationToken) => capturedQueueItem = queueItem)
+                .ReturnsAsync((DownloadClientConfiguration configuredClient, Download matchedDownload, QueueItem queueItem, CancellationToken cancellationToken) => queueItem);
+
+            var service = new DownloadItemService(
+                configurationService.Object,
+                Mock.Of<ILogger<IDownloadItemService>>(),
+                gateway.Object);
+
+            var result = await service.GetImportItemAsync(download);
+
+            Assert.NotNull(capturedQueueItem);
+            Assert.Equal(contentPath, capturedQueueItem.ContentPath);
+            Assert.Equal(contentPath, result.ContentPath);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- carry saved qBittorrent/RDT content_path metadata into import queue item resolution
- let the existing ContentPath translation/scanning fallback run when qBittorrent /torrents/files returns an empty list
- add a regression test for passing ClientContentPath to the download client gateway

## Tests
- dotnet restore tests/Listenarr.Tests.csproj --source https://api.nuget.org/v3/index.json
- dotnet test tests/Listenarr.Tests.csproj --no-restore --filter FullyQualifiedName~DownloadItemServiceTests
- dotnet test tests/Listenarr.Tests.csproj --no-restore --filter FullyQualifiedName~DownloadClientGatewayTests