### PR TITLE
fix(sabnzbd): set DownloadPath from history storage on completion (#631)

### DIFF
--- a/listenarr.infrastructure/Adapters/SabnzbdAdapter.cs
+++ b/listenarr.infrastructure/Adapters/SabnzbdAdapter.cs
@@ -1245,6 +1245,14 @@ namespace Listenarr.Infrastructure.Adapters
                         {
                             AdapterUtils.MapDownloadProgress(dl, 100.0, 0, "success");
 
+                            // Populate DownloadPath from SABnzbd's storage field so the import
+                            // processor knows where the completed files are located.
+                            // Without this, DownloadProcessingJobProcessor throws "has no path set" (#631).
+                            if (!string.IsNullOrEmpty(matchingItem.Path))
+                            {
+                                dl.DownloadPath = matchingItem.Path;
+                            }
+
                             // Record match type metrics
                             try
                             {

--- a/tests/Features/Infrastructure/Adapters/SabnzbdAdapterTests.cs
+++ b/tests/Features/Infrastructure/Adapters/SabnzbdAdapterTests.cs
@@ -140,6 +140,47 @@ namespace Listenarr.Tests.Features.Infrastructure.Adapters
             Assert.Equal(DownloadStatus.Moved, download.Status);
         }
 
+        /// <summary>
+        /// Regression test for https://github.com/Listenarrs/Listenarr/issues/631
+        /// SABnzbd downloads were getting "Import Blocked" with "has no path set" because
+        /// FetchDownloadsAsync marked downloads as Completed but never set DownloadPath
+        /// from the SABnzbd history storage field.
+        /// </summary>
+        [Fact]
+        public async Task PollSABnzbd_SetsDownloadPath_FromHistoryStorage_WhenPathWasEmpty()
+        {
+            var source = FileService.GetTempDirectory("sabnzbd-path-test");
+            var destination = FileService.GetTempDirectory("sabnzbd-path-destination");
+            await FileService.GetFileAsync(source, "hello.m4b");
+
+            sabnzbdApiMock.contentPath = source;
+
+            var audiobook = await _audiobookRepository.AddAsync(new AudiobookBuilder()
+                .WithBasePath(destination)
+                .Build());
+
+            // Simulate a download created with no DownloadPath (empty), as would happen
+            // if SABnzbd hadn't yet reported the storage location when the download was added.
+            var download = await _downloadRepository.AddAsync(new DownloadBuilder()
+                .WithPath(string.Empty)
+                .WithAudiobook(audiobook)
+                .WithDownloadClientConfiguration(_client)
+                .WithDownloading(0)
+                .WithTitle("hello")
+                .WithClientDownloadId(SabnzbdApiMock.COMPLETED_FILE_SABNZBD)
+                .Build());
+
+            var monitor = _provider.GetRequiredService<DownloadMonitorService>();
+            await monitor.MonitorDownloadsAsync(CancellationToken.None);
+
+            var updated = await _downloadRepository.GetByIdAsync(download.Id);
+            Assert.NotNull(updated);
+            Assert.Equal(DownloadStatus.Completed, updated.Status);
+            Assert.False(string.IsNullOrEmpty(updated.DownloadPath),
+                "DownloadPath must be populated from SABnzbd history storage so the import processor can find the files");
+            Assert.Equal(source, updated.DownloadPath);
+        }
+
         [Fact]
         public async Task PollSABnzbd_SchedulesRetry_AndFinalizes_WhenFileArrives()
         {


### PR DESCRIPTION
## Summary

SABnzbd downloads were landing in **Import Blocked** with the error \Inconsistency: Download has no path set\. When SABnzbd finishes a download, it moves the job from its active queue into history. \FetchDownloadsAsync\ was correctly matching these history entries and marking the download as \Completed\, but it never copied the SABnzbd \storage\ path back to \Download.DownloadPath\. The import processor later threw because \DownloadPath\ was empty.

Closes #631

## Changes

### Fixed
- \SabnzbdAdapter.FetchDownloadsAsync\: populate \dl.DownloadPath\ from the matched SABnzbd history slot's \storage\ field when a completed history entry is found

### Added
- Regression test \PollSABnzbd_SetsDownloadPath_FromHistoryStorage_WhenPathWasEmpty\ in \SabnzbdAdapterTests\ to prevent future regressions

## Testing

- New unit test \PollSABnzbd_SetsDownloadPath_FromHistoryStorage_WhenPathWasEmpty\ asserts that after \MonitorDownloadsAsync\, the download's \DownloadPath\ is populated from the SABnzbd history \storage\ value
- Full test suite: 673/673 passed, no regressions

## Notes

\DownloadClientGateway.FetchDownloadsAsync\ already runs the resulting \DownloadPath\ through \RemotePathMappingService.TranslatePathAsync\ after the adapter returns, so path mapping (remote → local) continues to work correctly for Docker and other remote setups.