### PR TITLE
Fix Audible regional search and links

### DIFF
--- a/.github/.cursorrules
+++ b/.github/.cursorrules
@@ -178,10 +178,22 @@ onMounted(() => {
 - Use index files for clean imports
 
 #### Testing
-- Write unit tests for business logic
-- Mock external dependencies
-- Use descriptive test names
-- Test both success and error scenarios
+- Write unit tests for all business logic; test both success and error scenarios.
+- Mock external dependencies (API clients, file system, download clients).
+- Test classes are named `{TestedClassName}Tests` and mirror the source project path under `tests/`.
+- Every test class inherits `BaseTests`.
+- Annotate with `[Trait("Name", "...Tests")]` and `[Trait("Category", "...")]`.
+- Call `Init()` (optionally with DI overrides) before adding test data:
+  ```csharp
+  Init(services => services.WithSingleton(myMock.Object));
+  Init(services => services.Without<IServiceToRemove>());
+  ```
+- Use builder classes under `tests/Builders/` to create populated test entities. Prefer fluent `.With...()` methods followed by `.Build()` over multi-property inline object initializers.
+- If a coherent domain/model fixture needs repeated setup and no builder exists, add a focused builder.
+- Only add repository data *after* calling `Init()`.
+- Structure tests as Given / When / Then.
+- API mock helpers inherit `BaseMock`; use `GetCallCount()`, `GetLastRequest()`, `GetLastContent()`.
+- See `tests/README.md` for full conventions.
 
 #### Documentation
 - Add XML comments to public methods and classes
@@ -266,13 +278,33 @@ onMounted(() => {
 - Frontend: Restart `npm run dev` if Vite HMR fails
 - File locks may prevent hot reload; full restart resolves this
 
-### Development Workflow
+#### Architecture / Layering
+- `listenarr.api` **must not** reference `listenarr.infrastructure` (except `listenarr.api/Program.cs`).
+- `listenarr.application` **must not** reference `listenarr.infrastructure`.
+- Data flows inward only: `infrastructure` → `application` → `api`. Violations are caught by the pre-commit hook.
 
-1. **Branching**: Use feature branches for new work
-2. **Commits**: Make small, focused commits with clear messages
-3. **Testing**: Run tests before committing
-4. **Code Review**: Submit PRs for review
-5. **Deployment**: Use automated deployment scripts
+#### Async Code
+- **Never use `async void`** in production code. Always use `async Task`. `async void` causes unobservable exceptions and is rejected by the pre-commit hook.
+
+#### Dependency Injection
+- Use `AddListenarrInfrastructure` to register DbContext/IDbContextFactory (replaces `AddListenarrPersistence` / separate `AddDbContext` calls).
+- Inject `IDbContextFactory<ListenArrDbContext>` in hosted/background services; create and dispose contexts per operation.
+
+### Pre-Commit and Pre-Push Enforcement
+
+**Pre-commit** (`node scripts/lint-staged.mjs` + layering check + `async void` check):
+- C# staged files: `dotnet-format` (no alignment padding allowed).
+- Vue/TS staged files: Prettier check (`cd fe && npm run format:prettier:check`).
+- Layering rules (see above) checked across all source projects.
+- `async void` grep rejects any occurrences in production projects.
+
+Quick fix: `dotnet format && cd fe && npm run format:prettier && cd ..`
+
+**Pre-push** (runs on `git push`):
+1. Version sync — `node scripts/sync-fe-version-from-csproj.mjs`
+2. Full solution format — `dotnet format listenarr.slnx --no-restore --verify-no-changes`
+3. Vue TypeScript check — `cd fe && vue-tsc --build tsconfig.app.json`
+4. Frontend unit tests — `cd fe && vitest run`
 
 ### Common Patterns
 

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -63,4 +63,56 @@ Adhere strictly to best practices from OWASP, with particular consideration for 
 - Use watchers for side effects
 - Use provide/inject for deep component communication
 - Use async components for code-splitting
+
+
+## Code Formatting Rules (enforced by pre-commit hook)
+
+The pre-commit hook runs `node scripts/lint-staged.mjs`. **All staged files must pass before a commit is accepted.**
+
+### C# (`dotnet-format`)
+- **No alignment/column-padding spaces.** Do not add extra spaces to align dictionary values, tuple elements, or assignment operators into columns. The formatter treats this as a WHITESPACE error.
+  ```csharp
+  // ❌ WRONG
+  ["ca"] = ("www.audible.ca",     "www.amazon.ca"),
+
+  // ✅ CORRECT
+  ["ca"] = ("www.audible.ca", "www.amazon.ca"),
+  ```
+- Run `dotnet format` from the repo root to auto-fix.
+
+### Vue / TypeScript (`prettier`)
+- All `.vue`, `.ts`, and `.tsx` files must satisfy Prettier's style.
+- Run `cd fe && npm run format:prettier` to auto-fix (the script is `format:prettier`, not `format`).
+
+### Quick fix
+```bash
+dotnet format
+cd fe && npm run format:prettier && cd ..
+```
+
+### Layering Rules (enforced by pre-commit hook)
+
+- `listenarr.api` **must not** reference `listenarr.infrastructure` (except `listenarr.api/Program.cs`)
+- `listenarr.application` **must not** reference `listenarr.infrastructure`
+- Data flows inward only: `infrastructure` → `application` → `api`
+
+Violations cause commit rejection with a "Layering violation" error.
+
+### No `async void` (enforced by pre-commit hook)
+
+Never use `async void` in production code. Always use `async Task` — `async void` causes unobservable exceptions and the pre-commit hook will reject it.
+
+### Backend Test Fixtures
+
+- Use builders from `tests/Builders` for backend test data, with fluent `.With...()` methods followed by `.Build()`.
+- If a test needs a coherent domain/model fixture and no builder exists, add a focused builder instead of using multi-property inline object initializers.
+- Keep inline object initializers only for trivial throwaway values; repeated or behavior-significant fixtures should use builders.
+
+### Pre-Push Checks
+
+The pre-push hook runs additional checks on `git push`:
+1. **Version sync** — `node scripts/sync-fe-version-from-csproj.mjs`
+2. **Full solution format** — `dotnet format listenarr.slnx --no-restore --verify-no-changes`
+3. **Frontend TypeScript check** — `cd fe && vue-tsc --build tsconfig.app.json`
+4. **Frontend unit tests** — `cd fe && vitest run`
 ````

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -102,11 +102,20 @@ Violations cause commit rejection with a "Layering violation" error.
 
 Never use `async void` in production code. Always use `async Task` — `async void` causes unobservable exceptions and the pre-commit hook will reject it.
 
-### Backend Test Fixtures
+### Backend Test Conventions
 
-- Use builders from `tests/Builders` for backend test data, with fluent `.With...()` methods followed by `.Build()`.
-- If a test needs a coherent domain/model fixture and no builder exists, add a focused builder instead of using multi-property inline object initializers.
-- Keep inline object initializers only for trivial throwaway values; repeated or behavior-significant fixtures should use builders.
+- Test classes are named `{TestedClassName}Tests` and mirror the source project path under `tests/`.
+- Every test class inherits `BaseTests`.
+- Annotate with `[Trait("Name", "...Tests")]` and `[Trait("Category", "...")]`.
+- Call `Init()` (optionally with DI overrides) before adding test data:
+  ```csharp
+  Init(services => services.WithSingleton(myMock.Object));
+  Init(services => services.Without<IServiceToRemove>());
+  ```
+- Only add repository data *after* calling `Init()`.
+- Use builder classes under `tests/Builders/` with fluent `.With...().Build()` chains for coherent test entities. Add a focused builder rather than repeating multi-property inline object initializers.
+- Structure tests as Given / When / Then.
+- API mocks inherit `BaseMock`; use `GetCallCount()`, `GetLastRequest()`, `GetLastContent()`.
 
 ### Pre-Push Checks
 

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -70,26 +70,51 @@ As a security-aware developer, generate secure .NET code using ASP.NET Core that
 
 ---
 
-## Changelog maintenance
+## Code Formatting Rules (enforced by pre-commit hook)
 
-After completing any meaningful change (bug fix, new feature, improvement, or notable refactor), update `CHANGELOG.md` at the repo root.
+The pre-commit hook runs `node scripts/lint-staged.mjs`. **All staged files must pass before a commit is accepted.**
 
-**Determine where to add the entry:**
+### C# (`dotnet-format`)
+- **No alignment/column-padding spaces.** Do not add extra spaces to align dictionary values, tuple elements, or assignment operators into columns. The formatter treats this as a WHITESPACE error.
+  ```csharp
+  // ❌ WRONG
+  ["ca"] = ("www.audible.ca",     "www.amazon.ca"),
 
-- **Unpublished branch** (not yet merged/released — e.g. a feature or bugfix branch): add to a next-version section at the very top of the changelog, directly below the header block. Determine the next version by incrementing the patch number of the topmost released version (e.g. if the latest is `[0.2.61]`, use `[0.2.62]`). Create that section if it does not already exist. Do not include a date — the release pipeline adds it on publish.
-- **Published branch** (changes are already in a released version tag or on the main/canary branch): add to the latest version block (the topmost `## [x.y.z]` entry).
+  // ✅ CORRECT
+  ["ca"] = ("www.audible.ca", "www.amazon.ca"),
+  ```
+- Run `dotnet format` from the repo root to auto-fix.
 
-To check: run `git log --oneline origin/canary..HEAD` — if it returns commits, the branch is unpublished. If empty, the changes are already on canary/main (published).
+### Vue / TypeScript (`prettier`)
+- All `.vue`, `.ts`, and `.tsx` files must satisfy Prettier's style.
+- Run `cd fe && npm run format:prettier` to auto-fix (the script is `format:prettier`, not `format`).
 
-**Entry format** — match the existing style exactly:
+### Layering Rules (enforced by pre-commit hook)
+- `listenarr.api` **must not** reference `listenarr.infrastructure` (except `listenarr.api/Program.cs`)
+- `listenarr.application` **must not** reference `listenarr.infrastructure`
+- Data flows inward only: `infrastructure` → `application` → `api`. Violations cause commit rejection.
 
+### No `async void` (enforced by pre-commit hook)
+Never use `async void` in production code. Always use `async Task` — `async void` causes unobservable exceptions and is rejected by the pre-commit hook.
+
+### Backend Test Conventions
+- Test classes are named `{TestedClassName}Tests` and inherit `BaseTests`.
+- Annotate with `[Trait("Name", "...Tests")]` and `[Trait("Category", "...")]`.
+- Call `Init()` (optionally with DI overrides) before adding test data. Only add repository data *after* `Init()`.
+- Use builder classes under `tests/Builders/` with fluent `.With...().Build()` chains for coherent test entities.
+- Structure tests as Given / When / Then. API mocks inherit `BaseMock`.
+
+### Pre-Push Checks
+The pre-push hook runs on `git push`:
+1. **Version sync** — `node scripts/sync-fe-version-from-csproj.mjs`
+2. **Full solution format** — `dotnet format listenarr.slnx --no-restore --verify-no-changes`
+3. **Frontend TypeScript check** — `cd fe && vue-tsc --build tsconfig.app.json`
+4. **Frontend unit tests** — `cd fe && vitest run`
+
+### Quick fix
+```bash
+dotnet format
+cd fe && npm run format:prettier && cd ..
 ```
-### Fixed          ← or Added / Changed / Removed / Security / Deprecated
-- **Short descriptive title:** One-sentence explanation of what changed and why it matters to users or developers.
-```
 
-**Rules:**
-- One bullet per logical change; group related sub-changes under a single bullet rather than listing each file touched.
-- Use plain language — write for someone reading the changelog without code context.
-- Do not add a changelog entry for purely mechanical changes (e.g. bumping a lock file, fixing a typo in a comment, updating test fixtures with no behavior change).
 ````

--- a/fe/src/__tests__/AddLibraryModal.editableMetadata.spec.ts
+++ b/fe/src/__tests__/AddLibraryModal.editableMetadata.spec.ts
@@ -57,6 +57,7 @@ const fakeBook = {
   explicit: false,
   abridged: false,
   source: 'Audible',
+  region: 'de',
 }
 
 describe('AddLibraryModal editable metadata', () => {
@@ -94,6 +95,7 @@ describe('AddLibraryModal editable metadata', () => {
     })
 
     await flushPromises()
+    expect(apiMocks.getAudibleMetadata).toHaveBeenCalledWith('B001234567', 'de')
     apiMocks.previewLibraryPath.mockClear()
 
     expect(wrapper.find('.metadata-edit-grid').exists()).toBe(false)
@@ -127,6 +129,7 @@ describe('AddLibraryModal editable metadata', () => {
       edition: 'Library Edition',
       publisher: 'Edited Publisher',
       authors: ['Edited Author'],
+      region: 'de',
     })
 
     const relativeInput = wrapper.get('input.relative-input')
@@ -141,6 +144,7 @@ describe('AddLibraryModal editable metadata', () => {
         edition: 'Library Edition',
         publisher: 'Edited Publisher',
         authors: ['Edited Author'],
+        region: 'de',
       }),
       expect.any(Object),
     )

--- a/fe/src/__tests__/AddNewView.spec.ts
+++ b/fe/src/__tests__/AddNewView.spec.ts
@@ -24,6 +24,7 @@ import { createRouter, createMemoryHistory } from 'vue-router'
 import AddNewView from '@/views/content/AddNewView.vue'
 import { useLibraryStore } from '@/stores/library'
 import { useConfigurationStore } from '@/stores/configuration'
+import type { SearchResult } from '@/types'
 
 // apiService and signalR are mocked centrally in test-setup.ts
 
@@ -754,6 +755,9 @@ describe('AddNewView pagination', () => {
     expect(sourceLink.exists()).toBe(true)
     expect(sourceLink.attributes('href')).toBe('https://www.audible.de/pd/BAUD1')
     expect(sourceLink.text()).toContain('Audible')
+    expect(wrapper.findAll('.result-meta a')).toHaveLength(1)
+    expect(sourceLink.classes()).toContain('metadata-source-link')
+    expect(sourceLink.findAll('svg')).toHaveLength(2)
   })
 
   it('shows Amazon metadata badge links for the selected result region', async () => {
@@ -783,6 +787,106 @@ describe('AddNewView pagination', () => {
     expect(metaLink.exists()).toBe(true)
     expect(metaLink.attributes('href')).toBe('https://www.amazon.de/dp/BAMZ1')
     expect(metaLink.text()).toContain('Metadata: Amazon')
+  })
+
+  it('shows metadata and source links for simple Audible-backed card results', async () => {
+    const router = createTestRouter()
+    const wrapper = mount(AddNewView, { global: { plugins: [createPinia(), router] } })
+    const vm = wrapper.vm as unknown as {
+      handleSimpleSearchResults?: (results: SearchResult[]) => Promise<void>
+    }
+
+    await vm.handleSimpleSearchResults?.([
+      {
+        id: 'simple-audible-url',
+        title: 'Simple Audible Result',
+        artist: 'Author Name',
+        album: '',
+        category: '',
+        source: '',
+        sourceLink: '',
+        publishedDate: '',
+        format: '',
+        size: 0,
+        magnetLink: '',
+        torrentUrl: '',
+        nzbUrl: '',
+        downloadType: 'Torrent',
+        language: 'english',
+        publisher: 'Pottermore Publishing',
+        releaseDate: '2016-11-20',
+        link: 'https://www.audible.de/pd/B01M02FJ7A',
+      },
+    ])
+    await flushPromises()
+    await wrapper.vm.$nextTick()
+
+    const metaLink = wrapper.find('.title-results .metadata-source-link')
+    expect(metaLink.exists()).toBe(true)
+    expect(metaLink.attributes('data-source')).toBe('audible')
+    expect(metaLink.attributes('href')).toBe('https://www.audible.de/pd/B01M02FJ7A')
+    expect(metaLink.text()).toContain('Audible')
+
+    const sourceLink = wrapper.find('.title-results .source-link')
+    expect(sourceLink.exists()).toBe(true)
+    expect(sourceLink.attributes('href')).toBe('https://www.audible.de/pd/B01M02FJ7A')
+    expect(sourceLink.text()).toContain('Audible')
+    expect(wrapper.findAll('.title-results .result-meta a')).toHaveLength(1)
+    expect(sourceLink.classes()).toContain('metadata-source-link')
+    expect(sourceLink.findAll('svg')).toHaveLength(2)
+
+    const badgeText = wrapper
+      .findAll('.title-results .metadata-badges .metadata-badge')
+      .map((badge) => badge.text())
+    expect(badgeText).toContain('Pottermore Publishing')
+    expect(badgeText).toContain('2016')
+  })
+
+  it('shows metadata and source links for advanced Audible-backed results', async () => {
+    const apiModule = await import('@/services/api')
+    const advancedSearchSpy = vi.spyOn(apiModule.apiService, 'advancedSearch').mockResolvedValue([
+      {
+        asin: 'B01M02FJ7A',
+        region: 'de',
+        title: 'Advanced Audible Result',
+        author: 'Author Name',
+        language: 'english',
+        link: 'https://www.audible.de/pd/B01M02FJ7A',
+      },
+    ])
+
+    try {
+      const router = createTestRouter()
+      const wrapper = mount(AddNewView, { global: { plugins: [createPinia(), router] } })
+      const vm = wrapper.vm as unknown as {
+        showAdvancedSearch?: boolean
+        advancedSearchParams?: Record<string, unknown>
+        performAdvancedSearch?: () => Promise<void>
+      }
+
+      vm.showAdvancedSearch = true
+      vm.advancedSearchParams = { title: 'Advanced Audible Result' }
+
+      await vm.performAdvancedSearch?.()
+      await flushPromises()
+      await wrapper.vm.$nextTick()
+
+      const metaLink = wrapper.find('.title-results .metadata-source-link')
+      expect(metaLink.exists()).toBe(true)
+      expect(metaLink.attributes('data-source')).toBe('audible')
+      expect(metaLink.attributes('href')).toBe('https://www.audible.de/pd/B01M02FJ7A')
+      expect(metaLink.text()).toContain('Audible')
+
+      const sourceLink = wrapper.find('.title-results .source-link')
+      expect(sourceLink.exists()).toBe(true)
+      expect(sourceLink.attributes('href')).toBe('https://www.audible.de/pd/B01M02FJ7A')
+      expect(sourceLink.text()).toContain('Audible')
+      expect(wrapper.findAll('.title-results .result-meta a')).toHaveLength(1)
+      expect(sourceLink.classes()).toContain('metadata-source-link')
+      expect(sourceLink.findAll('svg')).toHaveLength(2)
+    } finally {
+      advancedSearchSpy.mockRestore()
+    }
   })
 
   it('does not label non-Audible URLs containing audible.com as Audible', async () => {

--- a/fe/src/__tests__/AddNewView.spec.ts
+++ b/fe/src/__tests__/AddNewView.spec.ts
@@ -239,7 +239,7 @@ describe('AddNewView pagination', () => {
     expect((advRegion.element as HTMLSelectElement).value).toBe('us')
   })
 
-  it('shows the configured region and defaults language to the region primary language', async () => {
+  it('shows the configured region and preserves the configured default language', async () => {
     const apiModule = await import('@/services/api')
     const apiService = apiModule.apiService as unknown as { getApplicationSettings?: Mock }
     apiService.getApplicationSettings?.mockResolvedValue({
@@ -258,8 +258,28 @@ describe('AddNewView pagination', () => {
     }
 
     expect(vm.searchLanguage).toBe('de')
-    expect(vm.preferredSearchLanguage).toBe('german')
+    expect(vm.preferredSearchLanguage).toBe('polish')
     expect((wrapper.find('select#region-select').element as HTMLSelectElement).value).toBe('de')
+  })
+
+  it('defaults language to the region primary language when no language is configured', async () => {
+    const apiModule = await import('@/services/api')
+    const apiService = apiModule.apiService as unknown as { getApplicationSettings?: Mock }
+    apiService.getApplicationSettings?.mockResolvedValue({
+      defaultSearchRegion: 'de',
+    })
+
+    const router = createTestRouter()
+    const wrapper = mount(AddNewView, { global: { plugins: [createPinia(), router] } })
+    await flushPromises()
+
+    const vm = wrapper.vm as unknown as {
+      searchLanguage?: string
+      preferredSearchLanguage?: string
+    }
+
+    expect(vm.searchLanguage).toBe('de')
+    expect(vm.preferredSearchLanguage).toBe('german')
   })
 
   it('allows ad-hoc region changes without overwriting saved settings and updates language', async () => {
@@ -300,7 +320,7 @@ describe('AddNewView pagination', () => {
     advancedSearchSpy.mockRestore()
   })
 
-  it('uses the selected region primary language even when the saved language is all', async () => {
+  it('preserves a saved all-language preference for the configured region', async () => {
     const apiModule = await import('@/services/api')
     const apiService = apiModule.apiService as unknown as { getApplicationSettings?: Mock }
     apiService.getApplicationSettings?.mockResolvedValue({
@@ -319,7 +339,7 @@ describe('AddNewView pagination', () => {
       performSearch?: () => Promise<void>
     }
 
-    expect(vm.preferredSearchLanguage).toBe('german')
+    expect(vm.preferredSearchLanguage).toBe('all')
 
     vm.searchQuery = 'Dune'
     await vm.performSearch?.()
@@ -328,11 +348,11 @@ describe('AddNewView pagination', () => {
     expect(advancedSearchSpy).toHaveBeenCalled()
     const lastCall = advancedSearchSpy.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined
     expect(lastCall?.region).toBe('de')
-    expect(lastCall?.language).toBe('german')
+    expect(lastCall?.language).toBeUndefined()
     advancedSearchSpy.mockRestore()
   })
 
-  it('filters mixed-language audible results using the selected language while keeping the default region', async () => {
+  it('filters mixed-language audible results using the saved language while keeping the default region', async () => {
     const apiModule = await import('@/services/api')
     const apiService = apiModule.apiService as unknown as { getApplicationSettings?: Mock }
     apiService.getApplicationSettings?.mockResolvedValue({
@@ -374,9 +394,9 @@ describe('AddNewView pagination', () => {
     expect(advancedSearchSpy).toHaveBeenCalled()
     const lastCall = advancedSearchSpy.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined
     expect(lastCall?.region).toBe('de')
-    expect(lastCall?.language).toBe('german')
+    expect(lastCall?.language).toBe('english')
     expect(vm.titleResults?.length).toBe(1)
-    expect(vm.titleResults?.[0]?.title).toBe('German Result')
+    expect(vm.titleResults?.[0]?.title).toBe('English Result')
     advancedSearchSpy.mockRestore()
   })
 

--- a/fe/src/__tests__/AddNewView.spec.ts
+++ b/fe/src/__tests__/AddNewView.spec.ts
@@ -23,6 +23,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import AddNewView from '@/views/content/AddNewView.vue'
 import { useLibraryStore } from '@/stores/library'
+import { useConfigurationStore } from '@/stores/configuration'
 
 // apiService and signalR are mocked centrally in test-setup.ts
 
@@ -33,9 +34,16 @@ describe('AddNewView pagination', () => {
       routes: [{ path: '/', component: { template: '<div />' } }],
     })
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
     window.localStorage.clear()
+    const apiModule = await import('@/services/api')
+    const apiService = apiModule.apiService as unknown as {
+      getApplicationSettings?: Mock
+      searchAudibleByTitleAndAuthor?: Mock
+    }
+    apiService.getApplicationSettings?.mockResolvedValue({})
+    apiService.searchAudibleByTitleAndAuthor?.mockResolvedValue({ totalResults: 0, results: [] })
     const pinia = createPinia()
     setActivePinia(pinia)
   })
@@ -113,6 +121,7 @@ describe('AddNewView pagination', () => {
       results: [
         {
           asin: 'B000123',
+          region: 'de',
           title: 'Dune',
           subtitle: 'A Heroic Saga',
           authors: [{ name: 'Frank Herbert' }],
@@ -152,7 +161,7 @@ describe('AddNewView pagination', () => {
     expect(tr.searchResult.series).toBe('Dune Series')
     expect(tr.publisher && tr.publisher[0]).toBe('Chilton')
     expect(tr.first_publish_year).toBe(1965)
-    expect(tr.searchResult.productUrl).toBe('https://www.audible.com/pd/B000123')
+    expect(tr.searchResult.productUrl).toBe('https://www.audible.de/pd/B000123')
 
     // Rendered subtitle should appear in the title-result card
     await wrapper.vm.$nextTick()
@@ -210,6 +219,9 @@ describe('AddNewView pagination', () => {
     const simpleOptions = simpleSelect.findAll('option').map((o) => o.text())
     expect(simpleOptions).toContain('All')
     expect(simpleOptions).toContain('English')
+    const simpleRegion = wrapper.find('select#region-select')
+    expect(simpleRegion.exists()).toBe(true)
+    expect((simpleRegion.element as HTMLSelectElement).value).toBe('us')
 
     // Advanced search select should be labeled Language and contain German
     await wrapper.vm.$nextTick()
@@ -222,9 +234,12 @@ describe('AddNewView pagination', () => {
     const advOptions = advSelect.findAll('option').map((o) => o.text())
     expect(advOptions).toContain('German')
     expect(wrapper.find('label[for="adv-language"]').text()).toBe('Language')
+    const advRegion = wrapper.find('select#adv-region')
+    expect(advRegion.exists()).toBe(true)
+    expect((advRegion.element as HTMLSelectElement).value).toBe('us')
   })
 
-  it('applies configured default region and language from application settings', async () => {
+  it('shows the configured region and defaults language to the region primary language', async () => {
     const apiModule = await import('@/services/api')
     const apiService = apiModule.apiService as unknown as { getApplicationSettings?: Mock }
     apiService.getApplicationSettings?.mockResolvedValue({
@@ -243,10 +258,49 @@ describe('AddNewView pagination', () => {
     }
 
     expect(vm.searchLanguage).toBe('de')
-    expect(vm.preferredSearchLanguage).toBe('polish')
+    expect(vm.preferredSearchLanguage).toBe('german')
+    expect((wrapper.find('select#region-select').element as HTMLSelectElement).value).toBe('de')
   })
 
-  it('omits language filtering when default language is set to all', async () => {
+  it('allows ad-hoc region changes without overwriting saved settings and updates language', async () => {
+    const apiModule = await import('@/services/api')
+    const apiService = apiModule.apiService as unknown as { getApplicationSettings?: Mock }
+    apiService.getApplicationSettings?.mockResolvedValue({
+      defaultSearchRegion: 'de',
+      defaultSearchLanguage: 'german',
+    })
+    const advancedSearchSpy = vi.spyOn(apiModule.apiService, 'advancedSearch').mockResolvedValue([])
+
+    const router = createTestRouter()
+    const wrapper = mount(AddNewView, { global: { plugins: [createPinia(), router] } })
+    await flushPromises()
+
+    const configStore = useConfigurationStore()
+    const vm = wrapper.vm as unknown as {
+      searchLanguage?: string
+      preferredSearchLanguage?: string
+      searchQuery?: string
+      performSearch?: () => Promise<void>
+    }
+
+    await wrapper.find('select#region-select').setValue('fr')
+    await wrapper.vm.$nextTick()
+
+    expect(vm.searchLanguage).toBe('fr')
+    expect(vm.preferredSearchLanguage).toBe('french')
+    expect(configStore.applicationSettings?.defaultSearchRegion).toBe('de')
+
+    vm.searchQuery = 'Dune'
+    await vm.performSearch?.()
+    await flushPromises()
+
+    const lastCall = advancedSearchSpy.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined
+    expect(lastCall?.region).toBe('fr')
+    expect(lastCall?.language).toBe('french')
+    advancedSearchSpy.mockRestore()
+  })
+
+  it('uses the selected region primary language even when the saved language is all', async () => {
     const apiModule = await import('@/services/api')
     const apiService = apiModule.apiService as unknown as { getApplicationSettings?: Mock }
     apiService.getApplicationSettings?.mockResolvedValue({
@@ -265,7 +319,7 @@ describe('AddNewView pagination', () => {
       performSearch?: () => Promise<void>
     }
 
-    expect(vm.preferredSearchLanguage).toBe('all')
+    expect(vm.preferredSearchLanguage).toBe('german')
 
     vm.searchQuery = 'Dune'
     await vm.performSearch?.()
@@ -274,7 +328,7 @@ describe('AddNewView pagination', () => {
     expect(advancedSearchSpy).toHaveBeenCalled()
     const lastCall = advancedSearchSpy.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined
     expect(lastCall?.region).toBe('de')
-    expect(lastCall).not.toHaveProperty('language')
+    expect(lastCall?.language).toBe('german')
     advancedSearchSpy.mockRestore()
   })
 
@@ -320,9 +374,9 @@ describe('AddNewView pagination', () => {
     expect(advancedSearchSpy).toHaveBeenCalled()
     const lastCall = advancedSearchSpy.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined
     expect(lastCall?.region).toBe('de')
-    expect(lastCall?.language).toBe('english')
+    expect(lastCall?.language).toBe('german')
     expect(vm.titleResults?.length).toBe(1)
-    expect(vm.titleResults?.[0]?.title).toBe('English Result')
+    expect(vm.titleResults?.[0]?.title).toBe('German Result')
     advancedSearchSpy.mockRestore()
   })
 
@@ -651,6 +705,7 @@ describe('AddNewView pagination', () => {
     vm.searchType = 'asin'
     ;(vm as unknown).audibleResult = {
       asin: 'BAUD1',
+      region: 'de',
       title: 'Title',
       authors: [{ name: 'Author Name' }],
       narrators: [{ name: 'Narrator Name' }],
@@ -667,13 +722,13 @@ describe('AddNewView pagination', () => {
     // Metadata badge should link to the Audible product page
     const metaLink = wrapper.find('.result-meta .metadata-source-link')
     expect(metaLink.exists()).toBe(true)
-    expect(metaLink.attributes('href')).toBe('https://www.audible.com/pd/BAUD1')
+    expect(metaLink.attributes('href')).toBe('https://www.audible.de/pd/BAUD1')
     expect(metaLink.text()).toContain('Audible')
 
     // Source link should prefer Audible product URL and show 'Audible'
     const sourceLink = wrapper.find('.result-meta .source-link')
     expect(sourceLink.exists()).toBe(true)
-    expect(sourceLink.attributes('href')).toBe('https://www.audible.com/pd/BAUD1')
+    expect(sourceLink.attributes('href')).toBe('https://www.audible.de/pd/BAUD1')
     expect(sourceLink.text()).toContain('Audible')
   })
 

--- a/fe/src/__tests__/AddNewView.spec.ts
+++ b/fe/src/__tests__/AddNewView.spec.ts
@@ -303,6 +303,10 @@ describe('AddNewView pagination', () => {
       performSearch?: () => Promise<void>
     }
 
+    await wrapper.find('select.language-select').setValue('english')
+    await wrapper.vm.$nextTick()
+    expect(vm.preferredSearchLanguage).toBe('english')
+
     await wrapper.find('select#region-select').setValue('fr')
     await wrapper.vm.$nextTick()
 

--- a/fe/src/__tests__/AddNewView.spec.ts
+++ b/fe/src/__tests__/AddNewView.spec.ts
@@ -756,6 +756,35 @@ describe('AddNewView pagination', () => {
     expect(sourceLink.text()).toContain('Audible')
   })
 
+  it('shows Amazon metadata badge links for the selected result region', async () => {
+    const router = createTestRouter()
+    const wrapper = mount(AddNewView, { global: { plugins: [createPinia(), router] } })
+    const vm = wrapper.vm as unknown as { searchType?: string; titleResults?: unknown[] }
+
+    vm.searchType = 'title'
+    vm.titleResults = [
+      {
+        key: 'BAMZ1',
+        title: 'Amazon Result',
+        author_name: ['Author Name'],
+        metadataSource: 'Amazon',
+        searchResult: {
+          asin: 'BAMZ1',
+          region: 'de',
+          artist: 'Author Name',
+          metadataSource: 'Amazon',
+        },
+      },
+    ]
+
+    await wrapper.vm.$nextTick()
+
+    const metaLink = wrapper.find('.title-results .metadata-source-link')
+    expect(metaLink.exists()).toBe(true)
+    expect(metaLink.attributes('href')).toBe('https://www.amazon.de/dp/BAMZ1')
+    expect(metaLink.text()).toContain('Metadata: Amazon')
+  })
+
   it('does not label non-Audible URLs containing audible.com as Audible', async () => {
     const router = createTestRouter()
     const wrapper = mount(AddNewView, { global: { plugins: [createPinia(), router] } })

--- a/fe/src/__tests__/SearchResultCard.spec.ts
+++ b/fe/src/__tests__/SearchResultCard.spec.ts
@@ -508,5 +508,75 @@ describe('SearchResultCard', () => {
       const text = wrapper.text()
       expect(text).toContain('Metadata: openlibrary')
     })
+
+    it('shows nested metadata source badges', () => {
+      const wrapper = mount(SearchResultCard, {
+        props: {
+          book: {
+            ...mockBook,
+            metadataSource: undefined,
+            searchResult: {
+              ...mockBook.searchResult,
+              metadataSource: undefined,
+              searchResult: {
+                metadataSource: 'Amazon',
+              },
+            } as unknown as SearchResult,
+          },
+        },
+      })
+
+      const badge = wrapper.find('.metadata-source-badge')
+      expect(badge.exists()).toBe(true)
+      expect(badge.attributes('data-source')).toBe('Amazon')
+      expect(badge.text()).toContain('Metadata: Amazon')
+    })
+
+    it('labels metadata links from nested metadata source', () => {
+      const wrapper = mount(SearchResultCard, {
+        props: {
+          book: {
+            ...mockBook,
+            metadataSource: undefined,
+            searchResult: {
+              ...mockBook.searchResult,
+              metadataSource: undefined,
+              searchResult: {
+                metadataSource: 'Amazon',
+              },
+            } as unknown as SearchResult,
+          },
+          metadataSourceUrl: 'https://www.amazon.de/dp/BAMZ2',
+        },
+      })
+
+      const link = wrapper.find('.metadata-source-link')
+      expect(link.exists()).toBe(true)
+      expect(link.attributes('href')).toBe('https://www.amazon.de/dp/BAMZ2')
+      expect(link.attributes('data-source')).toBe('Amazon')
+      expect(link.text()).toContain('Metadata: Amazon')
+    })
+
+    it('combines metadata and source links when urls match', () => {
+      const wrapper = mount(SearchResultCard, {
+        props: {
+          book: {
+            ...mockBook,
+            metadataSource: 'audible',
+          },
+          metadataSourceUrl: 'https://www.audible.de/pd/B01M02FJ7A',
+          sourceUrl: 'https://www.audible.de/pd/B01M02FJ7A',
+        },
+      })
+
+      const links = wrapper.findAll('.result-meta a')
+      expect(links).toHaveLength(1)
+      const link = links[0]!
+      expect(link.classes()).toContain('metadata-source-link')
+      expect(link.classes()).toContain('source-link')
+      expect(link.attributes('href')).toBe('https://www.audible.de/pd/B01M02FJ7A')
+      expect(link.text()).toContain('Audible')
+      expect(link.findAll('svg')).toHaveLength(2)
+    })
   })
 })

--- a/fe/src/__tests__/languageMapping.spec.ts
+++ b/fe/src/__tests__/languageMapping.spec.ts
@@ -17,6 +17,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import {
+  getPrimaryPreferredSearchLanguageForRegion,
   normalizePreferredSearchLanguage,
   normalizeSearchResultLanguage,
 } from '@/utils/languageMapping'
@@ -40,6 +41,13 @@ describe('languageMapping', () => {
     // Region codes that don't directly map to a supported language
     expect(normalizePreferredSearchLanguage('br')).toBe('portuguese')
     expect(normalizePreferredSearchLanguage('jp')).toBe('japanese')
+  })
+
+  it('maps search regions to their primary supported language filters', () => {
+    expect(getPrimaryPreferredSearchLanguageForRegion('de')).toBe('german')
+    expect(getPrimaryPreferredSearchLanguageForRegion('fr')).toBe('french')
+    expect(getPrimaryPreferredSearchLanguageForRegion('uk')).toBe('english')
+    expect(getPrimaryPreferredSearchLanguageForRegion('unknown')).toBe('english')
   })
 
   it('maps result languages to supported filter values', () => {

--- a/fe/src/__tests__/test-setup.ts
+++ b/fe/src/__tests__/test-setup.ts
@@ -294,40 +294,48 @@ try {
   }
 } catch {}
 
-// Provide a simple localStorage polyfill for tests that rely on it
-// Ensure a working localStorage implementation exists for tests. Some test
-// runners may set a placeholder object; normalize it so .setItem/.getItem exist.
-if (
-  typeof (globalThis as unknown as { localStorage?: { setItem?: unknown } }).localStorage ===
-    'undefined' ||
-  typeof (globalThis as unknown as { localStorage?: { setItem?: unknown } }).localStorage
-    ?.setItem !== 'function'
-) {
-  ;(
-    globalThis as unknown as {
-      localStorage?: {
-        _store?: Record<string, string>
-        getItem?: (k: string) => string | null
-        setItem?: (k: string, v: string) => void
-        removeItem?: (k: string) => void
-        clear?: () => void
-      }
-    }
-  ).localStorage = {
-    _store: {} as Record<string, string>,
-    getItem(key: string) {
-      return this._store[key] ?? null
-    },
-    setItem(key: string, value: string) {
-      this._store[key] = value + ''
-    },
-    removeItem(key: string) {
-      delete this._store[key]
-    },
-    clear() {
-      this._store = {}
-    },
-  }
+// Ensure a working localStorage implementation exists for tests. Node 24 exposes
+// a native global localStorage getter that warns unless --localstorage-file is
+// configured, so install test storage without reading the getter.
+type TestStorage = {
+  _store?: Record<string, string>
+  getItem?: (k: string) => string | null
+  setItem?: (k: string, v: string) => void
+  removeItem?: (k: string) => void
+  clear?: () => void
+}
+
+const createMemoryStorage = (): TestStorage => ({
+  _store: {},
+  getItem(key: string) {
+    return this._store?.[key] ?? null
+  },
+  setItem(key: string, value: string) {
+    this._store = this._store ?? {}
+    this._store[key] = value + ''
+  },
+  removeItem(key: string) {
+    delete this._store?.[key]
+  },
+  clear() {
+    this._store = {}
+  },
+})
+
+const testLocalStorage = createMemoryStorage()
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: testLocalStorage,
+  writable: true,
+})
+
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: testLocalStorage,
+    writable: true,
+  })
 }
 
 // Defensive: JSDOM / Vitest may encounter `file://` asset URLs (e.g. transformed

--- a/fe/src/components/domain/audiobook/AddLibraryModal.vue
+++ b/fe/src/components/domain/audiobook/AddLibraryModal.vue
@@ -464,6 +464,7 @@ import RootFolderSelect from '@/components/form/RootFolderSelect.vue'
 import Checkbox from '@/components/form/Checkbox.vue'
 import FormRow from '@/components/settings/FormRow.vue'
 import { useRootFoldersStore } from '@/stores/rootFolders'
+import { buildAudibleProductUrl } from '@/utils/marketDomains'
 import {
   PhX,
   PhSpinner,
@@ -623,6 +624,7 @@ function cloneMetadata(source: AudibleBookMetadata): AudibleBookMetadata {
     abridged: Boolean(source.abridged),
     source: trimToUndefined(source.source),
     sourceLink: trimToUndefined(source.sourceLink),
+    region: trimToUndefined(source.region),
     openLibraryId: trimToUndefined(source.openLibraryId),
     metadataSource: trimToUndefined(source.metadataSource),
   }
@@ -672,6 +674,7 @@ function buildMetadataPayload(): AudibleBookMetadata {
     imageUrl: trimToUndefined(source?.imageUrl),
     explicit: Boolean(source?.explicit),
     abridged: Boolean(source?.abridged),
+    region: trimToUndefined(source?.region),
     openLibraryId: trimToUndefined(source?.openLibraryId),
   }
 }
@@ -723,12 +726,12 @@ const audibleSourceUrl = computed(() => {
   const source = (metadataSource.value || currentMetadata.value?.source || '').toLowerCase()
   const asin = currentMetadata.value?.asin
   if (!source.includes('audible') || !asin) return null
-  return `https://www.audible.com/pd/${encodeURIComponent(asin)}`
+  return buildAudibleProductUrl(asin, currentMetadata.value?.region)
 })
 
 const audibleProductUrl = computed(() => {
   const asin = currentMetadata.value?.asin
-  return asin ? `https://www.audible.com/pd/${asin}` : '#'
+  return asin ? buildAudibleProductUrl(asin, currentMetadata.value?.region) : '#'
 })
 
 const openLibraryUrl = computed(() => {
@@ -844,6 +847,7 @@ interface Audible {
   imageUrl?: string
   lengthMinutes?: number
   language?: string
+  region?: string
   genres?: AudibleGenre[]
   series?: AudibleSeries[]
   bookFormat?: string
@@ -907,6 +911,7 @@ const mapAudibleToAudible = (
     edition: props.book?.edition,
     version: audible?.version || props.book?.version,
     genres: genres.length ? genres : props.book?.genres || [],
+    region: audible?.region || props.book?.region,
     series: primaryMembership?.seriesName || props.book?.series,
     seriesNumber:
       primaryMembership?.seriesNumber ||
@@ -979,7 +984,7 @@ const seedPreview = async () => {
       try {
         const resp = await apiService.getAudibleMetadata<
           AudibleMetadataResponse | Partial<Audible>
-        >(props.book.asin)
+        >(props.book.asin, props.book.region)
         const payload = (resp && typeof resp === 'object' ? resp : {}) as
           | AudibleMetadataResponse
           | Partial<Audible>

--- a/fe/src/components/domain/audiobook/AudiobookDetailsModal.vue
+++ b/fe/src/components/domain/audiobook/AudiobookDetailsModal.vue
@@ -191,6 +191,7 @@ import { useProtectedImages } from '@/composables/useProtectedImages'
 import { Modal, ModalBody, ModalHeader } from '@/components/feedback'
 import { formatDate, formatRuntime, capitalizeFirst } from '@/utils/searchResultFormatting'
 import { formatSeriesMemberships } from '@/utils/seriesUtils'
+import { buildAudibleProductUrl } from '@/utils/marketDomains'
 
 interface Props {
   visible: boolean
@@ -229,12 +230,12 @@ const audibleSourceUrl = computed(() => {
   const source = props.book?.source?.toLowerCase()
   const asin = props.book?.asin
   if (!source?.includes('audible') || !asin) return null
-  return `https://www.audible.com/pd/${encodeURIComponent(asin)}`
+  return buildAudibleProductUrl(asin, props.book?.region)
 })
 
 const audibleProductUrl = computed(() => {
   const asin = props.book?.asin
-  return asin ? `https://www.audible.com/pd/${asin}` : '#'
+  return asin ? buildAudibleProductUrl(asin, props.book?.region) : '#'
 })
 
 const openLibraryUrl = computed(() => {

--- a/fe/src/components/domain/audiobook/AudiobookModal.vue
+++ b/fe/src/components/domain/audiobook/AudiobookModal.vue
@@ -191,6 +191,7 @@ import { useProtectedImages } from '@/composables/useProtectedImages'
 import { Modal, ModalBody, ModalHeader } from '@/components/feedback'
 import { formatDate, formatRuntime, capitalizeFirst } from '@/utils/searchResultFormatting'
 import { formatSeriesMemberships } from '@/utils/seriesUtils'
+import { buildAudibleProductUrl } from '@/utils/marketDomains'
 
 interface Props {
   visible: boolean
@@ -229,12 +230,12 @@ const audibleSourceUrl = computed(() => {
   const source = props.book?.source?.toLowerCase()
   const asin = props.book?.asin
   if (!source?.includes('audible') || !asin) return null
-  return `https://www.audible.com/pd/${encodeURIComponent(asin)}`
+  return buildAudibleProductUrl(asin, props.book?.region)
 })
 
 const audibleProductUrl = computed(() => {
   const asin = props.book?.asin
-  return asin ? `https://www.audible.com/pd/${asin}` : '#'
+  return asin ? buildAudibleProductUrl(asin, props.book?.region) : '#'
 })
 
 const openLibraryUrl = computed(() => {

--- a/fe/src/components/search/SearchResultCard.vue
+++ b/fe/src/components/search/SearchResultCard.vue
@@ -146,39 +146,53 @@
       <slot name="meta-links">
         <div class="result-meta">
           <a
-            v-if="metadataSourceUrl"
-            :href="metadataSourceUrl"
+            v-if="sharedMetadataSourceUrl"
+            :href="sharedMetadataSourceUrl"
             target="_blank"
             rel="noopener noreferrer"
-            class="metadata-source-link"
-            :data-source="book.metadataSource"
+            class="metadata-source-link source-link combined-source-link"
+            :data-source="metadataSource"
           >
             <PhGlobe />
+            <PhCloud />
             {{ metadataSourceLabel }}
           </a>
-          <span
-            v-else-if="book.metadataSource"
-            class="metadata-source-badge"
-            :data-source="book.metadataSource"
-          >
-            <PhGlobe />
-            {{ metadataSourceLabel }}
-          </span>
+          <template v-else>
+            <a
+              v-if="metadataSource && metadataSourceUrl"
+              :href="metadataSourceUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="metadata-source-link"
+              :data-source="metadataSource"
+            >
+              <PhGlobe />
+              {{ metadataSourceLabel }}
+            </a>
+            <span
+              v-else-if="metadataSource"
+              class="metadata-source-badge"
+              :data-source="metadataSource"
+            >
+              <PhGlobe />
+              {{ metadataSourceLabel }}
+            </span>
 
-          <a
-            v-if="sourceUrl"
-            :href="sourceUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="source-link"
-          >
-            <PhCloud />
-            {{ sourceLabel }}
-          </a>
-          <span v-else-if="book.searchResult?.source" class="source-badge">
-            <PhCloud />
-            Source: {{ book.searchResult.source }}
-          </span>
+            <a
+              v-if="sourceUrl"
+              :href="sourceUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="source-link"
+            >
+              <PhCloud />
+              {{ sourceLabel }}
+            </a>
+            <span v-else-if="book.searchResult?.source" class="source-badge">
+              <PhCloud />
+              Source: {{ book.searchResult.source }}
+            </span>
+          </template>
         </div>
       </slot>
     </div>
@@ -269,6 +283,13 @@ const openLibraryId = computed(() => {
   return props.book.searchResult?.id || props.book.key || undefined
 })
 
+const nestedSearchResult = computed(() => {
+  const nested = (props.book.searchResult as unknown as Record<string, unknown> | undefined)?.[
+    'searchResult'
+  ]
+  return nested && typeof nested === 'object' ? (nested as Record<string, unknown>) : undefined
+})
+
 /**
  * Format author names from various sources
  */
@@ -302,9 +323,22 @@ const formatAuthors = (book: typeof props.book): string => {
 const isAudibleHost = (url?: string): boolean => {
   if (!url) return false
   try {
-    return /audible\.|audible-/i.test(new URL(url).hostname)
+    const host = new URL(url, window.location.origin).hostname.toLowerCase()
+    return host.startsWith('audible.') || host.startsWith('www.audible.')
   } catch {
     return false
+  }
+}
+
+const areSameUrl = (left?: string, right?: string): boolean => {
+  if (!left || !right) return false
+
+  try {
+    return (
+      new URL(left, window.location.origin).href === new URL(right, window.location.origin).href
+    )
+  } catch {
+    return left === right
   }
 }
 
@@ -312,10 +346,24 @@ const isAudibleHost = (url?: string): boolean => {
  * Generate metadata source label
  */
 const metadataSourceLabel = computed((): string => {
-  if (!props.book.metadataSource) return ''
-  const source = props.book.metadataSource.toLowerCase()
+  if (!metadataSource.value) return ''
+  const source = metadataSource.value.toLowerCase()
   if (source.includes('audible')) return 'Audible'
-  return `Metadata: ${props.book.metadataSource}`
+  return `Metadata: ${metadataSource.value}`
+})
+
+const metadataSource = computed((): string | undefined => {
+  const source =
+    props.book.metadataSource ??
+    props.book.searchResult?.metadataSource ??
+    (nestedSearchResult.value?.['metadataSource'] as string | undefined)
+
+  return typeof source === 'string' && source.trim() ? source : undefined
+})
+
+const sharedMetadataSourceUrl = computed((): string | undefined => {
+  if (!metadataSource.value) return undefined
+  return areSameUrl(props.metadataSourceUrl, props.sourceUrl) ? props.metadataSourceUrl : undefined
 })
 
 /**
@@ -324,7 +372,12 @@ const metadataSourceLabel = computed((): string => {
 const sourceLabel = computed((): string => {
   if (!props.sourceUrl) return ''
   if (isAudibleHost(props.sourceUrl)) return 'Audible'
-  return props.book.searchResult?.source || props.book.metadataSource || 'OpenLibrary'
+  return (
+    props.book.searchResult?.source ||
+    (nestedSearchResult.value?.['source'] as string | undefined) ||
+    metadataSource.value ||
+    'OpenLibrary'
+  )
 })
 </script>
 

--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -436,6 +436,7 @@ export interface AudibleBookMetadata {
   abridged?: boolean
   source?: string
   sourceLink?: string
+  region?: string
   openLibraryId?: string
   metadataSource?: string
   // Optional local mapping to a quality profile ID when viewing in the UI

--- a/fe/src/utils/languageMapping.ts
+++ b/fe/src/utils/languageMapping.ts
@@ -248,6 +248,12 @@ export function getLanguageFromRegion(region: string): string {
   return regionToLanguage[region.toLowerCase()] || 'english'
 }
 
+export function getPrimaryPreferredSearchLanguageForRegion(
+  region: string | undefined | null,
+): string {
+  return normalizePreferredSearchLanguage(getLanguageFromRegion(normalizeSearchRegion(region)))
+}
+
 export function normalizeSearchRegion(region: string | undefined | null): string {
   const normalized = (region || '').trim().toLowerCase()
   if (!normalized) return 'us'

--- a/fe/src/views/content/AddNewView.vue
+++ b/fe/src/views/content/AddNewView.vue
@@ -1036,6 +1036,7 @@ type TitleSearchResult = Omit<OpenLibraryBook, 'isbn'> & {
   imageUrl?: string // For results that have direct image URLs
   metadataSource?: string // Store which metadata source was used
   isbn?: string | string[] // Normalized ISBN (string or array for OpenLibrary compatibility)
+  region?: string // Audible/Amazon market region from the search result
 }
 
 // Loose result type used for normalization of diverse backend shapes
@@ -1618,25 +1619,7 @@ const handleAdvancedSearchResults = async (results: Array<Partial<SearchResult> 
       tr['description'] = rrRes['description'] ?? rrRes['Description'] ?? undefined
       tr['asin'] = rrRes['asin'] ?? rrRes['Asin'] ?? undefined
       tr['id'] = rrRes['asin'] ?? rrRes['sku'] ?? rrRes['id'] ?? rrRes['title']
-      tr['region'] = rrRes['region'] ?? rrRes['Region'] ?? undefined
-      if (tr['region']) {
-        ;(tr['searchResult'] as Record<string, unknown>)['region'] = tr['region']
-      }
-      const rawProductUrl = rrRes['productUrl'] ?? rrRes['link'] ?? rrRes['Link'] ?? undefined
-      const asin = typeof tr['asin'] === 'string' ? tr['asin'] : undefined
-      const resultRegion = typeof tr['region'] === 'string' ? tr['region'] : searchLanguage.value
-      const sourceIsAudible =
-        String(titleResult.metadataSource ?? '')
-          .toLowerCase()
-          .includes('audible') ||
-        String(rrRes['source'] ?? rrRes['Source'] ?? '')
-          .toLowerCase()
-          .includes('audible')
-      tr['productUrl'] =
-        asin &&
-        (sourceIsAudible || (typeof rawProductUrl === 'string' && isAudibleHost(rawProductUrl)))
-          ? buildAudibleProductUrl(asin, resultRegion)
-          : rawProductUrl
+      normalizeResultRegionAndProductUrl(tr, rrRes, titleResult)
       if (tr['subtitle']) {
         ;(tr['searchResult'] as Record<string, unknown>)['subtitle'] = tr['subtitle']
       }
@@ -2244,17 +2227,45 @@ const formatAuthors = (book: TitleSearchResult): string => {
   return book.searchResult?.artist || 'Unknown Author'
 }
 
+/**
+ * Normalises the region and productUrl fields on a raw title result record.
+ * Propagates the resolved region into the nested searchResult, then determines
+ * whether the product link should be an Audible canonical URL or the raw value.
+ * Extracted to avoid duplication between handleAdvancedSearchResults and
+ * handleSimpleSearchResults.
+ */
+const normalizeResultRegionAndProductUrl = (
+  tr: Record<string, unknown>,
+  rrRes: Record<string, unknown>,
+  titleResult: TitleSearchResult,
+): void => {
+  tr['region'] = rrRes['region'] ?? rrRes['Region'] ?? undefined
+  if (tr['region']) {
+    ;(tr['searchResult'] as Record<string, unknown>)['region'] = tr['region']
+  }
+  const rawProductUrl = rrRes['productUrl'] ?? rrRes['link'] ?? rrRes['Link'] ?? undefined
+  const asin = typeof tr['asin'] === 'string' ? tr['asin'] : undefined
+  const resultRegion = typeof tr['region'] === 'string' ? tr['region'] : searchLanguage.value
+  const sourceIsAudible =
+    String(titleResult.metadataSource ?? '')
+      .toLowerCase()
+      .includes('audible') ||
+    String(rrRes['source'] ?? rrRes['Source'] ?? '')
+      .toLowerCase()
+      .includes('audible')
+  tr['productUrl'] =
+    asin && (sourceIsAudible || (typeof rawProductUrl === 'string' && isAudibleHost(rawProductUrl)))
+      ? buildAudibleProductUrl(asin, resultRegion)
+      : rawProductUrl
+}
+
 const getAsin = (book: TitleSearchResult): string | null => {
   return book.searchResult?.asin || resolvedAsins.value[book.key] || null
 }
 
 const getResultRegion = (book: TitleSearchResult): string => {
   const rawRegion =
-    (book as unknown as Record<string, unknown>)['region'] ??
-    ((book.searchResult as unknown as Record<string, unknown> | undefined)?.['region'] as
-      | string
-      | undefined)
-
+    book.region ?? (book.searchResult as Record<string, unknown> | undefined)?.['region']
   return typeof rawRegion === 'string' && rawRegion.trim() ? rawRegion : searchLanguage.value
 }
 
@@ -2993,25 +3004,7 @@ const handleSimpleSearchResults = async (results: SearchResult[]) => {
       tr['description'] = rrRes['description'] ?? rrRes['Description'] ?? undefined
       tr['asin'] = rrRes['asin'] ?? rrRes['Asin'] ?? undefined
       tr['id'] = rrRes['asin'] ?? rrRes['sku'] ?? rrRes['id'] ?? rrRes['title']
-      tr['region'] = rrRes['region'] ?? rrRes['Region'] ?? undefined
-      if (tr['region']) {
-        ;(tr['searchResult'] as Record<string, unknown>)['region'] = tr['region']
-      }
-      const rawProductUrl = rrRes['productUrl'] ?? rrRes['link'] ?? rrRes['Link'] ?? undefined
-      const asin = typeof tr['asin'] === 'string' ? tr['asin'] : undefined
-      const resultRegion = typeof tr['region'] === 'string' ? tr['region'] : searchLanguage.value
-      const sourceIsAudible =
-        String(titleResult.metadataSource ?? '')
-          .toLowerCase()
-          .includes('audible') ||
-        String(rrRes['source'] ?? rrRes['Source'] ?? '')
-          .toLowerCase()
-          .includes('audible')
-      tr['productUrl'] =
-        asin &&
-        (sourceIsAudible || (typeof rawProductUrl === 'string' && isAudibleHost(rawProductUrl)))
-          ? buildAudibleProductUrl(asin, resultRegion)
-          : rawProductUrl
+      normalizeResultRegionAndProductUrl(tr, rrRes, titleResult)
       // preserve seriesList for tooltip display when provided as an array
       try {
         const rawSeries = rr['series'] ?? rr['Series']

--- a/fe/src/views/content/AddNewView.vue
+++ b/fe/src/views/content/AddNewView.vue
@@ -473,55 +473,69 @@
 
               <div class="result-meta">
                 <a
-                  v-if="
-                    audibleResult.asin &&
-                    ((audibleResult.metadataSource &&
-                      audibleResult.metadataSource.toLowerCase().includes('audible')) ||
-                      (audibleResult.searchResult &&
-                        audibleResult.searchResult.metadataSource &&
-                        audibleResult.searchResult.metadataSource
-                          .toLowerCase()
-                          .includes('audible')))
-                  "
-                  :href="audibleResultProductUrl"
+                  v-if="audibleResultSharedSourceUrl"
+                  :href="audibleResultSharedSourceUrl"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="metadata-source-link"
-                  :data-source="
-                    audibleResult.metadataSource ||
-                    (audibleResult.searchResult && audibleResult.searchResult.metadataSource)
-                  "
+                  class="metadata-source-link source-link combined-source-link"
+                  :data-source="audibleResultMetadataSource"
                 >
                   <PhGlobe />
+                  <PhCloud />
                   Audible
                 </a>
-                <span
-                  v-else-if="audibleResult.metadataSource"
-                  class="metadata-source-badge"
-                  :data-source="audibleResult.metadataSource"
-                >
-                  <PhGlobe />
-                  Metadata: {{ audibleResult.metadataSource }}
-                </span>
+                <template v-else>
+                  <a
+                    v-if="
+                      audibleResult.asin &&
+                      ((audibleResult.metadataSource &&
+                        audibleResult.metadataSource.toLowerCase().includes('audible')) ||
+                        (audibleResult.searchResult &&
+                          audibleResult.searchResult.metadataSource &&
+                          audibleResult.searchResult.metadataSource
+                            .toLowerCase()
+                            .includes('audible')))
+                    "
+                    :href="audibleResultProductUrl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="metadata-source-link"
+                    :data-source="
+                      audibleResult.metadataSource ||
+                      (audibleResult.searchResult && audibleResult.searchResult.metadataSource)
+                    "
+                  >
+                    <PhGlobe />
+                    Audible
+                  </a>
+                  <span
+                    v-else-if="audibleResult.metadataSource"
+                    class="metadata-source-badge"
+                    :data-source="audibleResult.metadataSource"
+                  >
+                    <PhGlobe />
+                    Metadata: {{ audibleResult.metadataSource }}
+                  </span>
 
-                <a
-                  v-if="audibleResultSourceUrl"
-                  :href="audibleResultSourceUrl"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="source-link"
-                >
-                  <PhCloud />
-                  {{
-                    isAudibleHost(audibleResultSourceUrl)
-                      ? 'Audible'
-                      : `Source: ${audibleResult.source}`
-                  }}
-                </a>
-                <span v-else-if="audibleResult.source" class="source-badge">
-                  <PhCloud />
-                  Source: {{ audibleResult.source }}
-                </span>
+                  <a
+                    v-if="audibleResultSourceUrl"
+                    :href="audibleResultSourceUrl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="source-link"
+                  >
+                    <PhCloud />
+                    {{
+                      isAudibleHost(audibleResultSourceUrl)
+                        ? 'Audible'
+                        : `Source: ${audibleResult.source}`
+                    }}
+                  </a>
+                  <span v-else-if="audibleResult.source" class="source-badge">
+                    <PhCloud />
+                    Source: {{ audibleResult.source }}
+                  </span>
+                </template>
                 <span v-if="audibleResult.explicit" class="metadata-badge">
                   <PhWarning />
                   Explicit
@@ -784,48 +798,58 @@
 
               <div class="result-meta">
                 <a
-                  v-if="book.metadataSource && getMetadataSourceUrl(book)"
-                  :href="getMetadataSourceUrl(book)"
+                  v-if="getSharedMetadataSourceUrl(book)"
+                  :href="getSharedMetadataSourceUrl(book)"
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="metadata-source-link"
-                  :data-source="book.metadataSource"
+                  class="metadata-source-link source-link combined-source-link"
+                  :data-source="getBookMetadataSource(book)"
                 >
                   <PhGlobe />
-                  {{
-                    book.metadataSource && book.metadataSource.toLowerCase().includes('audible')
-                      ? 'Audible'
-                      : `Metadata: ${book.metadataSource}`
-                  }}
+                  <PhCloud />
+                  {{ getMetadataSourceLabel(getBookMetadataSource(book)) }}
                 </a>
-                <span
-                  v-else-if="book.metadataSource"
-                  class="metadata-source-badge"
-                  :data-source="book.metadataSource"
-                >
-                  <PhGlobe />
-                  Metadata: {{ book.metadataSource }}
-                </span>
+                <template v-else>
+                  <a
+                    v-if="getBookMetadataSource(book) && getMetadataSourceUrl(book)"
+                    :href="getMetadataSourceUrl(book)"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="metadata-source-link"
+                    :data-source="getBookMetadataSource(book)"
+                  >
+                    <PhGlobe />
+                    {{ getMetadataSourceLabel(getBookMetadataSource(book)) }}
+                  </a>
+                  <span
+                    v-else-if="getBookMetadataSource(book)"
+                    class="metadata-source-badge"
+                    :data-source="getBookMetadataSource(book)"
+                  >
+                    <PhGlobe />
+                    {{ getMetadataSourceLabel(getBookMetadataSource(book)) }}
+                  </span>
 
-                <!-- Prefer to show Audible as product source when metadata comes from Audible -->
-                <a
-                  v-if="getSourceUrl(book)"
-                  :href="getSourceUrl(book)"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="source-link"
-                >
-                  <PhCloud />
-                  {{
-                    isAudibleHost(getSourceUrl(book))
-                      ? 'Audible'
-                      : book.searchResult?.source || book.metadataSource || 'OpenLibrary'
-                  }}
-                </a>
-                <span v-else-if="book.searchResult?.source" class="source-badge">
-                  <PhCloud />
-                  Source: {{ book.searchResult.source }}
-                </span>
+                  <!-- Prefer to show Audible as product source when metadata comes from Audible -->
+                  <a
+                    v-if="getSourceUrl(book)"
+                    :href="getSourceUrl(book)"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="source-link"
+                  >
+                    <PhCloud />
+                    {{
+                      isAudibleHost(getSourceUrl(book))
+                        ? 'Audible'
+                        : book.searchResult?.source || getBookMetadataSource(book) || 'OpenLibrary'
+                    }}
+                  </a>
+                  <span v-else-if="book.searchResult?.source" class="source-badge">
+                    <PhCloud />
+                    Source: {{ book.searchResult.source }}
+                  </span>
+                </template>
               </div>
             </div>
 
@@ -990,7 +1014,6 @@ import { EmptyState } from '@/components/base'
 import { formatDate, formatRuntime, capitalizeLanguage } from '@/utils/searchResultFormatting'
 import {
   extractAuthors,
-  extractPublishedDate,
   normalizeSource,
   getOptionalString,
   canAddOpenLibraryResult as canAddOpenLibraryResultHelper,
@@ -1041,6 +1064,21 @@ type TitleSearchResult = Omit<OpenLibraryBook, 'isbn'> & {
 
 // Loose result type used for normalization of diverse backend shapes
 type LooseResult = Partial<SearchResult> & Record<string, unknown>
+
+const ASIN_KEYS = ['asin', 'Asin'] as const
+const METADATA_SOURCE_KEYS = ['metadataSource'] as const
+const PRODUCT_LINK_KEYS = ['productUrl', 'link', 'Link', 'sourceLink'] as const
+const PUBLISH_DATE_KEYS = [
+  'publishedDate',
+  'PublishedDate',
+  'releaseDate',
+  'ReleaseDate',
+  'release_date',
+  'Release_date',
+  'publishDate',
+  'PublishDate',
+] as const
+const SOURCE_KEYS = ['source', 'Source'] as const
 
 interface AudibleSeriesEntry {
   name?: string
@@ -1167,6 +1205,10 @@ const selectedSearchRegion = computed({
 
 const audibleResultRegion = computed(() => audibleResult.value?.region || searchLanguage.value)
 
+const audibleResultMetadataSource = computed(() => {
+  return audibleResult.value?.metadataSource ?? audibleResult.value?.searchResult?.metadataSource
+})
+
 const audibleResultProductUrl = computed(() =>
   audibleResult.value?.asin
     ? buildAudibleProductUrl(audibleResult.value.asin, audibleResultRegion.value)
@@ -1181,6 +1223,16 @@ const audibleResultSourceUrl = computed(() => {
   }
 
   return result.sourceLink
+})
+
+const audibleResultSharedSourceUrl = computed(() => {
+  const metadataSource = audibleResultMetadataSource.value
+  if (!metadataSource?.toLowerCase().includes('audible')) return undefined
+  if (!audibleResult.value?.asin) return undefined
+
+  return areSameUrl(audibleResultProductUrl.value, audibleResultSourceUrl.value)
+    ? audibleResultProductUrl.value
+    : undefined
 })
 
 // Parsed search query components (for error messages)
@@ -1460,6 +1512,31 @@ const filterResultsBySelectedLanguage = <T extends Partial<SearchResult> | Loose
   return results.filter((result) => getResultLanguageKey(result) === filter)
 }
 
+const getDateRecordValue = (
+  record: Record<string, unknown> | undefined,
+  keys: readonly string[],
+): string | undefined => {
+  if (!record) return undefined
+
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+    if (value instanceof Date) return value.toISOString().split('T')[0]
+  }
+
+  return undefined
+}
+
+const getResultPublishYear = (result: LooseResult): number | undefined => {
+  const nested = getNestedResultRecord(result)
+  const publishDateStr =
+    getDateRecordValue(result, PUBLISH_DATE_KEYS) ?? getDateRecordValue(nested, PUBLISH_DATE_KEYS)
+  if (!publishDateStr) return undefined
+
+  const year = parseInt(publishDateStr.substring(0, 4), 10)
+  return Number.isNaN(year) ? undefined : year
+}
+
 const handleAdvancedSearchResults = async (results: Array<Partial<SearchResult> | LooseResult>) => {
   const filteredResults = filterResultsBySelectedLanguage(results)
 
@@ -1483,6 +1560,7 @@ const handleAdvancedSearchResults = async (results: Array<Partial<SearchResult> 
   for (const result of filteredResults) {
     const r = result as LooseResult
     const rr = r as Record<string, unknown>
+    const nestedSearchResult = getNestedResultRecord(rr)
 
     // Normalize all sources to standard TitleSearchResult
     // 1. Normalize ISBN
@@ -1492,14 +1570,10 @@ const handleAdvancedSearchResults = async (results: Array<Partial<SearchResult> 
     const authorsFromResult = extractAuthors(r)
 
     // 3. Normalize publish year
-    const publishDateStr = extractPublishedDate(r)
-    const publishYear = publishDateStr ? parseInt(publishDateStr.substring(0, 4)) : undefined
+    const publishYear = getResultPublishYear(r)
 
     // 4. Normalize source
-    let source = ''
-    try {
-      source = normalizeSource(result.metadataSource ?? result.source) || ''
-    } catch {}
+    const source = normalizeSource(getResultSourceValue(rr, nestedSearchResult)) || ''
 
     // 5. Normalize publisher
     let publisher: string[] | undefined = undefined
@@ -1518,13 +1592,10 @@ const handleAdvancedSearchResults = async (results: Array<Partial<SearchResult> 
     // 7. Normalize key
     const key = String(rr['asin'] ?? rr['id'] ?? rr['key'] ?? normalizedIsbn ?? '')
 
+    const isAudibleBacked = isAudibleBackedResult(rr, source, nestedSearchResult)
+
     // 8. Normalize metadataSource
-    let metadataSource: string | undefined = undefined
-    if (source) {
-      metadataSource = source
-    } else if (result.metadataSource) {
-      metadataSource = String(result.metadataSource)
-    }
+    const metadataSource = getAlignedMetadataSource(rr, source, nestedSearchResult)
 
     // 9. Compose TitleSearchResult
     const titleResult: TitleSearchResult = {
@@ -1548,9 +1619,8 @@ const handleAdvancedSearchResults = async (results: Array<Partial<SearchResult> 
     }
 
     const looksLikeAudibleMetadata =
-      (metadataSource && ['audible'].includes(String(metadataSource).toLowerCase())) ||
-      Boolean(rr['isEnriched']) ||
-      Boolean(rr['asin'])
+      (metadataSource && String(metadataSource).toLowerCase().includes('audible')) ||
+      isAudibleBacked
 
     if (looksLikeAudibleMetadata) {
       // Populate commonly used Audible-like fields (flattened to top-level)
@@ -2233,6 +2303,124 @@ const formatAuthors = (book: TitleSearchResult): string => {
   return book.searchResult?.artist || 'Unknown Author'
 }
 
+// Safely check whether a URL points to Audible or a subdomain of Audible. Avoids substring checks that can be
+// bypassed by crafted URLs containing 'audible.com' elsewhere (e.g., query parameters or malicious hostnames).
+const isAudibleHost = (url?: string): boolean => {
+  if (!url) return false
+  try {
+    // Use a base origin so relative URLs can be parsed too
+    const parsed = new URL(url, window.location.origin)
+    const host = parsed.hostname.toLowerCase()
+    return host.startsWith('audible.') || host.startsWith('www.audible.')
+  } catch {
+    // If parsing fails, treat as not audible
+    return false
+  }
+}
+
+const areSameUrl = (left?: string, right?: string): boolean => {
+  if (!left || !right) return false
+
+  try {
+    return (
+      new URL(left, window.location.origin).href === new URL(right, window.location.origin).href
+    )
+  } catch {
+    return left === right
+  }
+}
+
+const getStringRecordValue = (
+  record: Record<string, unknown> | undefined,
+  keys: readonly string[],
+): string | undefined => {
+  if (!record) return undefined
+
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+
+  return undefined
+}
+
+const getNestedResultRecord = (
+  record: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined => {
+  const nested = record?.['searchResult']
+  return nested && typeof nested === 'object' ? (nested as Record<string, unknown>) : undefined
+}
+
+const getExplicitAsinValue = (
+  record: Record<string, unknown> | undefined,
+  nested = getNestedResultRecord(record),
+): string | undefined => {
+  return getStringRecordValue(record, ASIN_KEYS) ?? getStringRecordValue(nested, ASIN_KEYS)
+}
+
+const getResultProductLink = (
+  record: Record<string, unknown> | undefined,
+  nested = getNestedResultRecord(record),
+): string | undefined => {
+  return (
+    getStringRecordValue(record, PRODUCT_LINK_KEYS) ??
+    getStringRecordValue(nested, PRODUCT_LINK_KEYS)
+  )
+}
+
+const getResultSourceValue = (
+  record: Record<string, unknown> | undefined,
+  nested = getNestedResultRecord(record),
+): string | undefined => {
+  return (
+    getStringRecordValue(record, METADATA_SOURCE_KEYS) ??
+    getStringRecordValue(nested, METADATA_SOURCE_KEYS) ??
+    getStringRecordValue(record, SOURCE_KEYS) ??
+    getStringRecordValue(nested, SOURCE_KEYS)
+  )
+}
+
+const isAudibleBackedResult = (
+  record: Record<string, unknown> | undefined,
+  normalizedSource = '',
+  nested = getNestedResultRecord(record),
+): boolean => {
+  const sourceValues = [
+    normalizedSource,
+    getStringRecordValue(record, METADATA_SOURCE_KEYS),
+    getStringRecordValue(nested, METADATA_SOURCE_KEYS),
+    getStringRecordValue(record, SOURCE_KEYS),
+    getStringRecordValue(nested, SOURCE_KEYS),
+  ]
+
+  return (
+    sourceValues.some((source) => source?.toLowerCase().includes('audible')) ||
+    Boolean(record?.['isEnriched'] ?? nested?.['isEnriched']) ||
+    Boolean(getExplicitAsinValue(record, nested)) ||
+    isAudibleHost(getResultProductLink(record, nested))
+  )
+}
+
+const getAlignedMetadataSource = (
+  record: Record<string, unknown> | undefined,
+  normalizedSource = '',
+  nested = getNestedResultRecord(record),
+): string | undefined => {
+  if (normalizedSource) return normalizedSource
+
+  const explicitSource =
+    getStringRecordValue(record, METADATA_SOURCE_KEYS) ??
+    getStringRecordValue(nested, METADATA_SOURCE_KEYS)
+  if (explicitSource) return explicitSource
+
+  return isAudibleBackedResult(record, normalizedSource, nested) ? 'audible' : undefined
+}
+
+const getMetadataSourceLabel = (source?: string): string => {
+  if (!source) return ''
+  return source.toLowerCase().includes('audible') ? 'Audible' : `Metadata: ${source}`
+}
+
 /**
  * Normalises the region and productUrl fields on a raw title result record.
  * Propagates the resolved region into the nested searchResult, then determines
@@ -2249,8 +2437,8 @@ const normalizeResultRegionAndProductUrl = (
   if (tr['region']) {
     ;(tr['searchResult'] as Record<string, unknown>)['region'] = tr['region']
   }
-  const rawProductUrl = rrRes['productUrl'] ?? rrRes['link'] ?? rrRes['Link'] ?? undefined
-  const asin = typeof tr['asin'] === 'string' ? tr['asin'] : undefined
+  const rawProductUrl = getResultProductLink(rrRes)
+  const asin = getExplicitAsinValue(tr, rrRes)
   const resultRegion = typeof tr['region'] === 'string' ? tr['region'] : searchLanguage.value
   const sourceIsAudible =
     String(titleResult.metadataSource ?? '')
@@ -2266,29 +2454,69 @@ const normalizeResultRegionAndProductUrl = (
 }
 
 const getAsin = (book: TitleSearchResult): string | null => {
-  return book.searchResult?.asin || resolvedAsins.value[book.key] || null
+  return (
+    ((book as unknown as Record<string, unknown>)['asin'] as string | undefined) ||
+    book.searchResult?.asin ||
+    getNestedSearchResultValue<string>(book, 'asin') ||
+    resolvedAsins.value[book.key] ||
+    null
+  )
 }
 
 const getResultRegion = (book: TitleSearchResult): string => {
   const rawRegion =
-    book.region ?? (book.searchResult as Record<string, unknown> | undefined)?.['region']
+    book.region ??
+    (book.searchResult as Record<string, unknown> | undefined)?.['region'] ??
+    getNestedSearchResultValue<string>(book, 'region')
   return typeof rawRegion === 'string' && rawRegion.trim() ? rawRegion : searchLanguage.value
 }
 
-const getMetadataSourceUrl = (book: TitleSearchResult): string | undefined => {
+const getNestedSearchResultValue = <T,>(book: TitleSearchResult, field: string): T | undefined => {
+  const nested = getNestedResultRecord(book.searchResult as Record<string, unknown> | undefined)
+  return nested?.[field] as T | undefined
+}
+
+const getBookMetadataSource = (book: TitleSearchResult): string | undefined => {
   const source =
     book.metadataSource ??
-    ((book.searchResult as unknown as Record<string, unknown>)['metadataSource'] as
+    ((book.searchResult as Record<string, unknown> | undefined)?.['metadataSource'] as
       | string
-      | undefined)
+      | undefined) ??
+    getNestedSearchResultValue<string>(book, 'metadataSource')
+
+  return typeof source === 'string' && source.trim() ? source : undefined
+}
+
+const getBookProductUrl = (book: TitleSearchResult): string | undefined => {
+  const bookRecord = book as unknown as Record<string, unknown>
+  const searchResultRecord = book.searchResult as Record<string, unknown> | undefined
+
+  return (
+    getResultProductLink(bookRecord, searchResultRecord) ?? getResultProductLink(searchResultRecord)
+  )
+}
+
+const getSharedMetadataSourceUrl = (book: TitleSearchResult): string | undefined => {
+  if (!getBookMetadataSource(book)) return undefined
+
+  const metadataUrl = getMetadataSourceUrl(book)
+  const sourceUrl = getSourceUrl(book)
+  return areSameUrl(metadataUrl, sourceUrl) ? metadataUrl : undefined
+}
+
+const getMetadataSourceUrl = (book: TitleSearchResult): string | undefined => {
+  const source = getBookMetadataSource(book)
   if (!source) return undefined
 
   // OpenLibrary metadata does not require an ASIN; prefer resultUrl (JSON) then productUrl or OL work URL
   if (source.toLowerCase().includes('openlibrary')) {
     // Prefer the canonical metadata/result URL (e.g., OpenLibrary .json) if provided
     if (book.searchResult?.resultUrl) return book.searchResult.resultUrl
+    const nestedResultUrl = getNestedSearchResultValue<string>(book, 'resultUrl')
+    if (nestedResultUrl) return nestedResultUrl
     // Fall back to productUrl (human-facing page) if resultUrl is not available
-    if (book.searchResult?.productUrl) return book.searchResult.productUrl
+    const productUrl = getBookProductUrl(book)
+    if (productUrl) return productUrl
     const olBook = book as OpenLibraryBook
     // Avoid using our local generated keys (they start with 'search-') — prefer real OL identifiers
     const candidateKey = (olBook.key || '').toString()
@@ -2333,17 +2561,24 @@ const getMetadataSourceUrl = (book: TitleSearchResult): string | undefined => {
   }
 
   const asin = getAsin(book)
-  if (!asin) return undefined
+  const productUrl = getBookProductUrl(book)
 
   // Map metadata source to URL for ASIN-based providers
   if (source.toLowerCase().includes('audible')) {
+    if (productUrl) return productUrl
+    if (!asin) return undefined
     return buildAudibleProductUrl(asin, getResultRegion(book))
   } else if (source.toLowerCase().includes('audnex')) {
+    if (!asin) return undefined
     // Audnexus API format
     return `https://api.audnex.us/books/${asin}`
   } else if (source === 'Amazon') {
+    if (productUrl) return productUrl
+    if (!asin) return undefined
     return buildAmazonProductUrl(asin, getResultRegion(book))
   } else if (source === 'Audible') {
+    if (productUrl) return productUrl
+    if (!asin) return undefined
     return buildAudibleProductUrl(asin, getResultRegion(book))
   }
 
@@ -2353,23 +2588,16 @@ const getMetadataSourceUrl = (book: TitleSearchResult): string | undefined => {
 // Get a sensible 'source' URL for the book (indexer/product or OpenLibrary work page)
 const getSourceUrl = (book: TitleSearchResult): string | undefined => {
   const asin = getAsin(book)
-  const metaSource = (
-    book.metadataSource ??
-    ((book.searchResult as unknown as Record<string, unknown>)['metadataSource'] as
-      | string
-      | undefined) ??
-    ''
-  )
-    .toString()
-    .toLowerCase()
+  const metaSource = (getBookMetadataSource(book) ?? '').toString().toLowerCase()
 
   // Prefer explicit productUrl from the enriched SearchResult
-  if (book.searchResult?.productUrl) {
-    if ((metaSource.includes('audible') || isAudibleHost(book.searchResult.productUrl)) && asin) {
+  const productUrl = getBookProductUrl(book)
+  if (productUrl) {
+    if ((metaSource.includes('audible') || isAudibleHost(productUrl)) && asin) {
       return buildAudibleProductUrl(asin, getResultRegion(book))
     }
 
-    return book.searchResult.productUrl
+    return productUrl
   }
 
   // If metadata indicates Audible-backed metadata, link to the Audible product page when possible.
@@ -2398,21 +2626,6 @@ const getSourceUrl = (book: TitleSearchResult): string | undefined => {
   }
 
   return undefined
-}
-
-// Safely check whether a URL points to Audible or a subdomain of Audible. Avoids substring checks that can be
-// bypassed by crafted URLs containing 'audible.com' elsewhere (e.g., query parameters or malicious hostnames).
-const isAudibleHost = (url?: string): boolean => {
-  if (!url) return false
-  try {
-    // Use a base origin so relative URLs can be parsed too
-    const parsed = new URL(url, window.location.origin)
-    const host = parsed.hostname.toLowerCase()
-    return host.startsWith('audible.') || host.startsWith('www.audible.')
-  } catch {
-    // If parsing fails, treat as not audible
-    return false
-  }
 }
 
 // Extract ISBN candidates from an OpenLibrary-derived TitleSearchResult
@@ -2800,10 +3013,12 @@ const handleSimpleSearchResults = async (results: SearchResult[]) => {
   }
 
   for (const result of filteredResults) {
+    const rr = result as unknown as Record<string, unknown>
+    const nestedSearchResult = getNestedResultRecord(rr)
+
     // Normalize common metadata keys from backend variations so the template
     // consistently finds `subtitle`/`subtitles`, `narrator` and `source`.
     try {
-      const rr = result as unknown as Record<string, unknown>
       // subtitles may be provided as `subtitle`, `Subtitle`, `Subtitles` or `subtitles`
       rr['subtitles'] =
         rr['subtitles'] ?? rr['subtitle'] ?? rr['Subtitle'] ?? rr['Subtitles'] ?? undefined
@@ -2829,27 +3044,12 @@ const handleSimpleSearchResults = async (results: SearchResult[]) => {
           rr['narrator'] = rr['Narrator'] as string
         }
       }
-
-      // Normalize legacy/current Audible-backed metadata source values for display.
-      if (rr['metadataSource'] && String(rr['metadataSource']).toLowerCase().includes('audible')) {
-        rr['source'] = 'Audible'
-      }
     } catch (e) {
       // swallow normalization errors
       logger.debug('Normalization failed for simple result', e)
     }
 
-    // Extract year from publishedDate if it's a Date object, otherwise parse string
-    let publishYear: number | undefined
-    const dateStr = result.publishedDate
-    if (dateStr) {
-      if (typeof dateStr === 'object') {
-        publishYear = (dateStr as Date).getFullYear()
-      } else if (typeof dateStr === 'string') {
-        const year = parseInt(dateStr.substring(0, 4))
-        if (!isNaN(year)) publishYear = year
-      }
-    }
+    const publishYear = getResultPublishYear(result as unknown as LooseResult)
 
     const authorsFromResult = ((): string[] => {
       const rrec = result as unknown as Record<string, unknown>
@@ -2907,14 +3107,19 @@ const handleSimpleSearchResults = async (results: SearchResult[]) => {
       return []
     })()
 
+    const source = normalizeSource(getResultSourceValue(rr, nestedSearchResult)) || ''
+    const metadataSource = getAlignedMetadataSource(rr, source, nestedSearchResult)
+    const isAudibleBacked = isAudibleBackedResult(rr, source, nestedSearchResult)
+    if (metadataSource?.toLowerCase().includes('audible')) {
+      rr['source'] = 'Audible'
+    }
+
     // If the result looks like an Audible-backed audiobook result (or explicitly marked),
     // prefer to populate the richer audiobook-shaped fields so the Add New UI
     // can surface subtitles, narrators, runtime, publish date, etc.
     const looksLikeAudibleMetadata =
-      (result.metadataSource &&
-        ['audible', 'audible'].includes(String(result.metadataSource).toLowerCase())) ||
-      Boolean(result.isEnriched) ||
-      Boolean(result.asin)
+      (metadataSource && String(metadataSource).toLowerCase().includes('audible')) ||
+      isAudibleBacked
 
     const titleResult: TitleSearchResult = {
       title: result.title || '',
@@ -2932,17 +3137,7 @@ const handleSimpleSearchResults = async (results: SearchResult[]) => {
       searchResult: result,
       imageUrl: result.imageUrl,
       // Prefer explicit metadataSource, but normalize Audible-backed results to a stable label.
-      metadataSource: (looksLikeAudibleMetadata
-        ? 'audible'
-        : (result.metadataSource ??
-          ((result as unknown as Record<string, unknown>)['searchResult']
-            ? (
-                (result as unknown as Record<string, unknown>)['searchResult'] as Record<
-                  string,
-                  unknown
-                >
-              )['metadataSource']
-            : undefined))) as string | undefined,
+      metadataSource,
       // forward publisher into the top-level TitleSearchResult so template's publisher check works
       publisher: Array.isArray(result.publisher)
         ? result.publisher

--- a/fe/src/views/content/AddNewView.vue
+++ b/fe/src/views/content/AddNewView.vue
@@ -2336,7 +2336,7 @@ const getMetadataSourceUrl = (book: TitleSearchResult): string | undefined => {
     // Audnexus API format
     return `https://api.audnex.us/books/${asin}`
   } else if (source === 'Amazon') {
-    return buildAmazonProductUrl(asin)
+    return buildAmazonProductUrl(asin, getResultRegion(book))
   } else if (source === 'Audible') {
     return buildAudibleProductUrl(asin, getResultRegion(book))
   }

--- a/fe/src/views/content/AddNewView.vue
+++ b/fe/src/views/content/AddNewView.vue
@@ -66,6 +66,24 @@
                 @keydown.enter.prevent="onUnifiedSearchSubmit"
               />
 
+              <div class="region-select-wrapper" data-testid="search-region-indicator">
+                <label for="region-select" class="region-label">Region:</label>
+                <select
+                  v-model="selectedSearchRegion"
+                  id="region-select"
+                  class="region-select form-select"
+                  aria-label="Select Audible search region"
+                >
+                  <option
+                    v-for="option in searchRegionOptions"
+                    :key="option.value"
+                    :value="option.value"
+                  >
+                    {{ option.label }}
+                  </option>
+                </select>
+              </div>
+
               <div class="language-select-wrapper">
                 <label for="language-select" class="language-label">Language:</label>
                 <select
@@ -221,6 +239,25 @@
                   >
                     <option
                       v-for="option in preferredSearchLanguageOptions"
+                      :key="option.value"
+                      :value="option.value"
+                    >
+                      {{ option.label }}
+                    </option>
+                  </select>
+                </div>
+
+                <div class="form-group region-display-group">
+                  <label for="adv-region">Region</label>
+                  <select
+                    id="adv-region"
+                    aria-label="Select Audible search region"
+                    v-model="selectedSearchRegion"
+                    class="form-input"
+                    data-testid="advanced-search-region"
+                  >
+                    <option
+                      v-for="option in searchRegionOptions"
                       :key="option.value"
                       :value="option.value"
                     >
@@ -446,7 +483,7 @@
                           .toLowerCase()
                           .includes('audible')))
                   "
-                  :href="`https://www.audible.com/pd/${audibleResult.asin}`"
+                  :href="audibleResultProductUrl"
                   target="_blank"
                   rel="noopener noreferrer"
                   class="metadata-source-link"
@@ -468,15 +505,15 @@
                 </span>
 
                 <a
-                  v-if="audibleResult.sourceLink"
-                  :href="audibleResult.sourceLink"
+                  v-if="audibleResultSourceUrl"
+                  :href="audibleResultSourceUrl"
                   target="_blank"
                   rel="noopener noreferrer"
                   class="source-link"
                 >
                   <PhCloud />
                   {{
-                    isAudibleHost(audibleResult.sourceLink)
+                    isAudibleHost(audibleResultSourceUrl)
                       ? 'Audible'
                       : `Source: ${audibleResult.source}`
                   }}
@@ -960,11 +997,12 @@ import {
 } from '@/utils/searchResultHelpers'
 import { useProtectedImages, isLikelyBackendImageUrl } from '@/composables/useProtectedImages'
 import {
+  getPrimaryPreferredSearchLanguageForRegion,
   getPreferredSearchLanguageFilter,
-  normalizePreferredSearchLanguage,
   normalizeSearchResultLanguage,
   normalizeSearchRegion,
   preferredSearchLanguageOptions,
+  searchRegionOptions,
 } from '@/utils/languageMapping'
 
 // Helper to normalize ISBN (strip hyphens/spaces, prefer ISBN-13 if present)
@@ -1009,6 +1047,7 @@ interface AudibleSeriesEntry {
 
 interface AudibleMetadataPayload {
   asin?: string
+  region?: string
   title?: string
   subtitle?: string
   authors?: AudibleAuthor[]
@@ -1114,6 +1153,33 @@ const isbnResult = ref<ISBNBook | null>(null) // retained for potential enrichme
 const isbnLookupMessage = ref('')
 const isbnLookupWarning = ref(false)
 const totalTitleResultsCount = ref<number>(0)
+
+const selectedSearchRegion = computed({
+  get: () => normalizeSearchRegion(searchLanguage.value),
+  set: (value: string) => {
+    const normalizedRegion = normalizeSearchRegion(value)
+    searchLanguage.value = normalizedRegion
+    preferredSearchLanguage.value = getPrimaryPreferredSearchLanguageForRegion(normalizedRegion)
+  },
+})
+
+const audibleResultRegion = computed(() => audibleResult.value?.region || searchLanguage.value)
+
+const audibleResultProductUrl = computed(() =>
+  audibleResult.value?.asin
+    ? buildAudibleProductUrl(audibleResult.value.asin, audibleResultRegion.value)
+    : undefined,
+)
+
+const audibleResultSourceUrl = computed(() => {
+  const result = audibleResult.value
+  if (!result?.sourceLink) return undefined
+  if (result.asin && isAudibleHost(result.sourceLink)) {
+    return buildAudibleProductUrl(result.asin, audibleResultRegion.value)
+  }
+
+  return result.sourceLink
+})
 
 // Parsed search query components (for error messages)
 const asinQuery = ref('')
@@ -1551,7 +1617,25 @@ const handleAdvancedSearchResults = async (results: Array<Partial<SearchResult> 
       tr['description'] = rrRes['description'] ?? rrRes['Description'] ?? undefined
       tr['asin'] = rrRes['asin'] ?? rrRes['Asin'] ?? undefined
       tr['id'] = rrRes['asin'] ?? rrRes['sku'] ?? rrRes['id'] ?? rrRes['title']
-      tr['productUrl'] = rrRes['productUrl'] ?? rrRes['link'] ?? rrRes['Link'] ?? undefined
+      tr['region'] = rrRes['region'] ?? rrRes['Region'] ?? undefined
+      if (tr['region']) {
+        ;(tr['searchResult'] as Record<string, unknown>)['region'] = tr['region']
+      }
+      const rawProductUrl = rrRes['productUrl'] ?? rrRes['link'] ?? rrRes['Link'] ?? undefined
+      const asin = typeof tr['asin'] === 'string' ? tr['asin'] : undefined
+      const resultRegion = typeof tr['region'] === 'string' ? tr['region'] : searchLanguage.value
+      const sourceIsAudible =
+        String(titleResult.metadataSource ?? '')
+          .toLowerCase()
+          .includes('audible') ||
+        String(rrRes['source'] ?? rrRes['Source'] ?? '')
+          .toLowerCase()
+          .includes('audible')
+      tr['productUrl'] =
+        asin &&
+        (sourceIsAudible || (typeof rawProductUrl === 'string' && isAudibleHost(rawProductUrl)))
+          ? buildAudibleProductUrl(asin, resultRegion)
+          : rawProductUrl
       if (tr['subtitle']) {
         ;(tr['searchResult'] as Record<string, unknown>)['subtitle'] = tr['subtitle']
       }
@@ -1873,9 +1957,7 @@ const performAdvancedSearch = async () => {
 const clearAdvancedSearch = () => {
   // Reset form state via composable
   resetAdvancedSearch()
-  preferredSearchLanguage.value = normalizePreferredSearchLanguage(
-    configStore.applicationSettings?.defaultSearchLanguage,
-  )
+  preferredSearchLanguage.value = getPrimaryPreferredSearchLanguageForRegion(searchLanguage.value)
   advancedSearchError.value = ''
   // Reset audible paging state
   audiblePage.value = 1
@@ -2165,6 +2247,16 @@ const getAsin = (book: TitleSearchResult): string | null => {
   return book.searchResult?.asin || resolvedAsins.value[book.key] || null
 }
 
+const getResultRegion = (book: TitleSearchResult): string => {
+  const rawRegion =
+    (book as unknown as Record<string, unknown>)['region'] ??
+    ((book.searchResult as unknown as Record<string, unknown> | undefined)?.['region'] as
+      | string
+      | undefined)
+
+  return typeof rawRegion === 'string' && rawRegion.trim() ? rawRegion : searchLanguage.value
+}
+
 const getMetadataSourceUrl = (book: TitleSearchResult): string | undefined => {
   const source =
     book.metadataSource ??
@@ -2227,14 +2319,14 @@ const getMetadataSourceUrl = (book: TitleSearchResult): string | undefined => {
 
   // Map metadata source to URL for ASIN-based providers
   if (source.toLowerCase().includes('audible')) {
-    return buildAudibleProductUrl(asin)
+    return buildAudibleProductUrl(asin, getResultRegion(book))
   } else if (source.toLowerCase().includes('audnex')) {
     // Audnexus API format
     return `https://api.audnex.us/books/${asin}`
   } else if (source === 'Amazon') {
     return buildAmazonProductUrl(asin)
   } else if (source === 'Audible') {
-    return buildAudibleProductUrl(asin)
+    return buildAudibleProductUrl(asin, getResultRegion(book))
   }
 
   return undefined
@@ -2242,10 +2334,6 @@ const getMetadataSourceUrl = (book: TitleSearchResult): string | undefined => {
 
 // Get a sensible 'source' URL for the book (indexer/product or OpenLibrary work page)
 const getSourceUrl = (book: TitleSearchResult): string | undefined => {
-  // Prefer explicit productUrl from the enriched SearchResult
-  if (book.searchResult?.productUrl) return book.searchResult.productUrl
-
-  // If metadata indicates Audible-backed metadata, link to the Audible product page when possible.
   const asin = getAsin(book)
   const metaSource = (
     book.metadataSource ??
@@ -2256,8 +2344,19 @@ const getSourceUrl = (book: TitleSearchResult): string | undefined => {
   )
     .toString()
     .toLowerCase()
+
+  // Prefer explicit productUrl from the enriched SearchResult
+  if (book.searchResult?.productUrl) {
+    if ((metaSource.includes('audible') || isAudibleHost(book.searchResult.productUrl)) && asin) {
+      return buildAudibleProductUrl(asin, getResultRegion(book))
+    }
+
+    return book.searchResult.productUrl
+  }
+
+  // If metadata indicates Audible-backed metadata, link to the Audible product page when possible.
   if (metaSource.includes('audible') && asin) {
-    return buildAudibleProductUrl(asin)
+    return buildAudibleProductUrl(asin, getResultRegion(book))
   }
 
   // If provider/source is OpenLibrary or we have an OL key, link to the OL work page
@@ -2291,7 +2390,7 @@ const isAudibleHost = (url?: string): boolean => {
     // Use a base origin so relative URLs can be parsed too
     const parsed = new URL(url, window.location.origin)
     const host = parsed.hostname.toLowerCase()
-    return host === 'audible.com' || host.endsWith('.audible.com')
+    return host.startsWith('audible.') || host.startsWith('www.audible.')
   } catch {
     // If parsing fails, treat as not audible
     return false
@@ -2392,6 +2491,7 @@ const selectTitleResult = async (book: TitleSearchResult) => {
 
       const metadata: AudibleBookMetadata = {
         asin: result.asin || '',
+        region: getResultRegion(book),
         title: result.title || 'Unknown Title',
         subtitle: undefined,
         authors: result.artist ? [result.artist] : [],
@@ -2459,6 +2559,7 @@ const selectTitleResult = async (book: TitleSearchResult) => {
         const result = book.searchResult
         const fallbackMetadata: AudibleBookMetadata = {
           asin: asin || '',
+          region: getResultRegion(book),
           title: result?.title || book.title || 'Unknown Title',
           subtitle: result?.subtitle,
           authors: result?.artist
@@ -2497,6 +2598,7 @@ const selectTitleResult = async (book: TitleSearchResult) => {
 
       const metadata: AudibleBookMetadata = {
         asin: audibleData.asin || asin || '',
+        region: audibleData.region || getResultRegion(book),
         title: audibleData.title || 'Unknown Title',
         subtitle: audibleData.subtitle,
         authors:
@@ -2890,7 +2992,25 @@ const handleSimpleSearchResults = async (results: SearchResult[]) => {
       tr['description'] = rrRes['description'] ?? rrRes['Description'] ?? undefined
       tr['asin'] = rrRes['asin'] ?? rrRes['Asin'] ?? undefined
       tr['id'] = rrRes['asin'] ?? rrRes['sku'] ?? rrRes['id'] ?? rrRes['title']
-      tr['productUrl'] = rrRes['productUrl'] ?? rrRes['link'] ?? rrRes['Link'] ?? undefined
+      tr['region'] = rrRes['region'] ?? rrRes['Region'] ?? undefined
+      if (tr['region']) {
+        ;(tr['searchResult'] as Record<string, unknown>)['region'] = tr['region']
+      }
+      const rawProductUrl = rrRes['productUrl'] ?? rrRes['link'] ?? rrRes['Link'] ?? undefined
+      const asin = typeof tr['asin'] === 'string' ? tr['asin'] : undefined
+      const resultRegion = typeof tr['region'] === 'string' ? tr['region'] : searchLanguage.value
+      const sourceIsAudible =
+        String(titleResult.metadataSource ?? '')
+          .toLowerCase()
+          .includes('audible') ||
+        String(rrRes['source'] ?? rrRes['Source'] ?? '')
+          .toLowerCase()
+          .includes('audible')
+      tr['productUrl'] =
+        asin &&
+        (sourceIsAudible || (typeof rawProductUrl === 'string' && isAudibleHost(rawProductUrl)))
+          ? buildAudibleProductUrl(asin, resultRegion)
+          : rawProductUrl
       // preserve seriesList for tooltip display when provided as an array
       try {
         const rawSeries = rr['series'] ?? rr['Series']
@@ -2999,11 +3119,8 @@ onMounted(async () => {
   await configStore.loadApiConfigurations()
 
   const defaultRegion = normalizeSearchRegion(configStore.applicationSettings?.defaultSearchRegion)
-  const defaultLanguage = normalizePreferredSearchLanguage(
-    configStore.applicationSettings?.defaultSearchLanguage,
-  )
   searchLanguage.value = defaultRegion
-  preferredSearchLanguage.value = defaultLanguage
+  preferredSearchLanguage.value = getPrimaryPreferredSearchLanguageForRegion(defaultRegion)
 
   // Audible integration removed: no auth status to check
 
@@ -3266,7 +3383,8 @@ onUnmounted(() => {
   font-weight: 400;
 }
 
-.unified-search-bar .language-select {
+.unified-search-bar .language-select,
+.unified-search-bar .region-select {
   padding: 6px 8px;
   border: 1px solid #444;
   border-radius: 6px;
@@ -3293,36 +3411,42 @@ onUnmounted(() => {
   background-size: 1.125rem !important;
 }
 
-.unified-search-bar .language-select:focus-visible {
+.unified-search-bar .language-select:focus-visible,
+.unified-search-bar .region-select:focus-visible {
   outline: none;
   border-color: #2196f3;
   box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
 }
 
-.unified-search-bar .language-select:hover {
+.unified-search-bar .language-select:hover,
+.unified-search-bar .region-select:hover {
   border-color: #555;
 }
 
-.unified-search-bar .language-select:focus {
+.unified-search-bar .language-select:focus,
+.unified-search-bar .region-select:focus {
   outline: none;
   border-color: #2196f3;
   box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.2);
 }
 
-.unified-search-bar .language-select option {
+.unified-search-bar .language-select option,
+.unified-search-bar .region-select option {
   background-color: #1a1a1a !important;
   color: white !important;
   padding: 0.5rem !important;
 }
 
-.language-select-wrapper {
+.language-select-wrapper,
+.region-select-wrapper {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   white-space: nowrap;
 }
 
-.language-label {
+.language-label,
+.region-label {
   color: #b0bec5;
   font-size: 0.85rem;
   font-weight: 500;
@@ -3524,18 +3648,21 @@ select.form-input:focus {
     flex-basis: auto;
   }
 
-  .language-select-wrapper {
+  .language-select-wrapper,
+  .region-select-wrapper {
     width: 100%;
     flex-direction: row;
     align-items: center;
   }
 
-  .language-label {
+  .language-label,
+  .region-label {
     min-width: 60px;
     flex-shrink: 0;
   }
 
-  .unified-search-bar .language-select {
+  .unified-search-bar .language-select,
+  .unified-search-bar .region-select {
     flex: 1;
     min-width: auto;
     width: auto;
@@ -3616,16 +3743,19 @@ select.form-input:focus {
     font-size: 0.95rem;
   }
 
-  .language-select-wrapper {
+  .language-select-wrapper,
+  .region-select-wrapper {
     gap: 0.375rem;
   }
 
-  .language-label {
+  .language-label,
+  .region-label {
     min-width: 50px;
     font-size: 0.8rem;
   }
 
-  .unified-search-bar .language-select {
+  .unified-search-bar .language-select,
+  .unified-search-bar .region-select {
     font-size: 0.85rem;
     padding: 0.5rem 0.75rem;
   }

--- a/fe/src/views/content/AddNewView.vue
+++ b/fe/src/views/content/AddNewView.vue
@@ -1941,7 +1941,13 @@ const performAdvancedSearch = async () => {
 const clearAdvancedSearch = () => {
   // Reset form state via composable
   resetAdvancedSearch()
-  preferredSearchLanguage.value = getPrimaryPreferredSearchLanguageForRegion(searchLanguage.value)
+  // Mirror onMounted: respect the user's saved defaultSearchLanguage; only fall back
+  // to the region's primary language when no default language is configured.
+  const savedLanguage = configStore.applicationSettings?.defaultSearchLanguage
+  preferredSearchLanguage.value =
+    typeof savedLanguage === 'string' && savedLanguage.trim()
+      ? normalizePreferredSearchLanguage(savedLanguage)
+      : getPrimaryPreferredSearchLanguageForRegion(searchLanguage.value)
   advancedSearchError.value = ''
   // Reset audible paging state
   audiblePage.value = 1

--- a/fe/src/views/content/AddNewView.vue
+++ b/fe/src/views/content/AddNewView.vue
@@ -999,6 +999,7 @@ import { useProtectedImages, isLikelyBackendImageUrl } from '@/composables/usePr
 import {
   getPrimaryPreferredSearchLanguageForRegion,
   getPreferredSearchLanguageFilter,
+  normalizePreferredSearchLanguage,
   normalizeSearchResultLanguage,
   normalizeSearchRegion,
   preferredSearchLanguageOptions,
@@ -3119,8 +3120,12 @@ onMounted(async () => {
   await configStore.loadApiConfigurations()
 
   const defaultRegion = normalizeSearchRegion(configStore.applicationSettings?.defaultSearchRegion)
+  const defaultLanguage = configStore.applicationSettings?.defaultSearchLanguage
   searchLanguage.value = defaultRegion
-  preferredSearchLanguage.value = getPrimaryPreferredSearchLanguageForRegion(defaultRegion)
+  preferredSearchLanguage.value =
+    typeof defaultLanguage === 'string' && defaultLanguage.trim()
+      ? normalizePreferredSearchLanguage(defaultLanguage)
+      : getPrimaryPreferredSearchLanguageForRegion(defaultRegion)
 
   // Audible integration removed: no auth status to check
 

--- a/fe/src/views/library/AudiobookDetailView.vue
+++ b/fe/src/views/library/AudiobookDetailView.vue
@@ -669,6 +669,7 @@ import { safeText, stripHtmlAndNormalize } from '@/utils/textUtils'
 import { logger } from '@/utils/logger'
 import { errorTracking } from '@/services/errorTracking'
 import { useProtectedImages } from '@/composables/useProtectedImages'
+import { buildAudibleProductUrl } from '@/utils/marketDomains'
 import EditAudiobookModal from '@/components/domain/audiobook/EditAudiobookModal.vue'
 import ManualSearchModal from '@/components/domain/search/ManualSearchModal.vue'
 import RenamePreviewModal from '@/components/domain/organize/RenamePreviewModal.vue'
@@ -899,13 +900,20 @@ const assignedProfileName = computed(() => {
   return p ? p.name : null
 })
 
-const primaryAsin = computed(() => {
+const primaryAsinIdentifier = computed(() => {
   const ids = audiobook.value?.identifiers || []
   const explicitPrimary = ids.find((id) => id.type === 'Asin' && id.isPrimary && id.value?.trim())
-  if (explicitPrimary) return explicitPrimary.value.trim()
+  if (explicitPrimary) return explicitPrimary
 
   const firstAsin = ids.find((id) => id.type === 'Asin' && id.value?.trim())
-  if (firstAsin) return firstAsin.value.trim()
+  if (firstAsin) return firstAsin
+
+  return null
+})
+
+const primaryAsin = computed(() => {
+  const identifier = primaryAsinIdentifier.value
+  if (identifier?.value?.trim()) return identifier.value.trim()
 
   const legacy = (audiobook.value?.asin || '').trim()
   return legacy || null
@@ -914,7 +922,7 @@ const primaryAsin = computed(() => {
 const audibleSourceUrl = computed(() => {
   const asin = primaryAsin.value
   if (!asin) return null
-  return `https://www.audible.com/pd/${encodeURIComponent(asin)}`
+  return buildAudibleProductUrl(asin, primaryAsinIdentifier.value?.region ?? undefined)
 })
 
 const displayIdentifiers = computed<DetailIdentifierItem[]>(() => {
@@ -929,6 +937,7 @@ const displayIdentifiers = computed<DetailIdentifierItem[]>(() => {
     type: AudiobookExternalIdentifier['type'],
     rawValue: unknown,
     isPrimary = false,
+    rawRegion?: string | null,
   ) => {
     const value = typeof rawValue === 'string' ? rawValue.trim() : ''
     if (!value) return
@@ -944,13 +953,18 @@ const displayIdentifiers = computed<DetailIdentifierItem[]>(() => {
       type,
       typeLabel: formatIdentifierType(type),
       value,
-      href: getIdentifierHref(type, value),
+      href: getIdentifierHref(type, value, rawRegion),
       isPrimary,
     })
   }
 
   for (const identifier of book.identifiers || []) {
-    addIdentifier(identifier.type, identifier.value, Boolean(identifier.isPrimary))
+    addIdentifier(
+      identifier.type,
+      identifier.value,
+      Boolean(identifier.isPrimary),
+      identifier.region,
+    )
   }
 
   if (book.asin) {
@@ -1109,9 +1123,10 @@ function normalizeIdentifierKey(type: AudiobookExternalIdentifier['type'], value
 function getIdentifierHref(
   type: AudiobookExternalIdentifier['type'],
   value: string,
+  region?: string | null,
 ): string | null {
   if (type === 'Asin') {
-    return `https://www.audible.com/pd/${encodeURIComponent(value)}`
+    return buildAudibleProductUrl(value, region ?? undefined)
   }
 
   if (type === 'OpenLibraryId') {

--- a/fe/vite.config.ts
+++ b/fe/vite.config.ts
@@ -55,9 +55,16 @@ export default defineConfig(({ mode }) => {
         },
       },
     },
+    ...(mode === 'production'
+      ? {
+          esbuild: {
+            drop: ['console', 'debugger'],
+          },
+        }
+      : {}),
     resolve: {
       alias: {
-        '@': fileURLToPath(new URL('./src', import.meta.url))
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
       },
     },
     server: {
@@ -89,20 +96,25 @@ export default defineConfig(({ mode }) => {
                         httpRes.end(JSON.stringify({ message: 'API is starting, please retry.' }))
                       }
                     }
-                  } catch { /* ignore */ }
+                  } catch {
+                    /* ignore */
+                  }
                   return
                 }
               })
               proxy.on('proxyReq', (proxyReq, req) => {
                 try {
-                  const origCookie = req && req.headers && (req.headers['cookie'] || req.headers.cookie)
+                  const origCookie =
+                    req && req.headers && (req.headers['cookie'] || req.headers.cookie)
                   if (origCookie) {
                     proxyReq.setHeader('cookie', origCookie)
                   }
-                } catch {}
+                } catch {
+                  /* ignore */
+                }
               })
             }
-          }
+          },
         },
         '/hubs': {
           target: 'http://localhost:4545',
@@ -117,9 +129,9 @@ export default defineConfig(({ mode }) => {
                 // ECONNREFUSED during startup - ignore silently
               })
             }
-          }
-        }
-      }
-    }
+          },
+        },
+      },
+    },
   }
 })

--- a/listenarr.api/Features/Configuration/SettingsController.cs
+++ b/listenarr.api/Features/Configuration/SettingsController.cs
@@ -18,6 +18,7 @@
 
 using Listenarr.Api.Attributes;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using System.Text.Json;
 
 namespace Listenarr.Api.Features.Configuration
@@ -30,15 +31,18 @@ namespace Listenarr.Api.Features.Configuration
         private readonly IConfigurationService _configurationService;
         private readonly ILogger<SettingsController> _logger;
         private readonly IHubBroadcaster _hubBroadcaster;
+        private readonly IMemoryCache? _cache;
 
         public SettingsController(
             IConfigurationService configurationService,
             ILogger<SettingsController> logger,
-            IHubBroadcaster hubBroadcaster)
+            IHubBroadcaster hubBroadcaster,
+            IMemoryCache? cache = null)
         {
             _configurationService = configurationService;
             _logger = logger;
             _hubBroadcaster = hubBroadcaster;
+            _cache = cache;
         }
 
         /// <summary>
@@ -77,6 +81,7 @@ namespace Listenarr.Api.Features.Configuration
             {
                 _logger.LogDebug("Saving application settings");
                 await _configurationService.SaveApplicationSettingsAsync(settings);
+                _cache?.Remove("default-search-region");
 
                 var savedSettings = PrepareApplicationSettingsResponse(await _configurationService.GetApplicationSettingsAsync());
                 savedSettings.AdminUsername = null;

--- a/listenarr.api/Features/Search/SearchByTitleWorkflow.cs
+++ b/listenarr.api/Features/Search/SearchByTitleWorkflow.cs
@@ -22,11 +22,12 @@ namespace Listenarr.Api.Features.Search
         ISearchService searchService,
         AudibleService audibleService,
         IAudiobookMetadataService metadataService,
-        Microsoft.Extensions.Logging.ILogger<SearchByTitleWorkflow> logger)
+        Microsoft.Extensions.Logging.ILogger<SearchByTitleWorkflow> logger,
+        IConfigurationService? configurationService = null)
     {
         public async Task<SearchByTitleWorkflowResult> ExecuteAsync(
             string query,
-            string region,
+            string? region,
             int limit,
             CancellationToken cancellationToken)
         {
@@ -37,11 +38,13 @@ namespace Listenarr.Api.Features.Search
                     return SearchByTitleWorkflowResult.BadRequest("Query parameter is required");
                 }
 
+                var resolvedRegion = await ResolveSearchRegionAsync(region);
+
                 logger.LogInformation("Searching by title: {Query}", query);
 
                 if (IsAsin(query.Trim()))
                 {
-                    var directResult = await TryLookupAsinAsync(query.Trim(), region);
+                    var directResult = await TryLookupAsinAsync(query.Trim(), resolvedRegion);
                     if (directResult != null)
                     {
                         return SearchByTitleWorkflowResult.Ok(directResult);
@@ -50,7 +53,7 @@ namespace Listenarr.Api.Features.Search
 
                 var searchResults = await searchService.IntelligentSearchAsync(
                     query,
-                    region: region,
+                    region: resolvedRegion,
                     language: null,
                     ct: cancellationToken);
 
@@ -60,7 +63,7 @@ namespace Listenarr.Api.Features.Search
                     return SearchByTitleWorkflowResult.Ok(new List<object>());
                 }
 
-                var results = BuildDiscordTitleResults(searchResults.Take(limit));
+                var results = BuildDiscordTitleResults(searchResults.Take(limit), resolvedRegion);
 
                 logger.LogInformation("Successfully fetched {Count} enriched results for title search: {Query}", results.Count, query);
                 return SearchByTitleWorkflowResult.Ok(results);
@@ -85,7 +88,7 @@ namespace Listenarr.Api.Features.Search
                     {
                         metadata = audible,
                         source = "Audible",
-                        sourceUrl = "https://www.audible.com"
+                        sourceUrl = GetAudibleBaseUrl(region)
                     };
                     return new List<object> { metadataObj };
                 }
@@ -113,7 +116,7 @@ namespace Listenarr.Api.Features.Search
             return null;
         }
 
-        private List<object> BuildDiscordTitleResults(IEnumerable<MetadataSearchResult> searchResults)
+        private List<object> BuildDiscordTitleResults(IEnumerable<MetadataSearchResult> searchResults, string region)
         {
             var results = new List<object>();
 
@@ -141,7 +144,7 @@ namespace Listenarr.Api.Features.Search
                     {
                         metadata,
                         source = searchResult.MetadataSource ?? searchResult.Source ?? "Amazon/Audible",
-                        sourceUrl = "https://www.amazon.com"
+                        sourceUrl = GetAudibleBaseUrl(region)
                     });
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
@@ -159,6 +162,37 @@ namespace Listenarr.Api.Features.Search
             if (s.Length != 10) return false;
             if (!(s.StartsWith("B0") || char.IsDigit(s[0]))) return false;
             return s.All(char.IsLetterOrDigit);
+        }
+
+        private async Task<string> ResolveSearchRegionAsync(string? requestedRegion)
+        {
+            if (!string.IsNullOrWhiteSpace(requestedRegion))
+            {
+                return requestedRegion.Trim();
+            }
+
+            if (configurationService != null)
+            {
+                try
+                {
+                    var settings = await configurationService.GetApplicationSettingsAsync().ConfigureAwait(false);
+                    if (!string.IsNullOrWhiteSpace(settings?.DefaultSearchRegion))
+                    {
+                        return settings.DefaultSearchRegion.Trim();
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+                {
+                    logger.LogWarning(ex, "Failed to resolve configured default search region; falling back to us");
+                }
+            }
+
+            return "us";
+        }
+
+        private static string GetAudibleBaseUrl(string region)
+        {
+            return $"https://{MarketDomainResolver.GetAudibleDomain(region)}";
         }
     }
 

--- a/listenarr.api/Features/Search/SearchByTitleWorkflow.cs
+++ b/listenarr.api/Features/Search/SearchByTitleWorkflow.cs
@@ -144,7 +144,7 @@ namespace Listenarr.Api.Features.Search
                     {
                         metadata,
                         source = searchResult.MetadataSource ?? searchResult.Source ?? "Amazon/Audible",
-                        sourceUrl = GetAudibleBaseUrl(region)
+                        sourceUrl = GetMetadataSourceBaseUrl(searchResult.MetadataSource ?? searchResult.Source, region)
                     });
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
@@ -193,6 +193,21 @@ namespace Listenarr.Api.Features.Search
         private static string GetAudibleBaseUrl(string region)
         {
             return $"https://{MarketDomainResolver.GetAudibleDomain(region)}";
+        }
+
+        private static string GetAmazonBaseUrl(string region)
+        {
+            return $"https://{MarketDomainResolver.GetAmazonDomain(region)}";
+        }
+
+        private static string GetMetadataSourceBaseUrl(string? source, string region)
+        {
+            var isAmazon = source?.Contains("amazon", StringComparison.OrdinalIgnoreCase) == true;
+            var isAudible = source?.Contains("audible", StringComparison.OrdinalIgnoreCase) == true;
+
+            return isAmazon && !isAudible
+                ? GetAmazonBaseUrl(region)
+                : GetAudibleBaseUrl(region);
         }
     }
 

--- a/listenarr.api/Features/Search/SearchController.cs
+++ b/listenarr.api/Features/Search/SearchController.cs
@@ -35,6 +35,7 @@ namespace Listenarr.Api.Features.Search
         private readonly StructuredSearchWorkflow _structuredSearchWorkflow;
         private readonly SearchByTitleWorkflow _searchByTitleWorkflow;
         private readonly IDownloadReferenceService? _downloadReferenceService;
+        private readonly IConfigurationService? _configurationService;
 
         public SearchController(
             ISearchService searchService,
@@ -46,7 +47,8 @@ namespace Listenarr.Api.Features.Search
             SearchResponseMapper? responseMapper = null,
             StructuredSearchWorkflow? structuredSearchWorkflow = null,
             SearchByTitleWorkflow? searchByTitleWorkflow = null,
-            IDownloadReferenceService? downloadReferenceService = null)
+            IDownloadReferenceService? downloadReferenceService = null,
+            IConfigurationService? configurationService = null)
         {
             _searchService = searchService;
             _logger = logger;
@@ -58,6 +60,7 @@ namespace Listenarr.Api.Features.Search
                 metadataService,
                 Microsoft.Extensions.Logging.Abstractions.NullLogger<SearchResponseMapper>.Instance,
                 imageCacheService);
+            _configurationService = configurationService;
             _structuredSearchWorkflow = structuredSearchWorkflow ?? new StructuredSearchWorkflow(
                 searchService,
                 Microsoft.Extensions.Logging.Abstractions.NullLogger<StructuredSearchWorkflow>.Instance,
@@ -65,7 +68,8 @@ namespace Listenarr.Api.Features.Search
                 metadataService,
                 imageCacheService,
                 metadataConvertersInstance,
-                _responseMapper);
+                _responseMapper,
+                configurationService);
             _searchByTitleWorkflow = searchByTitleWorkflow ?? new SearchByTitleWorkflow(
                 searchService,
                 audibleService,
@@ -203,7 +207,9 @@ namespace Listenarr.Api.Features.Search
                 }
 
                 _logger.LogInformation("IntelligentSearch called for query: {Query}", LogRedaction.SanitizeText(query));
-                var region = Request.Query.TryGetValue("region", out var regionValue) ? regionValue.ToString() ?? "us" : "us";
+                var region = Request.Query.TryGetValue("region", out var regionValue)
+                    ? regionValue.ToString() ?? "us"
+                    : await ResolveSearchRegionAsync(null);
                 var language = Request.Query.TryGetValue("language", out var languageValue) ? languageValue.ToString() : null;
                 var results = await _searchService.IntelligentSearchAsync(query, candidateLimit, returnLimit, containmentMode, requireAuthorAndPublisher, fuzzyThreshold, region, language, HttpContext.RequestAborted);
                 await _responseMapper.NormalizeMetadataResultImagesAsync(results, HttpContext, "metadata result");
@@ -215,6 +221,32 @@ namespace Listenarr.Api.Features.Search
                 _logger.LogError(ex, "Error performing intelligent search for query: {Query}", LogRedaction.SanitizeText(query));
                 return StatusCode(500, "Internal server error");
             }
+        }
+
+        private async Task<string> ResolveSearchRegionAsync(string? requestedRegion)
+        {
+            if (!string.IsNullOrWhiteSpace(requestedRegion))
+            {
+                return requestedRegion.Trim();
+            }
+
+            if (_configurationService != null)
+            {
+                try
+                {
+                    var settings = await _configurationService.GetApplicationSettingsAsync().ConfigureAwait(false);
+                    if (!string.IsNullOrWhiteSpace(settings?.DefaultSearchRegion))
+                    {
+                        return settings.DefaultSearchRegion.Trim();
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+                {
+                    _logger.LogWarning(ex, "Failed to resolve configured default search region; falling back to us");
+                }
+            }
+
+            return "us";
         }
 
         /// <summary>

--- a/listenarr.api/Features/Search/SearchController.cs
+++ b/listenarr.api/Features/Search/SearchController.cs
@@ -188,13 +188,6 @@ namespace Listenarr.Api.Features.Search
         {
             try
             {
-                // Debug: log raw incoming query to help integration-test diagnostics
-                try { _logger.LogDebug("[DEBUG] IntelligentSearch called with query='{Query}'", LogRedaction.SanitizeText(query ?? "<null>")); }
-                catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
-                {
-                    System.Diagnostics.Debug.WriteLine($"SearchController IntelligentSearch debug logging failed: {ex.Message}");
-                }
-
                 if (string.IsNullOrEmpty(query))
                 {
                     return BadRequest("Query parameter is required");
@@ -353,33 +346,6 @@ namespace Listenarr.Api.Features.Search
             }
         }
 
-        // [HttpGet("indexers")]
-        // public async Task<ActionResult<List<SearchResult>>> SearchIndexers(
-        //     [FromQuery] string query,
-        //     [FromQuery] string? category = null)
-        // {
-        //     try
-        //     {
-        //         if (string.IsNullOrEmpty(query))
-        //         {
-        //             return BadRequest("Query parameter is required");
-        //         }
-
-        //         var results = await _searchService.SearchIndexersAsync(query, category);
-        // Optional tuning parameters exposed to callers
-        //var candidateLimit = int.TryParse(Request.Query["candidateLimit"], out var cl) ? Math.Clamp(cl, 5, 200) : 50;
-        //var returnLimit = int.TryParse(Request.Query["returnLimit"], out var rl) ? Math.Clamp(rl, 1, 100) : 10;
-        //var containmentMode = Request.Query.ContainsKey("containmentMode") ? Request.Query["containmentMode"].ToString() ?? "Relaxed" : "Relaxed";
-        //var requireAuthorAndPublisher = bool.TryParse(Request.Query["requireAuthorAndPublisher"], out var rap) ? rap : false;
-        //var fuzzyThreshold = double.TryParse(Request.Query["fuzzyThreshold"], out var ft) ? Math.Clamp(ft, 0.0, 1.0) : 0.7;
-        //         return Ok(results);
-        //     }
-        //     catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException) //     {
-        //         _logger.LogError(ex, "Error searching indexers for query: {Query}", query);
-        //         return StatusCode(500, "Internal server error");
-        //     }
-        // }
-
         /// <summary>
         /// Search the Audible catalog for audiobooks.
         /// </summary>
@@ -433,7 +399,6 @@ namespace Listenarr.Api.Features.Search
             };
         }
 
-        // existing code continuation
         /// <summary>
         /// Search a specific API by ID
         /// Note: This route uses a parameter and must come after all specific routes to avoid conflicts

--- a/listenarr.api/Features/Search/SearchController.cs
+++ b/listenarr.api/Features/Search/SearchController.cs
@@ -195,13 +195,6 @@ namespace Listenarr.Api.Features.Search
                     System.Diagnostics.Debug.WriteLine($"SearchController IntelligentSearch debug logging failed: {ex.Message}");
                 }
 
-                // Also emit a warning-level log so test output captures the value
-                try { _logger.LogWarning("[DBG] IntelligentSearch called with query='{Query}'", LogRedaction.SanitizeText(query ?? "<null>")); }
-                catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
-                {
-                    System.Diagnostics.Debug.WriteLine($"SearchController IntelligentSearch warning logging failed: {ex.Message}");
-                }
-
                 if (string.IsNullOrEmpty(query))
                 {
                     return BadRequest("Query parameter is required");

--- a/listenarr.api/Features/Search/SearchController.cs
+++ b/listenarr.api/Features/Search/SearchController.cs
@@ -74,7 +74,8 @@ namespace Listenarr.Api.Features.Search
                 searchService,
                 audibleService,
                 metadataService,
-                Microsoft.Extensions.Logging.Abstractions.NullLogger<SearchByTitleWorkflow>.Instance);
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<SearchByTitleWorkflow>.Instance,
+                configurationService);
             _downloadReferenceService = downloadReferenceService;
         }
 
@@ -427,7 +428,7 @@ namespace Listenarr.Api.Features.Search
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult<List<object>>> SearchByTitle(
             [FromQuery] string query,
-            [FromQuery] string region = "us",
+            [FromQuery] string? region = null,
             [FromQuery] int limit = 10)
         {
             var result = await _searchByTitleWorkflow.ExecuteAsync(query, region, limit, HttpContext.RequestAborted);

--- a/listenarr.api/Features/Search/SearchResponseMapper.cs
+++ b/listenarr.api/Features/Search/SearchResponseMapper.cs
@@ -68,14 +68,22 @@ public sealed class SearchResponseMapper
         }).Cast<object>().ToList() ?? new List<object>();
     }
 
-    public void SanitizeResultForPublicApi(SearchResult r)
+    public void SanitizeResultForPublicApi(SearchResult r, string region = "us")
     {
         try
         {
             if (r == null) return;
             if (string.IsNullOrWhiteSpace(r.ProductUrl) && !string.IsNullOrWhiteSpace(r.Asin))
             {
-                r.ProductUrl = $"https://www.amazon.com/dp/{r.Asin}";
+                r.ProductUrl = MarketDomainResolver.BuildAmazonProductUrl(r.Asin, region);
+            }
+
+            var sourceText = $"{r.Source} {r.MetadataSource}";
+            if (!string.IsNullOrWhiteSpace(r.Asin) &&
+                sourceText.Contains("Audible", StringComparison.OrdinalIgnoreCase))
+            {
+                r.ProductUrl = NormalizeAudibleProductUrl(r.ProductUrl, r.Asin, region);
+                r.SourceLink = NormalizeAudibleProductUrl(r.SourceLink, r.Asin, region);
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
@@ -198,7 +206,9 @@ public sealed class SearchResponseMapper
             releaseDate = book.ReleaseDate,
             @explicit = false,
             hasPdf = false,
-            link = !string.IsNullOrWhiteSpace(book.Asin) ? $"https://www.audible.com/pd/{book.Asin}" : (string?)null,
+            link = !string.IsNullOrWhiteSpace(book.Asin)
+                ? MarketDomainResolver.BuildAudibleProductUrl(book.Asin, region)
+                : (string?)null,
             sku = book.Sku,
             isListenable = !string.IsNullOrWhiteSpace(book.Asin),
             isAvailable = true,
@@ -266,7 +276,7 @@ public sealed class SearchResponseMapper
             releaseDate = md?.PublishedDate,
             @explicit = false,
             hasPdf = false,
-            link = md?.ProductUrl,
+            link = NormalizeAudibleProductUrl(md?.ProductUrl, md?.Asin, region),
             sku = (string?)null,
             skuGroup = (string?)null,
             isListenable = !string.IsNullOrWhiteSpace(md?.Asin),
@@ -400,9 +410,7 @@ public sealed class SearchResponseMapper
             releaseDate = aud.ReleaseDate ?? aud.PublishDate ?? md?.PublishedDate,
             @explicit = aud.Explicit ?? false,
             hasPdf = false,
-            link = !string.IsNullOrWhiteSpace(md?.ProductUrl)
-                ? md.ProductUrl
-                : !string.IsNullOrWhiteSpace(aud.Asin) ? $"https://www.audible.com/pd/{aud.Asin}" : null,
+            link = NormalizeAudibleProductUrl(md?.ProductUrl, aud.Asin ?? md?.Asin, aud.Region ?? region),
             sku = aud.Sku,
             skuGroup = (string?)null,
             isListenable = !string.IsNullOrWhiteSpace(aud.Asin ?? md?.Asin),
@@ -417,5 +425,55 @@ public sealed class SearchResponseMapper
             seriesList = series.Select(s => $"{s.name}{(s.position != null ? $" #{s.position}" : "")}").ToList(),
             updatedAt = DateTime.UtcNow.ToString("o")
         };
+    }
+
+    private static string? NormalizeAudibleProductUrl(string? url, string? asin, string? region)
+    {
+        if (!string.IsNullOrWhiteSpace(asin))
+        {
+            return MarketDomainResolver.BuildAudibleProductUrl(asin, region);
+        }
+
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return null;
+        }
+
+        if (!IsAudibleUrl(url))
+        {
+            return url;
+        }
+
+        return RegionalizeAudibleUrl(url, region);
+    }
+
+    private static bool IsAudibleUrl(string? url)
+    {
+        return !string.IsNullOrWhiteSpace(url) &&
+            Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+            IsAudibleHost(uri.Host);
+    }
+
+    private static bool IsAudibleHost(string host)
+    {
+        var normalized = host.Trim().ToLowerInvariant();
+        return normalized.StartsWith("audible.", StringComparison.Ordinal) ||
+               normalized.StartsWith("www.audible.", StringComparison.Ordinal) ||
+               normalized.StartsWith("api.audible.", StringComparison.Ordinal);
+    }
+
+    private static string RegionalizeAudibleUrl(string url, string? region)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return url;
+        }
+
+        var builder = new UriBuilder(uri)
+        {
+            Host = MarketDomainResolver.GetAudibleDomain(region)
+        };
+
+        return builder.Uri.ToString();
     }
 }

--- a/listenarr.api/Features/Search/StructuredSearchWorkflow.cs
+++ b/listenarr.api/Features/Search/StructuredSearchWorkflow.cs
@@ -209,7 +209,7 @@ namespace Listenarr.Api.Features.Search
 
             try
             {
-                var audible = await _audibleService.GetBookMetadataAsync(req.Asin, region, true);
+                var audible = await _audibleService.GetBookMetadataAsync(req.Asin, region, true, language);
                 if (audible != null)
                 {
                     var metadata = _metadataConverters.ConvertAudibleToMetadata(audible, req.Asin, source: "Audible");

--- a/listenarr.api/Features/Search/StructuredSearchWorkflow.cs
+++ b/listenarr.api/Features/Search/StructuredSearchWorkflow.cs
@@ -214,7 +214,7 @@ namespace Listenarr.Api.Features.Search
                 {
                     var metadata = _metadataConverters.ConvertAudibleToMetadata(audible, req.Asin, source: "Audible");
                     var sr = await _metadataConverters.ConvertMetadataToSearchResultAsync(metadata, req.Asin, req.Title, req.Author, fallbackImageUrl: null, fallbackLanguage: language);
-                    _responseMapper.SanitizeResultForPublicApi(sr);
+                    _responseMapper.SanitizeResultForPublicApi(sr, region);
                     var md = SearchResultConverters.ToMetadata(sr);
                     await SearchResultImageNormalizer.NormalizeMetadataResultAsync(
                         md,

--- a/listenarr.api/Features/Search/StructuredSearchWorkflow.cs
+++ b/listenarr.api/Features/Search/StructuredSearchWorkflow.cs
@@ -21,6 +21,7 @@ namespace Listenarr.Api.Features.Search
         private readonly MetadataConverters _metadataConverters;
         private readonly SearchResponseMapper _responseMapper;
         private readonly SearchRequestReader _requestReader;
+        private readonly IConfigurationService? _configurationService;
 
         public StructuredSearchWorkflow(
             ISearchService searchService,
@@ -29,12 +30,14 @@ namespace Listenarr.Api.Features.Search
             IAudiobookMetadataService metadataService,
             IImageCacheService? imageCacheService = null,
             MetadataConverters? metadataConverters = null,
-            SearchResponseMapper? responseMapper = null)
+            SearchResponseMapper? responseMapper = null,
+            IConfigurationService? configurationService = null)
         {
             _searchService = searchService;
             _logger = logger;
             _audibleService = audibleService;
             _imageCacheService = imageCacheService;
+            _configurationService = configurationService;
             _metadataConverters = metadataConverters ?? new MetadataConverters(imageCacheService, Microsoft.Extensions.Logging.Abstractions.NullLogger<MetadataConverters>.Instance);
             _responseMapper = responseMapper ?? new SearchResponseMapper(
                 metadataService,
@@ -60,10 +63,10 @@ namespace Listenarr.Api.Features.Search
 
                 if (req.Mode == SearchMode.Simple)
                 {
-                    return await ExecuteSimpleSearchAsync(req, httpContext);
+                    return await ExecuteSimpleSearchAsync(req, JsonObjectHasProperty(reqJson, "region"), httpContext);
                 }
 
-                return await ExecuteAdvancedSearchAsync(req, useSimplified, httpContext);
+                return await ExecuteAdvancedSearchAsync(req, useSimplified, JsonObjectHasProperty(reqJson, "region"), httpContext);
             }
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
             {
@@ -72,10 +75,10 @@ namespace Listenarr.Api.Features.Search
             }
         }
 
-        private async Task<StructuredSearchWorkflowResult> ExecuteSimpleSearchAsync(SearchRequest req, HttpContext httpContext)
+        private async Task<StructuredSearchWorkflowResult> ExecuteSimpleSearchAsync(SearchRequest req, bool hasRequestedRegion, HttpContext httpContext)
         {
             var q = req.Query ?? string.Empty;
-            var region = string.IsNullOrWhiteSpace(req.Region) ? "us" : req.Region;
+            var region = await ResolveSearchRegionAsync(hasRequestedRegion ? req.Region : null);
             var language = string.IsNullOrWhiteSpace(req.Language) ? null : req.Language;
             var results = await _searchService.IntelligentSearchAsync(q, region: region, language: language, ct: httpContext.RequestAborted) ?? new List<MetadataSearchResult>();
 
@@ -92,7 +95,7 @@ namespace Listenarr.Api.Features.Search
             return StructuredSearchWorkflowResult.Ok(mapped);
         }
 
-        private async Task<StructuredSearchWorkflowResult> ExecuteAdvancedSearchAsync(SearchRequest req, bool useSimplified, HttpContext httpContext)
+        private async Task<StructuredSearchWorkflowResult> ExecuteAdvancedSearchAsync(SearchRequest req, bool useSimplified, bool hasRequestedRegion, HttpContext httpContext)
         {
             var advancedValidationError = _requestReader.NormalizeAdvancedRequest(req);
             if (!string.IsNullOrWhiteSpace(advancedValidationError))
@@ -100,7 +103,7 @@ namespace Listenarr.Api.Features.Search
                 return StructuredSearchWorkflowResult.BadRequest(advancedValidationError);
             }
 
-            var region = string.IsNullOrWhiteSpace(req.Region) ? "us" : req.Region;
+            var region = await ResolveSearchRegionAsync(hasRequestedRegion ? req.Region : null);
             var language = string.IsNullOrWhiteSpace(req.Language) ? null : req.Language;
 
             if (string.IsNullOrWhiteSpace(req.Title)
@@ -151,6 +154,50 @@ namespace Listenarr.Api.Features.Search
             {
                 System.Diagnostics.Debug.WriteLine($"SearchController advanced-search debug logging failed: {ex.Message}");
             }
+        }
+
+        private static bool JsonObjectHasProperty(JsonElement element, string propertyName)
+        {
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            foreach (var property in element.EnumerateObject())
+            {
+                if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private async Task<string> ResolveSearchRegionAsync(string? requestedRegion)
+        {
+            if (!string.IsNullOrWhiteSpace(requestedRegion))
+            {
+                return requestedRegion.Trim();
+            }
+
+            if (_configurationService != null)
+            {
+                try
+                {
+                    var settings = await _configurationService.GetApplicationSettingsAsync().ConfigureAwait(false);
+                    if (!string.IsNullOrWhiteSpace(settings?.DefaultSearchRegion))
+                    {
+                        return settings.DefaultSearchRegion.Trim();
+                    }
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+                {
+                    _logger.LogWarning(ex, "Failed to resolve configured default search region; falling back to us");
+                }
+            }
+
+            return "us";
         }
 
         private async Task<StructuredSearchWorkflowResult?> TryExecuteAsinSearchAsync(SearchRequest req, bool useSimplified, string region, string? language, HttpContext httpContext)

--- a/listenarr.api/GlobalUsings.cs
+++ b/listenarr.api/GlobalUsings.cs
@@ -24,6 +24,7 @@ global using Listenarr.Application.Notifications.Contracts;
 global using Listenarr.Application.Realtime.Contracts;
 global using Listenarr.Application.Search.Contracts;
 global using Listenarr.Application.Search.Contracts.Repositories;
+global using Listenarr.Application.Search;
 global using Listenarr.Application.Security.Contracts;
 global using Listenarr.Application.SystemDiagnostics.Contracts;
 global using Listenarr.Application.Audiobooks.RootFolders;

--- a/listenarr.application/Audiobooks/Catalog/LibraryAddService.cs
+++ b/listenarr.application/Audiobooks/Catalog/LibraryAddService.cs
@@ -126,7 +126,7 @@ namespace Listenarr.Application.Audiobooks.Catalog
             audiobook.ImageUrl = imageUrl;
             audiobook.Monitored = request.Monitored;
 
-            AudiobookIdentifierMapper.SyncImportedIdentifiersFromLegacyFields(audiobook);
+            AudiobookIdentifierMapper.SyncImportedIdentifiersFromLegacyFields(audiobook, metadata.Region);
 
             if (request.QualityProfileId.HasValue)
             {

--- a/listenarr.application/Audiobooks/Identifiers/AudiobookIdentifierMapper.cs
+++ b/listenarr.application/Audiobooks/Identifiers/AudiobookIdentifierMapper.cs
@@ -49,10 +49,12 @@ public static class AudiobookIdentifierMapper
 
     public static List<AudiobookExternalIdentifier> BuildLegacyBackfillIdentifiers(
         Audiobook audiobook,
-        AudiobookExternalIdentifierSource source)
+        AudiobookExternalIdentifierSource source,
+        string? asinRegion = null)
     {
         var now = DateTime.UtcNow;
         var result = new List<AudiobookExternalIdentifier>();
+        var normalizedAsinRegion = AudiobookIdentifierNormalizer.NormalizeRegion(asinRegion);
 
         if (!string.IsNullOrWhiteSpace(audiobook.Asin) &&
             AudiobookIdentifierNormalizer.TryNormalize(AudiobookExternalIdentifierType.Asin, audiobook.Asin, out var normalizedAsin, out _))
@@ -62,7 +64,7 @@ public static class AudiobookIdentifierMapper
                 Type = AudiobookExternalIdentifierType.Asin,
                 ValueRaw = AudiobookIdentifierNormalizer.NormalizeRawValueForStorage(audiobook.Asin),
                 ValueNormalized = normalizedAsin,
-                Region = null,
+                Region = normalizedAsinRegion,
                 IsPrimary = true,
                 Source = source,
                 CreatedAt = now,
@@ -202,7 +204,7 @@ public static class AudiobookIdentifierMapper
         audiobook.OpenLibraryId = primaryOlid?.ValueNormalized;
     }
 
-    public static void SyncImportedIdentifiersFromLegacyFields(Audiobook audiobook)
+    public static void SyncImportedIdentifiersFromLegacyFields(Audiobook audiobook, string? asinRegion = null)
     {
         audiobook.ExternalIdentifiers ??= new List<AudiobookExternalIdentifier>();
 
@@ -217,7 +219,7 @@ public static class AudiobookIdentifierMapper
             StringComparer.OrdinalIgnoreCase);
         var seenImportedFullKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        var imported = BuildLegacyBackfillIdentifiers(audiobook, AudiobookExternalIdentifierSource.Imported);
+        var imported = BuildLegacyBackfillIdentifiers(audiobook, AudiobookExternalIdentifierSource.Imported, asinRegion);
         foreach (var item in imported.Where(item =>
                      !string.IsNullOrWhiteSpace(item.ValueNormalized) &&
                      !existingTypeValueKeys.Contains(TypeValueKey(item)) &&

--- a/listenarr.application/GlobalUsings.cs
+++ b/listenarr.application/GlobalUsings.cs
@@ -22,6 +22,7 @@ global using Listenarr.Application.Notifications.Contracts;
 global using Listenarr.Application.Realtime.Contracts;
 global using Listenarr.Application.Search.Contracts;
 global using Listenarr.Application.Search.Contracts.Repositories;
+global using Listenarr.Application.Search;
 global using Listenarr.Application.Security.Contracts;
 global using Listenarr.Application.Security.Contracts.Repositories;
 global using Listenarr.Application.SystemDiagnostics.Contracts;

--- a/listenarr.application/Metadata/Audible/AudibleRequestHelper.cs
+++ b/listenarr.application/Metadata/Audible/AudibleRequestHelper.cs
@@ -117,18 +117,6 @@ public static class AudibleRequestHelper
 
     public static string GetBaseUrl(string region)
     {
-        return region?.Trim().ToLowerInvariant() switch
-        {
-            "au" => "https://www.audible.com.au",
-            "ca" => "https://www.audible.ca",
-            "de" => "https://www.audible.de",
-            "es" => "https://www.audible.es",
-            "fr" => "https://www.audible.fr",
-            "in" => "https://www.audible.in",
-            "it" => "https://www.audible.it",
-            "jp" => "https://www.audible.co.jp",
-            "uk" => "https://www.audible.co.uk",
-            _ => "https://www.audible.com"
-        };
+        return $"https://{MarketDomainResolver.GetAudibleDomain(region)}";
     }
 }

--- a/listenarr.application/Search/Audible/AsinEnricher.cs
+++ b/listenarr.application/Search/Audible/AsinEnricher.cs
@@ -58,6 +58,7 @@ public class AsinEnricher
         Dictionary<string, OpenLibraryBook> asinToOpenLibrary,
         List<ApiConfiguration> metadataSources,
         string? query,
+        string? region = null,
         CancellationToken ct = default)
     {
         using var semaphore = new AsyncNonKeyedLocker(5); // Increased from 3 to 5 for better throughput
@@ -154,7 +155,7 @@ public class AsinEnricher
                         ct.ThrowIfCancellationRequested();
                         await _searchProgressReporter.BroadcastAsync($"Fetching metadata for ASIN: {asin}", asin);
                         (metadata, metadataSourceName) = await _metadataStrategyCoordinator.FetchMetadataAsync(
-                            asin, metadataSources, originalSource);
+                            asin, metadataSources, originalSource, region);
                     }
 
                     // If all metadata sources failed, queue for fallback handling
@@ -171,6 +172,7 @@ public class AsinEnricher
 
                     if (metadata != null)
                     {
+                        metadata.Region ??= AudiobookIdentifierNormalizer.NormalizeRegion(region);
                         // Accept metadata even if Title is missing. ConvertMetadataToSearchResult
                         // will use raw result title as fallback if metadata title is empty.
                         var enrichedResult = await _metadataConverters.ConvertMetadataToSearchResultAsync(metadata, asin, rawResult.Title, rawResult.Author, rawResult.ImageUrl, rawResult.Language);
@@ -248,4 +250,3 @@ public record EnrichmentResult(
     List<SearchResult> EnrichedResults,
     List<string> AsinsNeedingFallback,
     ConcurrentDictionary<string, string> CandidateDropReasons);
-

--- a/listenarr.application/Search/Audible/AsinSearchHandler.cs
+++ b/listenarr.application/Search/Audible/AsinSearchHandler.cs
@@ -55,7 +55,7 @@ public class AsinSearchHandler
     public async Task<List<SearchResult>> SearchByAsinAsync(
         string asin,
         List<ApiConfiguration> metadataSources,
-        string region = "us",
+        string? region = null,
         string? language = null,
         CancellationToken ct = default)
     {

--- a/listenarr.application/Search/Audible/AsinSearchHandler.cs
+++ b/listenarr.application/Search/Audible/AsinSearchHandler.cs
@@ -127,6 +127,7 @@ public class AsinSearchHandler
         if (metadata != null)
         {
             await _searchProgressReporter.BroadcastAsync($"Found audiobook: {metadata.Title}", null);
+            metadata.Region ??= safeRegion;
             var result = await _metadataConverters.ConvertMetadataToSearchResultAsync(metadata, asin, null, null, null);
             _logger.LogInformation("Converted metadata to SearchResult: Title={Title}, Series={Series}, SeriesNumber={SeriesNumber}",
                 result.Title, result.Series, result.SeriesNumber);

--- a/listenarr.application/Search/Audible/AsinSearchHandler.cs
+++ b/listenarr.application/Search/Audible/AsinSearchHandler.cs
@@ -137,18 +137,18 @@ public class AsinSearchHandler
             if (metadataSourceName == "Amazon")
             {
                 result.Source = "Amazon";
-                result.SourceLink = result.ProductUrl ?? BuildAmazonProductUrl(asin, metadata.Region ?? safeRegion);
+                result.SourceLink = result.ProductUrl ?? MarketDomainResolver.BuildAmazonProductUrl(asin, metadata.Region ?? safeRegion);
             }
             else if (metadataSourceName == "Audible")
             {
                 result.Source = "Audible";
-                result.SourceLink = result.ProductUrl ?? BuildAudibleProductUrl(asin, metadata.Region ?? safeRegion);
+                result.SourceLink = result.ProductUrl ?? MarketDomainResolver.BuildAudibleProductUrl(asin, metadata.Region ?? safeRegion);
             }
             else
             {
                 // Metadata API source - default to Audible for product link
                 result.Source = "Audible";
-                result.SourceLink = result.ProductUrl ?? BuildAudibleProductUrl(asin, metadata.Region ?? safeRegion);
+                result.SourceLink = result.ProductUrl ?? MarketDomainResolver.BuildAudibleProductUrl(asin, metadata.Region ?? safeRegion);
             }
 
             // Validate result before returning
@@ -173,49 +173,4 @@ public class AsinSearchHandler
         return new List<SearchResult>();
     }
 
-    private static string BuildAmazonProductUrl(string asin, string? region)
-    {
-        return $"https://{GetAmazonDomain(region)}/dp/{Uri.EscapeDataString(asin)}";
-    }
-
-    private static string BuildAudibleProductUrl(string asin, string? region)
-    {
-        return $"https://{GetAudibleDomain(region)}/pd/{Uri.EscapeDataString(asin)}";
-    }
-
-    private static string GetAmazonDomain(string? region)
-    {
-        return region?.Trim().ToLowerInvariant() switch
-        {
-            "au" => "www.amazon.com.au",
-            "br" => "www.amazon.com.br",
-            "ca" => "www.amazon.ca",
-            "de" => "www.amazon.de",
-            "es" => "www.amazon.es",
-            "fr" => "www.amazon.fr",
-            "in" => "www.amazon.in",
-            "it" => "www.amazon.it",
-            "jp" => "www.amazon.co.jp",
-            "uk" or "gb" => "www.amazon.co.uk",
-            _ => "www.amazon.com"
-        };
-    }
-
-    private static string GetAudibleDomain(string? region)
-    {
-        return region?.Trim().ToLowerInvariant() switch
-        {
-            "au" => "www.audible.com.au",
-            "br" => "www.audible.com.br",
-            "ca" => "www.audible.ca",
-            "de" => "www.audible.de",
-            "es" => "www.audible.es",
-            "fr" => "www.audible.fr",
-            "in" => "www.audible.in",
-            "it" => "www.audible.it",
-            "jp" => "www.audible.co.jp",
-            "uk" or "gb" => "www.audible.co.uk",
-            _ => "www.audible.com"
-        };
-    }
 }

--- a/listenarr.application/Search/Audible/AsinSearchHandler.cs
+++ b/listenarr.application/Search/Audible/AsinSearchHandler.cs
@@ -55,11 +55,14 @@ public class AsinSearchHandler
     public async Task<List<SearchResult>> SearchByAsinAsync(
         string asin,
         List<ApiConfiguration> metadataSources,
+        string region = "us",
+        string? language = null,
         CancellationToken ct = default)
     {
         _logger.LogInformation("Processing direct ASIN query: {Asin}", asin);
         await _searchProgressReporter.BroadcastAsync($"Extracting ASIN: {asin}", null);
 
+        var safeRegion = AudiobookIdentifierNormalizer.NormalizeRegion(region) ?? "us";
 
         // Initialize metadata variables
         AudibleBookMetadata? metadata = null;
@@ -71,7 +74,7 @@ public class AsinSearchHandler
 
         try
         {
-            var audibleData = await _audibleService.GetBookMetadataAsync(asin, "us", true);
+            var audibleData = await _audibleService.GetBookMetadataAsync(asin, safeRegion, true, language);
             if (audibleData != null)
             {
                 metadata = _metadataConverters.ConvertAudibleToMetadata(audibleData, asin, "Audible");
@@ -102,7 +105,7 @@ public class AsinSearchHandler
                     {
                         _logger.LogInformation("Attempting Audnexus for ASIN {Asin}", asin);
                         await _searchProgressReporter.BroadcastAsync($"Searching Audnexus for {asin}", null);
-                        var audnexusData = await _audnexusService.GetBookMetadataAsync(asin, "us", true, false);
+                        var audnexusData = await _audnexusService.GetBookMetadataAsync(asin, safeRegion, true, false);
                         if (audnexusData != null)
                         {
                             metadata = _metadataConverters.ConvertAudnexusToMetadata(audnexusData, asin, "Audible");
@@ -134,18 +137,18 @@ public class AsinSearchHandler
             if (metadataSourceName == "Amazon")
             {
                 result.Source = "Amazon";
-                result.SourceLink = $"https://www.amazon.com/dp/{asin}";
+                result.SourceLink = result.ProductUrl ?? BuildAmazonProductUrl(asin, metadata.Region ?? safeRegion);
             }
             else if (metadataSourceName == "Audible")
             {
                 result.Source = "Audible";
-                result.SourceLink = $"https://www.audible.com/pd/{asin}";
+                result.SourceLink = result.ProductUrl ?? BuildAudibleProductUrl(asin, metadata.Region ?? safeRegion);
             }
             else
             {
                 // Metadata API source - default to Audible for product link
                 result.Source = "Audible";
-                result.SourceLink = $"https://www.audible.com/pd/{asin}";
+                result.SourceLink = result.ProductUrl ?? BuildAudibleProductUrl(asin, metadata.Region ?? safeRegion);
             }
 
             // Validate result before returning
@@ -169,5 +172,50 @@ public class AsinSearchHandler
         // If we reach here, ASIN query failed - return empty list
         return new List<SearchResult>();
     }
-}
 
+    private static string BuildAmazonProductUrl(string asin, string? region)
+    {
+        return $"https://{GetAmazonDomain(region)}/dp/{Uri.EscapeDataString(asin)}";
+    }
+
+    private static string BuildAudibleProductUrl(string asin, string? region)
+    {
+        return $"https://{GetAudibleDomain(region)}/pd/{Uri.EscapeDataString(asin)}";
+    }
+
+    private static string GetAmazonDomain(string? region)
+    {
+        return region?.Trim().ToLowerInvariant() switch
+        {
+            "au" => "www.amazon.com.au",
+            "br" => "www.amazon.com.br",
+            "ca" => "www.amazon.ca",
+            "de" => "www.amazon.de",
+            "es" => "www.amazon.es",
+            "fr" => "www.amazon.fr",
+            "in" => "www.amazon.in",
+            "it" => "www.amazon.it",
+            "jp" => "www.amazon.co.jp",
+            "uk" or "gb" => "www.amazon.co.uk",
+            _ => "www.amazon.com"
+        };
+    }
+
+    private static string GetAudibleDomain(string? region)
+    {
+        return region?.Trim().ToLowerInvariant() switch
+        {
+            "au" => "www.audible.com.au",
+            "br" => "www.audible.com.br",
+            "ca" => "www.audible.ca",
+            "de" => "www.audible.de",
+            "es" => "www.audible.es",
+            "fr" => "www.audible.fr",
+            "in" => "www.audible.in",
+            "it" => "www.audible.it",
+            "jp" => "www.audible.co.jp",
+            "uk" or "gb" => "www.audible.co.uk",
+            _ => "www.audible.com"
+        };
+    }
+}

--- a/listenarr.application/Search/Audible/AudibleAuthorSearchWorkflow.cs
+++ b/listenarr.application/Search/Audible/AudibleAuthorSearchWorkflow.cs
@@ -95,7 +95,8 @@ namespace Listenarr.Application.Search.Audible
                     Series = book.Series,
                     Publisher = book.Publisher,
                     Narrators = book.Narrators,
-                    ReleaseDate = book.ReleaseDate
+                    ReleaseDate = book.ReleaseDate,
+                    Region = region
                 };
                 var metadata = _metadataConverters.ConvertAudibleToMetadata(bookResponse, book.Asin!, "Audible");
                 var searchResult = await _metadataConverters.ConvertMetadataToSearchResultAsync(metadata, book.Asin!);
@@ -170,6 +171,7 @@ namespace Listenarr.Application.Search.Audible
             var converted = await AudibleSearchResultMapper.ConvertToSearchResultsAsync(
                 authorFiltered,
                 _metadataConverters,
+                region,
                 detailedMetaByAsin,
                 _logger,
                 continueOnConversionError: true);

--- a/listenarr.application/Search/Audible/AudibleSearchResultMapper.cs
+++ b/listenarr.application/Search/Audible/AudibleSearchResultMapper.cs
@@ -25,6 +25,7 @@ namespace Listenarr.Application.Search.Audible
         public static async Task<List<SearchResult>> ConvertToSearchResultsAsync(
             IEnumerable<AudibleSearchResult> books,
             MetadataConverters metadataConverters,
+            string region,
             IReadOnlyDictionary<string, AudibleBookResponse>? detailedMetadataByAsin = null,
             ILogger? logger = null,
             bool continueOnConversionError = false)
@@ -38,7 +39,7 @@ namespace Listenarr.Application.Search.Audible
                     var bookResponse = detailedMetadataByAsin != null &&
                                        detailedMetadataByAsin.TryGetValue(book.Asin!, out var detailed)
                         ? detailed
-                        : ToBookResponse(book);
+                        : ToBookResponse(book, region);
 
                     var metadata = metadataConverters.ConvertAudibleToMetadata(bookResponse, book.Asin!, "Audible");
                     var result = await metadataConverters.ConvertMetadataToSearchResultAsync(metadata, book.Asin!);
@@ -59,7 +60,7 @@ namespace Listenarr.Application.Search.Audible
             return converted;
         }
 
-        private static AudibleBookResponse ToBookResponse(AudibleSearchResult book)
+        private static AudibleBookResponse ToBookResponse(AudibleSearchResult book, string region)
         {
             return new AudibleBookResponse
             {
@@ -74,7 +75,8 @@ namespace Listenarr.Application.Search.Audible
                 Series = book.Series,
                 Publisher = book.Publisher,
                 Narrators = book.Narrators,
-                ReleaseDate = book.ReleaseDate
+                ReleaseDate = book.ReleaseDate,
+                Region = region
             };
         }
     }

--- a/listenarr.application/Search/Audible/AudibleSimpleLookupWorkflow.cs
+++ b/listenarr.application/Search/Audible/AudibleSimpleLookupWorkflow.cs
@@ -79,7 +79,8 @@ namespace Listenarr.Application.Search.Audible
                     Publisher = book.Publisher,
                     Narrators = book.Narrators,
                     ReleaseDate = book.ReleaseDate,
-                    Isbn = book.Isbn
+                    Isbn = book.Isbn,
+                    Region = region
                 };
                 var metadata = _metadataConverters.ConvertAudibleToMetadata(bookResponse, book.Asin!, "Audible");
                 var searchResult = await _metadataConverters.ConvertMetadataToSearchResultAsync(metadata, book.Asin!);
@@ -105,7 +106,7 @@ namespace Listenarr.Application.Search.Audible
                 filtered = filtered.Where(b => string.IsNullOrWhiteSpace(b.Language) || string.Equals(b.Language, language, StringComparison.OrdinalIgnoreCase));
             }
 
-            var converted = await AudibleSearchResultMapper.ConvertToSearchResultsAsync(filtered, _metadataConverters);
+            var converted = await AudibleSearchResultMapper.ConvertToSearchResultsAsync(filtered, _metadataConverters, region);
             return converted.Any() ? SearchResultConverters.ToMetadataList(converted) : null;
         }
 
@@ -123,7 +124,7 @@ namespace Listenarr.Application.Search.Audible
                 filtered = filtered.Where(b => string.IsNullOrWhiteSpace(b.Language) || string.Equals(b.Language, language, StringComparison.OrdinalIgnoreCase));
             }
 
-            var converted = await AudibleSearchResultMapper.ConvertToSearchResultsAsync(filtered, _metadataConverters);
+            var converted = await AudibleSearchResultMapper.ConvertToSearchResultsAsync(filtered, _metadataConverters, region);
             return converted.Any() ? SearchResultConverters.ToMetadataList(converted) : null;
         }
     }

--- a/listenarr.application/Search/Core/SearchService.Intelligent.cs
+++ b/listenarr.application/Search/Core/SearchService.Intelligent.cs
@@ -149,6 +149,7 @@ namespace Listenarr.Application.Search.Core
                     asinToOpenLibrary,
                     metadataSources,
                     query,
+                    region,
                     ct);
 
                 var enrichedList = enrichmentResult.EnrichedResults;

--- a/listenarr.application/Search/Core/SearchService.Intelligent.cs
+++ b/listenarr.application/Search/Core/SearchService.Intelligent.cs
@@ -80,7 +80,12 @@ namespace Listenarr.Application.Search.Core
                 if (searchType == "ASIN" && !string.IsNullOrEmpty(asinVal))
                 {
                     var asinMetadataSources = await GetEnabledMetadataSourcesAsync();
-                    var asinSearchResults = await _asinSearchHandler.SearchByAsinAsync(asinVal, asinMetadataSources);
+                    var asinSearchResults = await _asinSearchHandler.SearchByAsinAsync(
+                        asinVal,
+                        asinMetadataSources,
+                        region,
+                        language,
+                        ct);
                     return asinSearchResults.Select(r => SearchResultConverters.ToMetadata(r)).ToList();
                 }
 

--- a/listenarr.application/Search/MarketDomainResolver.cs
+++ b/listenarr.application/Search/MarketDomainResolver.cs
@@ -1,0 +1,69 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Listenarr.Application.Search
+{
+    public static class MarketDomainResolver
+    {
+        public static string BuildAmazonProductUrl(string asin, string? region)
+        {
+            return $"https://{GetAmazonDomain(region)}/dp/{Uri.EscapeDataString(asin)}";
+        }
+
+        public static string BuildAudibleProductUrl(string asin, string? region)
+        {
+            return $"https://{GetAudibleDomain(region)}/pd/{Uri.EscapeDataString(asin)}";
+        }
+
+        public static string GetAmazonDomain(string? region)
+        {
+            return region?.Trim().ToLowerInvariant() switch
+            {
+                "au" => "www.amazon.com.au",
+                "br" => "www.amazon.com.br",
+                "ca" => "www.amazon.ca",
+                "de" => "www.amazon.de",
+                "es" => "www.amazon.es",
+                "fr" => "www.amazon.fr",
+                "in" => "www.amazon.in",
+                "it" => "www.amazon.it",
+                "jp" => "www.amazon.co.jp",
+                "uk" or "gb" => "www.amazon.co.uk",
+                _ => "www.amazon.com"
+            };
+        }
+
+        public static string GetAudibleDomain(string? region)
+        {
+            return region?.Trim().ToLowerInvariant() switch
+            {
+                "au" => "www.audible.com.au",
+                "br" => "www.audible.com.br",
+                "ca" => "www.audible.ca",
+                "de" => "www.audible.de",
+                "es" => "www.audible.es",
+                "fr" => "www.audible.fr",
+                "in" => "www.audible.in",
+                "it" => "www.audible.it",
+                "jp" => "www.audible.co.jp",
+                "uk" or "gb" => "www.audible.co.uk",
+                _ => "www.audible.com"
+            };
+        }
+    }
+}

--- a/listenarr.application/Search/MarketDomainResolver.cs
+++ b/listenarr.application/Search/MarketDomainResolver.cs
@@ -20,6 +20,23 @@ namespace Listenarr.Application.Search
 {
     public static class MarketDomainResolver
     {
+        // Single source of truth: add new markets here once, not twice.
+        private static readonly IReadOnlyDictionary<string, (string Audible, string Amazon)> _markets =
+            new Dictionary<string, (string, string)>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["au"] = ("www.audible.com.au", "www.amazon.com.au"),
+                ["br"] = ("www.audible.com.br", "www.amazon.com.br"),
+                ["ca"] = ("www.audible.ca", "www.amazon.ca"),
+                ["de"] = ("www.audible.de", "www.amazon.de"),
+                ["es"] = ("www.audible.es", "www.amazon.es"),
+                ["fr"] = ("www.audible.fr", "www.amazon.fr"),
+                ["in"] = ("www.audible.in", "www.amazon.in"),
+                ["it"] = ("www.audible.it", "www.amazon.it"),
+                ["jp"] = ("www.audible.co.jp", "www.amazon.co.jp"),
+                ["uk"] = ("www.audible.co.uk", "www.amazon.co.uk"),
+                ["gb"] = ("www.audible.co.uk", "www.amazon.co.uk"),
+            };
+
         public static string BuildAmazonProductUrl(string asin, string? region)
         {
             return $"https://{GetAmazonDomain(region)}/dp/{Uri.EscapeDataString(asin)}";
@@ -32,38 +49,14 @@ namespace Listenarr.Application.Search
 
         public static string GetAmazonDomain(string? region)
         {
-            return region?.Trim().ToLowerInvariant() switch
-            {
-                "au" => "www.amazon.com.au",
-                "br" => "www.amazon.com.br",
-                "ca" => "www.amazon.ca",
-                "de" => "www.amazon.de",
-                "es" => "www.amazon.es",
-                "fr" => "www.amazon.fr",
-                "in" => "www.amazon.in",
-                "it" => "www.amazon.it",
-                "jp" => "www.amazon.co.jp",
-                "uk" or "gb" => "www.amazon.co.uk",
-                _ => "www.amazon.com"
-            };
+            var key = region?.Trim();
+            return key != null && _markets.TryGetValue(key, out var m) ? m.Amazon : "www.amazon.com";
         }
 
         public static string GetAudibleDomain(string? region)
         {
-            return region?.Trim().ToLowerInvariant() switch
-            {
-                "au" => "www.audible.com.au",
-                "br" => "www.audible.com.br",
-                "ca" => "www.audible.ca",
-                "de" => "www.audible.de",
-                "es" => "www.audible.es",
-                "fr" => "www.audible.fr",
-                "in" => "www.audible.in",
-                "it" => "www.audible.it",
-                "jp" => "www.audible.co.jp",
-                "uk" or "gb" => "www.audible.co.uk",
-                _ => "www.audible.com"
-            };
+            var key = region?.Trim();
+            return key != null && _markets.TryGetValue(key, out var m) ? m.Audible : "www.audible.com";
         }
     }
 }

--- a/listenarr.application/Search/Metadata/MetadataConverters.cs
+++ b/listenarr.application/Search/Metadata/MetadataConverters.cs
@@ -282,8 +282,8 @@ public class MetadataConverters
         if (!string.IsNullOrEmpty(asin))
         {
             productUrl = metadata.Source == "Amazon"
-                ? BuildAmazonProductUrl(asin, metadata.Region)
-                : BuildAudibleProductUrl(asin, metadata.Region);
+                ? MarketDomainResolver.BuildAmazonProductUrl(asin, metadata.Region)
+                : MarketDomainResolver.BuildAudibleProductUrl(asin, metadata.Region);
         }
 
         // If metadata provided a non-http product link, prefer synthesized productUrl and
@@ -429,8 +429,8 @@ public class MetadataConverters
         if (!string.IsNullOrEmpty(asin))
         {
             productUrl = metadata.Source == "Amazon"
-                ? BuildAmazonProductUrl(asin, metadata.Region)
-                : BuildAudibleProductUrl(asin, metadata.Region);
+                ? MarketDomainResolver.BuildAmazonProductUrl(asin, metadata.Region)
+                : MarketDomainResolver.BuildAudibleProductUrl(asin, metadata.Region);
         }
 
         var categoryText = string.Join(", ", metadata.Genres ?? new List<string> { "Audiobook" });
@@ -485,49 +485,4 @@ public class MetadataConverters
         return result;
     }
 
-    private static string BuildAmazonProductUrl(string asin, string? region)
-    {
-        return $"https://{GetAmazonDomain(region)}/dp/{Uri.EscapeDataString(asin)}";
-    }
-
-    private static string BuildAudibleProductUrl(string asin, string? region)
-    {
-        return $"https://{GetAudibleDomain(region)}/pd/{Uri.EscapeDataString(asin)}";
-    }
-
-    private static string GetAmazonDomain(string? region)
-    {
-        return region?.Trim().ToLowerInvariant() switch
-        {
-            "au" => "www.amazon.com.au",
-            "br" => "www.amazon.com.br",
-            "ca" => "www.amazon.ca",
-            "de" => "www.amazon.de",
-            "es" => "www.amazon.es",
-            "fr" => "www.amazon.fr",
-            "in" => "www.amazon.in",
-            "it" => "www.amazon.it",
-            "jp" => "www.amazon.co.jp",
-            "uk" or "gb" => "www.amazon.co.uk",
-            _ => "www.amazon.com"
-        };
-    }
-
-    private static string GetAudibleDomain(string? region)
-    {
-        return region?.Trim().ToLowerInvariant() switch
-        {
-            "au" => "www.audible.com.au",
-            "br" => "www.audible.com.br",
-            "ca" => "www.audible.ca",
-            "de" => "www.audible.de",
-            "es" => "www.audible.es",
-            "fr" => "www.audible.fr",
-            "in" => "www.audible.in",
-            "it" => "www.audible.it",
-            "jp" => "www.audible.co.jp",
-            "uk" or "gb" => "www.audible.co.uk",
-            _ => "www.audible.com"
-        };
-    }
 }

--- a/listenarr.application/Search/Metadata/MetadataConverters.cs
+++ b/listenarr.application/Search/Metadata/MetadataConverters.cs
@@ -58,6 +58,7 @@ public class MetadataConverters
         {
             Asin = audibleData.Asin ?? asin,
             Source = source, // Use the original search source (Amazon or Audible)
+            Region = audibleData.Region,
             Title = audibleData.Title,
             Subtitle = audibleData.Subtitle,
             Authors = audibleData.Authors?.Where(a => !string.IsNullOrEmpty(a.Name)).Select(a => a.Name!).ToList(),
@@ -122,6 +123,7 @@ public class MetadataConverters
         {
             Asin = audnexusData.Asin ?? asin,
             Source = source, // Use the original search source (Amazon or Audible)
+            Region = audnexusData.Region,
             Title = audnexusData.Title,
             Subtitle = audnexusData.Subtitle,
             Authors = audnexusData.Authors?.Where(a => !string.IsNullOrEmpty(a.Name)).Select(a => a.Name!).ToList(),
@@ -280,8 +282,8 @@ public class MetadataConverters
         if (!string.IsNullOrEmpty(asin))
         {
             productUrl = metadata.Source == "Amazon"
-                ? $"https://www.amazon.com/dp/{asin}"
-                : $"https://www.audible.com/pd/{asin}";
+                ? BuildAmazonProductUrl(asin, metadata.Region)
+                : BuildAudibleProductUrl(asin, metadata.Region);
         }
 
         // If metadata provided a non-http product link, prefer synthesized productUrl and
@@ -427,8 +429,8 @@ public class MetadataConverters
         if (!string.IsNullOrEmpty(asin))
         {
             productUrl = metadata.Source == "Amazon"
-                ? $"https://www.amazon.com/dp/{asin}"
-                : $"https://www.audible.com/pd/{asin}";
+                ? BuildAmazonProductUrl(asin, metadata.Region)
+                : BuildAudibleProductUrl(asin, metadata.Region);
         }
 
         var categoryText = string.Join(", ", metadata.Genres ?? new List<string> { "Audiobook" });
@@ -481,5 +483,51 @@ public class MetadataConverters
             asin, metadata.PublishYear);
 
         return result;
+    }
+
+    private static string BuildAmazonProductUrl(string asin, string? region)
+    {
+        return $"https://{GetAmazonDomain(region)}/dp/{Uri.EscapeDataString(asin)}";
+    }
+
+    private static string BuildAudibleProductUrl(string asin, string? region)
+    {
+        return $"https://{GetAudibleDomain(region)}/pd/{Uri.EscapeDataString(asin)}";
+    }
+
+    private static string GetAmazonDomain(string? region)
+    {
+        return region?.Trim().ToLowerInvariant() switch
+        {
+            "au" => "www.amazon.com.au",
+            "br" => "www.amazon.com.br",
+            "ca" => "www.amazon.ca",
+            "de" => "www.amazon.de",
+            "es" => "www.amazon.es",
+            "fr" => "www.amazon.fr",
+            "in" => "www.amazon.in",
+            "it" => "www.amazon.it",
+            "jp" => "www.amazon.co.jp",
+            "uk" or "gb" => "www.amazon.co.uk",
+            _ => "www.amazon.com"
+        };
+    }
+
+    private static string GetAudibleDomain(string? region)
+    {
+        return region?.Trim().ToLowerInvariant() switch
+        {
+            "au" => "www.audible.com.au",
+            "br" => "www.audible.com.br",
+            "ca" => "www.audible.ca",
+            "de" => "www.audible.de",
+            "es" => "www.audible.es",
+            "fr" => "www.audible.fr",
+            "in" => "www.audible.in",
+            "it" => "www.audible.it",
+            "jp" => "www.audible.co.jp",
+            "uk" or "gb" => "www.audible.co.uk",
+            _ => "www.audible.com"
+        };
     }
 }

--- a/listenarr.application/Search/Strategies/AudibleMetadataStrategy.cs
+++ b/listenarr.application/Search/Strategies/AudibleMetadataStrategy.cs
@@ -51,10 +51,11 @@ namespace Listenarr.Application.Search.Strategies
                 baseUrl.Contains("api.audible", StringComparison.OrdinalIgnoreCase);
         }
 
-        public async Task<AudibleBookMetadata?> FetchMetadataAsync(string asin, ApiConfiguration source, string? originalSource)
+        public async Task<AudibleBookMetadata?> FetchMetadataAsync(string asin, ApiConfiguration source, string? originalSource, string? region = null)
         {
             _logger.LogDebug("Calling Audible metadata service for ASIN {Asin}", asin);
-            var audibleData = await _audibleService.GetBookMetadataAsync(asin, "us", true);
+            var safeRegion = AudiobookIdentifierNormalizer.NormalizeRegion(region) ?? "us";
+            var audibleData = await _audibleService.GetBookMetadataAsync(asin, safeRegion, true);
 
             if (audibleData != null)
             {
@@ -75,7 +76,7 @@ namespace Listenarr.Application.Search.Strategies
                 _logger.LogInformation(
                     "Audible metadata returned null for ASIN {Asin} (cache=true); retrying without cache",
                     asin);
-                var audibleRetry = await _audibleService.GetBookMetadataAsync(asin, "us", false);
+                var audibleRetry = await _audibleService.GetBookMetadataAsync(asin, safeRegion, false);
                 if (audibleRetry != null)
                 {
                     _logger.LogInformation(

--- a/listenarr.application/Search/Strategies/AudnexusStrategy.cs
+++ b/listenarr.application/Search/Strategies/AudnexusStrategy.cs
@@ -45,10 +45,11 @@ public class AudnexusStrategy : IMetadataStrategy
         return source.BaseUrl.Contains("audnex.us", StringComparison.OrdinalIgnoreCase);
     }
 
-    public async Task<AudibleBookMetadata?> FetchMetadataAsync(string asin, ApiConfiguration source, string? originalSource)
+    public async Task<AudibleBookMetadata?> FetchMetadataAsync(string asin, ApiConfiguration source, string? originalSource, string? region = null)
     {
         _logger.LogDebug("Calling Audnexus service for ASIN {Asin}", asin);
-        var audnexusData = await _audnexusService.GetBookMetadataAsync(asin, "us", true, false);
+        var safeRegion = AudiobookIdentifierNormalizer.NormalizeRegion(region) ?? "us";
+        var audnexusData = await _audnexusService.GetBookMetadataAsync(asin, safeRegion, true, false);
 
         if (audnexusData != null)
         {

--- a/listenarr.application/Search/Strategies/IMetadataStrategy.cs
+++ b/listenarr.application/Search/Strategies/IMetadataStrategy.cs
@@ -39,6 +39,7 @@ public interface IMetadataStrategy
     /// <param name="asin">The ASIN to fetch metadata for</param>
     /// <param name="source">The metadata source configuration</param>
     /// <param name="originalSource">Original source where the ASIN was found (Amazon/Audible)</param>
+    /// <param name="region">Requested marketplace region for region-specific providers</param>
     /// <returns>Metadata if successful, null otherwise</returns>
-    Task<AudibleBookMetadata?> FetchMetadataAsync(string asin, ApiConfiguration source, string? originalSource);
+    Task<AudibleBookMetadata?> FetchMetadataAsync(string asin, ApiConfiguration source, string? originalSource, string? region = null);
 }

--- a/listenarr.application/Search/Strategies/MetadataStrategyCoordinator.cs
+++ b/listenarr.application/Search/Strategies/MetadataStrategyCoordinator.cs
@@ -41,11 +41,13 @@ public class MetadataStrategyCoordinator
     /// <param name="asin">The ASIN to fetch metadata for</param>
     /// <param name="metadataSources">List of metadata sources to try in order</param>
     /// <param name="originalSource">Original source where ASIN was found (Amazon/Audible)</param>
+    /// <param name="region">Requested marketplace region for region-specific providers</param>
     /// <returns>Tuple of (metadata, sourceName) if successful, (null, null) otherwise</returns>
     public async Task<(AudibleBookMetadata? metadata, string? sourceName)> FetchMetadataAsync(
         string asin,
         List<ApiConfiguration> metadataSources,
-        string? originalSource)
+        string? originalSource,
+        string? region = null)
     {
         if (metadataSources.Count > 0)
         {
@@ -70,7 +72,7 @@ public class MetadataStrategyCoordinator
                     continue;
                 }
 
-                var metadata = await strategy.FetchMetadataAsync(asin, source, originalSource);
+                var metadata = await strategy.FetchMetadataAsync(asin, source, originalSource, region);
 
                 if (metadata != null)
                 {
@@ -88,4 +90,3 @@ public class MetadataStrategyCoordinator
         return (null, null);
     }
 }
-

--- a/listenarr.domain/Audiobooks/AudibleBookMetadata.cs
+++ b/listenarr.domain/Audiobooks/AudibleBookMetadata.cs
@@ -22,6 +22,7 @@ namespace Listenarr.Domain.Audiobooks
         // Use single canonical ASIN property to avoid JSON property name collisions
         public string? Asin { get; set; }
         public string? Source { get; set; } // "Audible" or "Amazon" to track metadata source
+        public string? Region { get; set; }
         public string? Title { get; set; }
         public string? Subtitle { get; set; }
         public List<string>? Authors { get; set; }

--- a/tests/Builders/ApplicationSettingsBuilder.cs
+++ b/tests/Builders/ApplicationSettingsBuilder.cs
@@ -90,6 +90,12 @@ namespace Listenarr.Tests.Builders
             return this;
         }
 
+        public ApplicationSettingsBuilder WithDefaultSearchRegion(string value)
+        {
+            _applicationSettings.DefaultSearchRegion = value;
+            return this;
+        }
+
         public ApplicationSettings Build()
         {
             _applicationSettings.ImportBlacklistExtensions = _importBlacklistExtensions;

--- a/tests/Builders/AudibleBookResponseBuilder.cs
+++ b/tests/Builders/AudibleBookResponseBuilder.cs
@@ -1,5 +1,3 @@
-using Listenarr.Application.Metadata;
-
 namespace Listenarr.Tests.Builders
 {
     public class AudibleBookResponseBuilder

--- a/tests/Builders/AudibleBookResponseBuilder.cs
+++ b/tests/Builders/AudibleBookResponseBuilder.cs
@@ -1,0 +1,86 @@
+using Listenarr.Application.Metadata;
+
+namespace Listenarr.Tests.Builders
+{
+    public class AudibleBookResponseBuilder
+    {
+        private readonly AudibleBookResponse _audibleBookResponse = new()
+        {
+            Asin = "B0TESTASIN",
+            Title = "Test Audiobook",
+            Authors = new List<AudibleAuthor> { new() { Asin = "A0TEST", Name = "Test Author", Region = "us" } },
+            Narrators = new List<AudibleNarrator> { new() { Name = "Test Narrator" } },
+            Genres = new List<AudibleGenre> { new() { Asin = "G0TEST", Name = "Fiction", Type = "Fiction" } },
+            Series = new List<AudibleSeries> { new() { Asin = "S0TEST", Name = "Test Series", Position = "1" } },
+            Region = "us",
+            Language = "english",
+            BookFormat = "unabridged",
+            ImageUrl = "http://example.com/cover.jpg"
+        };
+
+        public AudibleBookResponseBuilder WithAsin(string value)
+        {
+            _audibleBookResponse.Asin = value;
+            return this;
+        }
+
+        public AudibleBookResponseBuilder WithTitle(string value)
+        {
+            _audibleBookResponse.Title = value;
+            return this;
+        }
+
+        public AudibleBookResponseBuilder WithRegion(string value)
+        {
+            _audibleBookResponse.Region = value;
+            return this;
+        }
+
+        public AudibleBookResponseBuilder WithAuthor(string name, string? asin = null, string? region = null)
+        {
+            _audibleBookResponse.Authors = new List<AudibleAuthor> { new() { Asin = asin, Name = name, Region = region } };
+            return this;
+        }
+
+        public AudibleBookResponseBuilder WithNarrator(string name)
+        {
+            _audibleBookResponse.Narrators = new List<AudibleNarrator> { new() { Name = name } };
+            return this;
+        }
+
+        public AudibleBookResponseBuilder WithGenre(string asin, string name, string type)
+        {
+            _audibleBookResponse.Genres = new List<AudibleGenre> { new() { Asin = asin, Name = name, Type = type } };
+            return this;
+        }
+
+        public AudibleBookResponseBuilder WithSeries(string asin, string name, string position)
+        {
+            _audibleBookResponse.Series = new List<AudibleSeries> { new() { Asin = asin, Name = name, Position = position } };
+            return this;
+        }
+
+        public AudibleBookResponseBuilder WithLengthMinutes(int value)
+        {
+            _audibleBookResponse.LengthMinutes = value;
+            return this;
+        }
+
+        public AudibleBookResponseBuilder WithReleaseDate(string value)
+        {
+            _audibleBookResponse.ReleaseDate = value;
+            return this;
+        }
+
+        public AudibleBookResponseBuilder WithExplicit(bool value)
+        {
+            _audibleBookResponse.Explicit = value;
+            return this;
+        }
+
+        public AudibleBookResponse Build()
+        {
+            return _audibleBookResponse;
+        }
+    }
+}

--- a/tests/Builders/AudibleSearchResponseBuilder.cs
+++ b/tests/Builders/AudibleSearchResponseBuilder.cs
@@ -1,0 +1,32 @@
+using Listenarr.Application.Metadata;
+
+namespace Listenarr.Tests.Builders
+{
+    public class AudibleSearchResponseBuilder
+    {
+        private readonly AudibleSearchResponse _audibleSearchResponse = new()
+        {
+            Results = new List<AudibleSearchResult>(),
+            TotalResults = 0
+        };
+
+        public AudibleSearchResponseBuilder WithResult(AudibleSearchResult value)
+        {
+            _audibleSearchResponse.Results ??= new List<AudibleSearchResult>();
+            _audibleSearchResponse.Results.Add(value);
+            _audibleSearchResponse.TotalResults = _audibleSearchResponse.Results.Count;
+            return this;
+        }
+
+        public AudibleSearchResponseBuilder WithTotalResults(int value)
+        {
+            _audibleSearchResponse.TotalResults = value;
+            return this;
+        }
+
+        public AudibleSearchResponse Build()
+        {
+            return _audibleSearchResponse;
+        }
+    }
+}

--- a/tests/Builders/AudibleSearchResponseBuilder.cs
+++ b/tests/Builders/AudibleSearchResponseBuilder.cs
@@ -1,5 +1,3 @@
-using Listenarr.Application.Metadata;
-
 namespace Listenarr.Tests.Builders
 {
     public class AudibleSearchResponseBuilder

--- a/tests/Builders/AudibleSearchResultBuilder.cs
+++ b/tests/Builders/AudibleSearchResultBuilder.cs
@@ -1,5 +1,3 @@
-using Listenarr.Application.Metadata;
-
 namespace Listenarr.Tests.Builders
 {
     public class AudibleSearchResultBuilder
@@ -8,7 +6,7 @@ namespace Listenarr.Tests.Builders
         {
             Asin = "B0TESTASIN",
             Title = "Test Audiobook",
-            Authors = [new AudibleAuthor { Name = "Test Author" }],
+            Authors = [],
             Series = [],
             Language = "english",
             BookFormat = "unabridged"

--- a/tests/Builders/AudibleSearchResultBuilder.cs
+++ b/tests/Builders/AudibleSearchResultBuilder.cs
@@ -1,3 +1,4 @@
+using Listenarr.Application.Metadata;
 
 namespace Listenarr.Tests.Builders
 {
@@ -5,8 +6,12 @@ namespace Listenarr.Tests.Builders
     {
         private readonly AudibleSearchResult _result = new()
         {
-            Authors = [],
-            Series = []
+            Asin = "B0TESTASIN",
+            Title = "Test Audiobook",
+            Authors = [new AudibleAuthor { Name = "Test Author" }],
+            Series = [],
+            Language = "english",
+            BookFormat = "unabridged"
         };
 
         public AudibleSearchResultBuilder WithAsin(string value)
@@ -28,7 +33,7 @@ namespace Listenarr.Tests.Builders
             return this;
         }
 
-        public AudibleSearchResultBuilder WithLanguage(string value)
+        public AudibleSearchResultBuilder WithLanguage(string? value)
         {
             _result.Language = value;
             return this;

--- a/tests/Builders/MetadataSearchResultBuilder.cs
+++ b/tests/Builders/MetadataSearchResultBuilder.cs
@@ -1,5 +1,3 @@
-using Listenarr.Domain.Models;
-
 namespace Listenarr.Tests.Builders
 {
     public class MetadataSearchResultBuilder

--- a/tests/Builders/MetadataSearchResultBuilder.cs
+++ b/tests/Builders/MetadataSearchResultBuilder.cs
@@ -1,0 +1,76 @@
+using Listenarr.Domain.Models;
+
+namespace Listenarr.Tests.Builders
+{
+    public class MetadataSearchResultBuilder
+    {
+        private readonly MetadataSearchResult _metadataSearchResult = new()
+        {
+            Id = Guid.NewGuid().ToString(),
+            Asin = "B0TESTASIN",
+            Title = "Test Audiobook",
+            Artist = "Test Author",
+            Source = "Audible",
+            MetadataSource = "Audible"
+        };
+
+        public MetadataSearchResultBuilder WithAsin(string value)
+        {
+            _metadataSearchResult.Asin = value;
+            return this;
+        }
+
+        public MetadataSearchResultBuilder WithTitle(string value)
+        {
+            _metadataSearchResult.Title = value;
+            return this;
+        }
+
+        public MetadataSearchResultBuilder WithArtist(string value)
+        {
+            _metadataSearchResult.Artist = value;
+            return this;
+        }
+
+        public MetadataSearchResultBuilder WithSource(string value)
+        {
+            _metadataSearchResult.Source = value;
+            return this;
+        }
+
+        public MetadataSearchResultBuilder WithMetadataSource(string value)
+        {
+            _metadataSearchResult.MetadataSource = value;
+            return this;
+        }
+
+        public MetadataSearchResultBuilder WithSeries(string value)
+        {
+            _metadataSearchResult.Series = value;
+            return this;
+        }
+
+        public MetadataSearchResultBuilder WithProductUrl(string value)
+        {
+            _metadataSearchResult.ProductUrl = value;
+            return this;
+        }
+
+        public MetadataSearchResultBuilder WithImageUrl(string value)
+        {
+            _metadataSearchResult.ImageUrl = value;
+            return this;
+        }
+
+        public MetadataSearchResultBuilder WithEnriched()
+        {
+            _metadataSearchResult.IsEnriched = true;
+            return this;
+        }
+
+        public MetadataSearchResult Build()
+        {
+            return _metadataSearchResult;
+        }
+    }
+}

--- a/tests/Builders/SeriesLookupItemBuilder.cs
+++ b/tests/Builders/SeriesLookupItemBuilder.cs
@@ -1,5 +1,3 @@
-using Listenarr.Application.Metadata;
-
 namespace Listenarr.Tests.Builders
 {
     public class SeriesLookupItemBuilder

--- a/tests/Builders/SeriesLookupItemBuilder.cs
+++ b/tests/Builders/SeriesLookupItemBuilder.cs
@@ -1,9 +1,15 @@
+using Listenarr.Application.Metadata;
 
 namespace Listenarr.Tests.Builders
 {
     public class SeriesLookupItemBuilder
     {
-        private readonly SeriesLookupItem _series = new();
+        private readonly SeriesLookupItem _series = new()
+        {
+            Asin = "B0SERIES",
+            Name = "Test Series",
+            Region = "us"
+        };
 
         public SeriesLookupItemBuilder WithAsin(string? value)
         {

--- a/tests/Features/Api/Features/Library/LibraryController_AddToLibraryTests.cs
+++ b/tests/Features/Api/Features/Library/LibraryController_AddToLibraryTests.cs
@@ -131,6 +131,36 @@ namespace Listenarr.Tests.Features.Api.Features.Library
         }
 
         [Fact]
+        public async Task AddToLibrary_WithAsinRegion_PersistsIdentifierRegion()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+
+            var request = new LibraryController.AddToLibraryRequest
+            {
+                Metadata = new AudibleBookMetadata
+                {
+                    Title = "Region Title",
+                    Authors = new List<string> { "Region Author" },
+                    Asin = "B00REGION1",
+                    Region = "de"
+                },
+                Monitored = true
+            };
+
+            var actionResult = await controller.AddToLibrary(request);
+
+            Assert.IsType<OkObjectResult>(actionResult);
+
+            var stored = await _audiobookRepository.GetByAsinAsync("B00REGION1");
+            Assert.NotNull(stored);
+            var asinIdentifier = Assert.Single(
+                stored.ExternalIdentifiers ?? new List<AudiobookExternalIdentifier>(),
+                identifier => identifier.Type == AudiobookExternalIdentifierType.Asin);
+            Assert.Equal("de", asinIdentifier.Region);
+            Assert.True(asinIdentifier.IsPrimary);
+        }
+
+        [Fact]
         public async Task AddToLibrary_WithAsin_MovesImageToLibraryStorage()
         {
             var asin = "B000TEST01";

--- a/tests/Features/Api/Features/Search/SearchControllerUnifiedTests.cs
+++ b/tests/Features/Api/Features/Search/SearchControllerUnifiedTests.cs
@@ -143,6 +143,115 @@ namespace Listenarr.Tests.Features.Api.Features.Search
         }
 
         [Fact]
+        public async Task SimpleSearch_WithoutRegion_Uses_ConfiguredDefaultRegion()
+        {
+            var mockSearch = new Mock<ISearchService>();
+            mockSearch.Setup(s => s.IntelligentSearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<System.Threading.CancellationToken>()))
+                      .ReturnsAsync(new List<MetadataSearchResult>());
+            var mockMeta = new Mock<IAudiobookMetadataService>();
+            var mockConfig = new Mock<IConfigurationService>();
+            mockConfig.Setup(c => c.GetApplicationSettingsAsync())
+                      .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "de" });
+
+            var logger = new NullLogger<SearchController>();
+            var controller = new SearchController(
+                mockSearch.Object,
+                logger,
+                new StubAudibleService(),
+                mockMeta.Object,
+                configurationService: mockConfig.Object);
+            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+
+            var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(new { mode = "simple", query = "Dune" });
+
+            await controller.Search(reqJson);
+
+            mockSearch.Verify(s => s.IntelligentSearchAsync("Dune", 50, 50, "Relaxed", false, 0.7, "de", null, It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task AdvancedSearch_WithoutRegion_Uses_ConfiguredDefaultRegion()
+        {
+            var mockSearch = new Mock<ISearchService>();
+            mockSearch.Setup(s => s.IntelligentSearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<System.Threading.CancellationToken>()))
+                      .ReturnsAsync(new List<MetadataSearchResult>());
+            var mockMeta = new Mock<IAudiobookMetadataService>();
+            var mockConfig = new Mock<IConfigurationService>();
+            mockConfig.Setup(c => c.GetApplicationSettingsAsync())
+                      .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "fr" });
+
+            var logger = new NullLogger<SearchController>();
+            var controller = new SearchController(
+                mockSearch.Object,
+                logger,
+                new StubAudibleService(),
+                mockMeta.Object,
+                configurationService: mockConfig.Object);
+            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+
+            var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(new { mode = "advanced", title = "Dune" });
+
+            await controller.Search(reqJson);
+
+            mockSearch.Verify(s => s.IntelligentSearchAsync(It.IsAny<string>(), 200, 50, "Relaxed", false, 0.7, "fr", null, It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task AdvancedSearch_AsinWithoutRegion_Uses_ConfiguredDefaultRegion()
+        {
+            var mockSearch = new Mock<ISearchService>();
+            var stubAudible = new StubAudibleService
+            {
+                BookResponseToReturn = new AudibleBookResponse { Asin = "BASIN", Title = "ASIN Title" }
+            };
+            var mockMeta = new Mock<IAudiobookMetadataService>();
+            var mockConfig = new Mock<IConfigurationService>();
+            mockConfig.Setup(c => c.GetApplicationSettingsAsync())
+                      .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "de" });
+
+            var logger = new NullLogger<SearchController>();
+            var controller = new SearchController(
+                mockSearch.Object,
+                logger,
+                stubAudible,
+                mockMeta.Object,
+                configurationService: mockConfig.Object);
+            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+
+            var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(new { mode = "advanced", asin = "BASIN" });
+
+            await controller.Search(reqJson);
+
+            Assert.Equal("GetBookMetadataAsync", stubAudible.LastMethod);
+            Assert.Equal("de", stubAudible.LastRegion);
+        }
+
+        [Fact]
+        public async Task IntelligentSearch_WithoutRegion_Uses_ConfiguredDefaultRegion()
+        {
+            var mockSearch = new Mock<ISearchService>();
+            mockSearch.Setup(s => s.IntelligentSearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<System.Threading.CancellationToken>()))
+                      .ReturnsAsync(new List<MetadataSearchResult>());
+            var mockMeta = new Mock<IAudiobookMetadataService>();
+            var mockConfig = new Mock<IConfigurationService>();
+            mockConfig.Setup(c => c.GetApplicationSettingsAsync())
+                      .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "jp" });
+
+            var logger = new NullLogger<SearchController>();
+            var controller = new SearchController(
+                mockSearch.Object,
+                logger,
+                new StubAudibleService(),
+                mockMeta.Object,
+                configurationService: mockConfig.Object);
+            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+
+            await controller.IntelligentSearch("Dune");
+
+            mockSearch.Verify(s => s.IntelligentSearchAsync("Dune", 50, 50, "Relaxed", false, 0.7, "jp", null, It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
         public async Task AdvancedSearch_SeriesName_With_Asin_Property_Uses_SeriesAsin()
         {
             var mockSearch = new Mock<ISearchService>();

--- a/tests/Features/Api/Features/Search/SearchControllerUnifiedTests.cs
+++ b/tests/Features/Api/Features/Search/SearchControllerUnifiedTests.cs
@@ -131,13 +131,15 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var controller = new SearchController(mockSearch.Object, logger, stubAudible4, mockMeta.Object, null);
             controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
 
-            var req = new SearchRequest { Mode = SearchMode.Advanced, Asin = "BASIN" };
+            var req = new SearchRequest { Mode = SearchMode.Advanced, Asin = "BASIN", Region = "de", Language = "german" };
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(req);
             var res = await controller.Search(reqJson);
 
             Assert.NotNull(res);
             Assert.Equal("GetBookMetadataAsync", stubAudible4.LastMethod);
             Assert.Equal("BASIN", stubAudible4.LastTitle);
+            Assert.Equal("de", stubAudible4.LastRegion);
+            Assert.Equal("german", stubAudible4.LastLanguage);
         }
 
         [Fact]
@@ -239,7 +241,13 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var mockSearch = new Mock<ISearchService>();
             var mockMeta = new Mock<IAudiobookMetadataService>();
 
-            var md = new MetadataSearchResult { Asin = "BAUD1", Title = "Title", IsEnriched = true };
+            var md = new MetadataSearchResult
+            {
+                Asin = "BAUD1",
+                Title = "Title",
+                IsEnriched = true,
+                ProductUrl = "https://www.amazon.com/dp/BAUD1"
+            };
             mockSearch.Setup(s => s.IntelligentSearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<System.Threading.CancellationToken>()))
                       .ReturnsAsync(new List<MetadataSearchResult> { md });
 
@@ -251,6 +259,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
                 Narrators = new List<AudibleNarrator> { new AudibleNarrator { Name = "Narrator Name" } },
                 Genres = new List<AudibleGenre> { new AudibleGenre { Asin = "G1", Name = "Fiction", Type = "Fiction" } },
                 Series = new List<AudibleSeries> { new AudibleSeries { Asin = "S1", Name = "Series Name", Position = "1" } },
+                Region = "de",
                 ImageUrl = "http://example.com/cover.jpg",
                 LengthMinutes = 600,
                 ReleaseDate = "2021-05-04T00:00:00.000Z",
@@ -263,7 +272,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var controller = new SearchController(mockSearch.Object, logger, new StubAudibleService(), mockMeta.Object, null);
             controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
 
-            var req = new SearchRequest { Mode = SearchMode.Simple, Query = "q" };
+            var req = new SearchRequest { Mode = SearchMode.Simple, Query = "q", Region = "de" };
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(req);
             var res = await controller.Search(reqJson);
 
@@ -290,6 +299,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var series = sProp.EnumerateArray();
             var firstSeries = series.First();
             Assert.Equal("S1", firstSeries.GetProperty("asin").GetString());
+            Assert.Equal("https://www.audible.de/pd/BAUD1", first.GetProperty("link").GetString());
         }
 
         [Fact]
@@ -409,6 +419,8 @@ namespace Listenarr.Tests.Features.Api.Features.Search
         public string? LastMethod { get; set; }
         public string? LastTitle { get; set; }
         public string? LastAuthor { get; set; }
+        public string? LastRegion { get; set; }
+        public string? LastLanguage { get; set; }
         public int LastPage { get; set; }
         public int LastLimit { get; set; }
         public AudibleSearchResponse? ResponseToReturn { get; set; }
@@ -471,8 +483,9 @@ namespace Listenarr.Tests.Features.Api.Features.Search
         {
             LastMethod = "GetBookMetadataAsync";
             LastTitle = asin;
+            LastRegion = region;
+            LastLanguage = language;
             return Task.FromResult(BookResponseToReturn);
         }
     }
 }
-

--- a/tests/Features/Api/Features/Search/SearchControllerUnifiedTests.cs
+++ b/tests/Features/Api/Features/Search/SearchControllerUnifiedTests.cs
@@ -71,17 +71,19 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var stubAudible = new StubAudibleService();
             var mockMeta = new Mock<IAudiobookMetadataService>();
 
-            var sample = new AudibleSearchResponse
-            {
-                Results = new List<AudibleSearchResult>
-                {
-                    new AudibleSearchResult { Asin = "BTEST1", Title = "T" }
-                },
-                TotalResults = 1
-            };
+            var sample = new AudibleSearchResponseBuilder()
+                .WithResult(new AudibleSearchResultBuilder()
+                    .WithAsin("BTEST1")
+                    .WithTitle("T")
+                    .Build())
+                .Build();
 
             stubAudible.ResponseToReturn = sample;
-            mockMeta.Setup(m => m.GetAudibleMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(new AudibleBookResponse { Asin = "BTEST1", Title = "T" });
+            mockMeta.Setup(m => m.GetAudibleMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                    .ReturnsAsync(new AudibleBookResponseBuilder()
+                        .WithAsin("BTEST1")
+                        .WithTitle("T")
+                        .Build());
 
             var controller = CreateController(mockSearch, stubAudible, mockMeta);
 
@@ -101,17 +103,19 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var stubAudible2 = new StubAudibleService();
             var mockMeta = new Mock<IAudiobookMetadataService>();
 
-            var sample = new AudibleSearchResponse
-            {
-                Results = new List<AudibleSearchResult>
-                {
-                    new AudibleSearchResult { Asin = "BAUTH1", Title = "Title" }
-                },
-                TotalResults = 1
-            };
+            var sample = new AudibleSearchResponseBuilder()
+                .WithResult(new AudibleSearchResultBuilder()
+                    .WithAsin("BAUTH1")
+                    .WithTitle("Title")
+                    .Build())
+                .Build();
 
             stubAudible2.ResponseToReturn = sample;
-            mockMeta.Setup(m => m.GetAudibleMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(new AudibleBookResponse { Asin = "BAUTH1", Title = "Title" });
+            mockMeta.Setup(m => m.GetAudibleMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                    .ReturnsAsync(new AudibleBookResponseBuilder()
+                        .WithAsin("BAUTH1")
+                        .WithTitle("Title")
+                        .Build());
 
             var controller = CreateController(mockSearch, stubAudible2, mockMeta);
 
@@ -131,14 +135,12 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var stubAudible3 = new StubAudibleService();
             var mockMeta = new Mock<IAudiobookMetadataService>();
 
-            var sample = new AudibleSearchResponse
-            {
-                Results = new List<AudibleSearchResult>
-                {
-                    new AudibleSearchResult { Asin = "BISBN1", Title = "ISBNTitle" }
-                },
-                TotalResults = 1
-            };
+            var sample = new AudibleSearchResponseBuilder()
+                .WithResult(new AudibleSearchResultBuilder()
+                    .WithAsin("BISBN1")
+                    .WithTitle("ISBNTitle")
+                    .Build())
+                .Build();
 
             stubAudible3.ResponseToReturn = sample;
 
@@ -160,7 +162,10 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var stubAudible4 = new StubAudibleService();
             var mockMeta = new Mock<IAudiobookMetadataService>();
 
-            stubAudible4.BookResponseToReturn = new AudibleBookResponse { Asin = "BASIN", Title = "ASIN Title" };
+            stubAudible4.BookResponseToReturn = new AudibleBookResponseBuilder()
+                .WithAsin("BASIN")
+                .WithTitle("ASIN Title")
+                .Build();
 
             var controller = CreateController(mockSearch, stubAudible4, mockMeta);
 
@@ -184,7 +189,9 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var mockMeta = new Mock<IAudiobookMetadataService>();
             var mockConfig = new Mock<IConfigurationService>();
             mockConfig.Setup(c => c.GetApplicationSettingsAsync())
-                      .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "de" });
+                      .ReturnsAsync(new ApplicationSettingsBuilder()
+                          .WithDefaultSearchRegion("de")
+                          .Build());
 
             var controller = CreateController(mockSearch, metadataService: mockMeta, configurationService: mockConfig);
 
@@ -204,7 +211,9 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var mockMeta = new Mock<IAudiobookMetadataService>();
             var mockConfig = new Mock<IConfigurationService>();
             mockConfig.Setup(c => c.GetApplicationSettingsAsync())
-                      .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "fr" });
+                      .ReturnsAsync(new ApplicationSettingsBuilder()
+                          .WithDefaultSearchRegion("fr")
+                          .Build());
 
             var controller = CreateController(mockSearch, metadataService: mockMeta, configurationService: mockConfig);
 
@@ -221,12 +230,17 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var mockSearch = new Mock<ISearchService>();
             var stubAudible = new StubAudibleService
             {
-                BookResponseToReturn = new AudibleBookResponse { Asin = "BASIN", Title = "ASIN Title" }
+                BookResponseToReturn = new AudibleBookResponseBuilder()
+                    .WithAsin("BASIN")
+                    .WithTitle("ASIN Title")
+                    .Build()
             };
             var mockMeta = new Mock<IAudiobookMetadataService>();
             var mockConfig = new Mock<IConfigurationService>();
             mockConfig.Setup(c => c.GetApplicationSettingsAsync())
-                      .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "de" });
+                      .ReturnsAsync(new ApplicationSettingsBuilder()
+                          .WithDefaultSearchRegion("de")
+                          .Build());
 
             var controller = CreateController(mockSearch, stubAudible, mockMeta, mockConfig);
 
@@ -247,7 +261,9 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var mockMeta = new Mock<IAudiobookMetadataService>();
             var mockConfig = new Mock<IConfigurationService>();
             mockConfig.Setup(c => c.GetApplicationSettingsAsync())
-                      .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "jp" });
+                      .ReturnsAsync(new ApplicationSettingsBuilder()
+                          .WithDefaultSearchRegion("jp")
+                          .Build());
 
             var controller = CreateController(mockSearch, metadataService: mockMeta, configurationService: mockConfig);
 
@@ -277,7 +293,9 @@ namespace Listenarr.Tests.Features.Api.Features.Search
                     .ReturnsAsync((AudibleBookResponse?)null);
             var mockConfig = new Mock<IConfigurationService>();
             mockConfig.Setup(c => c.GetApplicationSettingsAsync())
-                      .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "de" });
+                      .ReturnsAsync(new ApplicationSettingsBuilder()
+                          .WithDefaultSearchRegion("de")
+                          .Build());
 
             var controller = CreateController(mockSearch, metadataService: mockMeta, configurationService: mockConfig);
 
@@ -295,6 +313,46 @@ namespace Listenarr.Tests.Features.Api.Features.Search
 
         [Fact]
         [Trait("Method", "SearchByTitle")]
+        [Trait("Scenario", "UsesConfiguredDefaultRegionForAmazonFallback")]
+        public async Task SearchByTitle_AmazonFallback_Uses_ConfiguredDefaultRegion_And_AmazonSourceUrl()
+        {
+            // Given
+            var mockSearch = new Mock<ISearchService>();
+            mockSearch.Setup(s => s.IntelligentSearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<System.Threading.CancellationToken>()))
+                      .ReturnsAsync(new List<MetadataSearchResult>
+                      {
+                          new MetadataSearchResultBuilder()
+                              .WithAsin("B0AMZN1234")
+                              .WithTitle("Dune")
+                              .WithArtist("Frank Herbert")
+                              .WithSource("Amazon")
+                              .WithMetadataSource("Amazon")
+                              .Build()
+                      });
+            var mockMeta = new Mock<IAudiobookMetadataService>();
+            var mockConfig = new Mock<IConfigurationService>();
+            mockConfig.Setup(c => c.GetApplicationSettingsAsync())
+                      .ReturnsAsync(new ApplicationSettingsBuilder()
+                          .WithDefaultSearchRegion("de")
+                          .Build());
+
+            var controller = CreateController(mockSearch, metadataService: mockMeta, configurationService: mockConfig);
+
+            // When
+            var response = await controller.SearchByTitle("TITLE:Dune");
+
+            // Then
+            var ok = Assert.IsType<OkObjectResult>(response.Result);
+            var serialized = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+            using var doc = System.Text.Json.JsonDocument.Parse(serialized);
+            var result = Assert.Single(doc.RootElement.EnumerateArray());
+            Assert.Equal("Amazon", result.GetProperty("source").GetString());
+            Assert.Equal("https://www.amazon.de", result.GetProperty("sourceUrl").GetString());
+            mockSearch.Verify(s => s.IntelligentSearchAsync("TITLE:Dune", It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), "de", null, It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        [Trait("Method", "SearchByTitle")]
         [Trait("Scenario", "UsesConfiguredDefaultRegionForAsinShortCircuit")]
         public async Task SearchByTitle_AsinWithoutRegion_Uses_ConfiguredDefaultRegion_And_RegionalSourceUrl()
         {
@@ -302,12 +360,17 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var mockSearch = new Mock<ISearchService>();
             var stubAudible = new StubAudibleService
             {
-                BookResponseToReturn = new AudibleBookResponse { Asin = "B0TEST1234", Title = "Localized Result" }
+                BookResponseToReturn = new AudibleBookResponseBuilder()
+                    .WithAsin("B0TEST1234")
+                    .WithTitle("Localized Result")
+                    .Build()
             };
             var mockMeta = new Mock<IAudiobookMetadataService>();
             var mockConfig = new Mock<IConfigurationService>();
             mockConfig.Setup(c => c.GetApplicationSettingsAsync())
-                      .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "br" });
+                      .ReturnsAsync(new ApplicationSettingsBuilder()
+                          .WithDefaultSearchRegion("br")
+                          .Build());
 
             var controller = CreateController(mockSearch, stubAudible, mockMeta, mockConfig);
 
@@ -334,7 +397,10 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             // Simulate series search returning SeriesLookupItem list with ASIN
             stubAudible.SeriesResponseToReturn = new List<SeriesLookupItem>
             {
-                new() { Asin = "B0SERIES1234", Name = "Some Series", Region = "us" }
+                new SeriesLookupItemBuilder()
+                    .WithAsin("B0SERIES1234")
+                    .WithName("Some Series")
+                    .Build()
             };
 
             var controller = CreateController(mockSearch, stubAudible, mockMeta);
@@ -360,7 +426,11 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             // the code should still pick the first item with a valid ASIN as a fallback
             stubAudible.SeriesResponseToReturn = new List<SeriesLookupItem>
             {
-                new() { Asin = "B0FALLBACK123", Name = "Some Series", Region = "de" }
+                new SeriesLookupItemBuilder()
+                    .WithAsin("B0FALLBACK123")
+                    .WithName("Some Series")
+                    .WithRegion("de")
+                    .Build()
             };
 
             var controller = CreateController(mockSearch, stubAudible, mockMeta);
@@ -434,20 +504,18 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             mockSearch.Setup(s => s.IntelligentSearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<System.Threading.CancellationToken>()))
                       .ReturnsAsync(new List<MetadataSearchResult> { md });
 
-            var audResp = new AudibleBookResponse
-            {
-                Asin = "BAUD1",
-                Title = "Title",
-                Authors = new List<AudibleAuthor> { new AudibleAuthor { Asin = "A1", Name = "Author Name", Region = "us" } },
-                Narrators = new List<AudibleNarrator> { new AudibleNarrator { Name = "Narrator Name" } },
-                Genres = new List<AudibleGenre> { new AudibleGenre { Asin = "G1", Name = "Fiction", Type = "Fiction" } },
-                Series = new List<AudibleSeries> { new AudibleSeries { Asin = "S1", Name = "Series Name", Position = "1" } },
-                Region = "de",
-                ImageUrl = "http://example.com/cover.jpg",
-                LengthMinutes = 600,
-                ReleaseDate = "2021-05-04T00:00:00.000Z",
-                Explicit = false
-            };
+            var audResp = new AudibleBookResponseBuilder()
+                .WithAsin("BAUD1")
+                .WithTitle("Title")
+                .WithAuthor("Author Name", "A1", "us")
+                .WithNarrator("Narrator Name")
+                .WithGenre("G1", "Fiction", "Fiction")
+                .WithSeries("S1", "Series Name", "1")
+                .WithRegion("de")
+                .WithLengthMinutes(600)
+                .WithReleaseDate("2021-05-04T00:00:00.000Z")
+                .WithExplicit(false)
+                .Build();
 
             mockMeta.Setup(m => m.GetAudibleMetadataAsync("BAUD1", It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(audResp);
 
@@ -531,18 +599,32 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             // Simulate series lookup returning a series ASIN
             stubAudible.SeriesResponseToReturn = new List<SeriesLookupItem>
             {
-                new() { Asin = "B0DUNE", Name = "Dune", Region = "us" }
+                new SeriesLookupItemBuilder()
+                    .WithAsin("B0DUNE")
+                    .WithName("Dune")
+                    .Build()
             };
 
             // Override GetBooksBySeriesAsinAsync to return books with null Language
             stubAudible.SeriesBooksOverride = new List<AudibleSearchResult>
             {
-                new AudibleSearchResult { Asin = "BDUNE1", Title = "Dune", Language = null },
-                new AudibleSearchResult { Asin = "BDUNE2", Title = "Dune Messiah", Language = "English" }
+                new AudibleSearchResultBuilder()
+                    .WithAsin("BDUNE1")
+                    .WithTitle("Dune")
+                    .WithLanguage(null)
+                    .Build(),
+                new AudibleSearchResultBuilder()
+                    .WithAsin("BDUNE2")
+                    .WithTitle("Dune Messiah")
+                    .WithLanguage("English")
+                    .Build()
             };
 
             mockMeta.Setup(m => m.GetAudibleMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
-                    .ReturnsAsync((string asin, string region, bool force) => new AudibleBookResponse { Asin = asin, Title = "Test" });
+                    .ReturnsAsync((string asin, string region, bool force) => new AudibleBookResponseBuilder()
+                        .WithAsin(asin)
+                        .WithTitle("Test")
+                        .Build());
 
             var controller = CreateController(mockSearch, stubAudible, mockMeta);
 
@@ -571,11 +653,17 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             // Simulate series lookup
             stubAudible.SeriesResponseToReturn = new List<SeriesLookupItem>
             {
-                new() { Asin = "B0SERIES", Name = "Test Series", Region = "us" }
+                new SeriesLookupItemBuilder()
+                    .WithAsin("B0SERIES")
+                    .WithName("Test Series")
+                    .Build()
             };
 
             mockMeta.Setup(m => m.GetAudibleMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
-                    .ReturnsAsync((string asin, string region, bool force) => new AudibleBookResponse { Asin = asin, Title = "Book in series" });
+                    .ReturnsAsync((string asin, string region, bool force) => new AudibleBookResponseBuilder()
+                        .WithAsin(asin)
+                        .WithTitle("Book in series")
+                        .Build());
 
             var controller = CreateController(mockSearch, stubAudible, mockMeta);
 
@@ -638,7 +726,10 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             // Return List<AudibleSearchResult> directly — controller casts with "as List<AudibleSearchResult>"
             var books = SeriesBooksOverride ?? new List<AudibleSearchResult>
             {
-                new AudibleSearchResult { Asin = seriesAsin, Title = "Book in series" }
+                new AudibleSearchResultBuilder()
+                    .WithAsin(seriesAsin)
+                    .WithTitle("Book in series")
+                    .Build()
             };
             return Task.FromResult<object?>(books);
         }

--- a/tests/Features/Api/Features/Search/SearchControllerUnifiedTests.cs
+++ b/tests/Features/Api/Features/Search/SearchControllerUnifiedTests.cs
@@ -16,13 +16,54 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using Listenarr.Tests.Builders;
+using Listenarr.Tests.Common;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Listenarr.Tests.Features.Api.Features.Search
 {
-    public class SearchControllerUnifiedTests
+    [Trait("Area", "SearchApi")]
+    [Trait("Name", "SearchControllerUnifiedTests")]
+    [Trait("Category", "SearchController")]
+    public class SearchControllerUnifiedTests : BaseTests
     {
+        private SearchController CreateController(
+            Mock<ISearchService>? searchService = null,
+            StubAudibleService? audibleService = null,
+            Mock<IAudiobookMetadataService>? metadataService = null,
+            Mock<IConfigurationService>? configurationService = null,
+            Action<ServiceCollectionBuilder>? configureServices = null)
+        {
+            searchService ??= new Mock<ISearchService>();
+            audibleService ??= new StubAudibleService();
+            metadataService ??= new Mock<IAudiobookMetadataService>();
+
+            Init(services =>
+            {
+                services
+                    .Without<IImageCacheService>()
+                    .Without<MetadataConverters>()
+                    .WithSingleton<ISearchService>(searchService.Object)
+                    .WithSingleton<AudibleService>(audibleService)
+                    .WithSingleton<IAudiobookMetadataService>(metadataService.Object)
+                    .WithTransient<SearchController, SearchController>();
+
+                if (configurationService != null)
+                {
+                    services.WithSingleton<IConfigurationService>(configurationService.Object);
+                }
+
+                configureServices?.Invoke(services);
+            });
+
+            var controller = _provider.GetRequiredService<SearchController>();
+            controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+            return controller;
+        }
+
         [Fact]
         public async Task AdvancedSearch_TitleOnly_Uses_Audible_SearchByTitleAsync()
         {
@@ -42,9 +83,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             stubAudible.ResponseToReturn = sample;
             mockMeta.Setup(m => m.GetAudibleMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(new AudibleBookResponse { Asin = "BTEST1", Title = "T" });
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(mockSearch.Object, logger, stubAudible, mockMeta.Object, null);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, stubAudible, mockMeta);
 
             var req = new SearchRequest { Mode = SearchMode.Advanced, Title = "T", Pagination = new Pagination { Page = 1, Limit = 10 } };
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(req);
@@ -74,9 +113,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             stubAudible2.ResponseToReturn = sample;
             mockMeta.Setup(m => m.GetAudibleMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(new AudibleBookResponse { Asin = "BAUTH1", Title = "Title" });
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(mockSearch.Object, logger, stubAudible2, mockMeta.Object, null);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, stubAudible2, mockMeta);
 
             var req = new SearchRequest { Mode = SearchMode.Advanced, Title = "Title", Author = "Author", Pagination = new Pagination { Page = 1, Limit = 20 } };
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(req);
@@ -105,9 +142,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
 
             stubAudible3.ResponseToReturn = sample;
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(mockSearch.Object, logger, stubAudible3, mockMeta.Object, null);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, stubAudible3, mockMeta);
 
             var req = new SearchRequest { Mode = SearchMode.Advanced, Isbn = "9780000000", Pagination = new Pagination { Page = 1, Limit = 10 } };
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(req);
@@ -127,9 +162,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
 
             stubAudible4.BookResponseToReturn = new AudibleBookResponse { Asin = "BASIN", Title = "ASIN Title" };
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(mockSearch.Object, logger, stubAudible4, mockMeta.Object, null);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, stubAudible4, mockMeta);
 
             var req = new SearchRequest { Mode = SearchMode.Advanced, Asin = "BASIN", Region = "de", Language = "german" };
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(req);
@@ -153,14 +186,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             mockConfig.Setup(c => c.GetApplicationSettingsAsync())
                       .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "de" });
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(
-                mockSearch.Object,
-                logger,
-                new StubAudibleService(),
-                mockMeta.Object,
-                configurationService: mockConfig.Object);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, metadataService: mockMeta, configurationService: mockConfig);
 
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(new { mode = "simple", query = "Dune" });
 
@@ -180,14 +206,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             mockConfig.Setup(c => c.GetApplicationSettingsAsync())
                       .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "fr" });
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(
-                mockSearch.Object,
-                logger,
-                new StubAudibleService(),
-                mockMeta.Object,
-                configurationService: mockConfig.Object);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, metadataService: mockMeta, configurationService: mockConfig);
 
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(new { mode = "advanced", title = "Dune" });
 
@@ -209,14 +228,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             mockConfig.Setup(c => c.GetApplicationSettingsAsync())
                       .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "de" });
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(
-                mockSearch.Object,
-                logger,
-                stubAudible,
-                mockMeta.Object,
-                configurationService: mockConfig.Object);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, stubAudible, mockMeta, mockConfig);
 
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(new { mode = "advanced", asin = "BASIN" });
 
@@ -237,18 +249,79 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             mockConfig.Setup(c => c.GetApplicationSettingsAsync())
                       .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "jp" });
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(
-                mockSearch.Object,
-                logger,
-                new StubAudibleService(),
-                mockMeta.Object,
-                configurationService: mockConfig.Object);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, metadataService: mockMeta, configurationService: mockConfig);
 
             await controller.IntelligentSearch("Dune");
 
             mockSearch.Verify(s => s.IntelligentSearchAsync("Dune", 50, 50, "Relaxed", false, 0.7, "jp", null, It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        [Trait("Method", "SearchByTitle")]
+        [Trait("Scenario", "UsesConfiguredDefaultRegionForTitleFallback")]
+        public async Task SearchByTitle_WithoutRegion_Uses_ConfiguredDefaultRegion_And_RegionalSourceUrl()
+        {
+            // Given
+            var mockSearch = new Mock<ISearchService>();
+            mockSearch.Setup(s => s.IntelligentSearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<System.Threading.CancellationToken>()))
+                      .ReturnsAsync(new List<MetadataSearchResult>
+                      {
+                          new MetadataSearchResultBuilder()
+                              .WithAsin("B0DUNE1234")
+                              .WithTitle("Dune")
+                              .WithArtist("Frank Herbert")
+                              .Build()
+                      });
+            var mockMeta = new Mock<IAudiobookMetadataService>();
+            mockMeta.Setup(m => m.GetAudibleMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                    .ReturnsAsync((AudibleBookResponse?)null);
+            var mockConfig = new Mock<IConfigurationService>();
+            mockConfig.Setup(c => c.GetApplicationSettingsAsync())
+                      .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "de" });
+
+            var controller = CreateController(mockSearch, metadataService: mockMeta, configurationService: mockConfig);
+
+            // When
+            var response = await controller.SearchByTitle("TITLE:Dune");
+
+            // Then
+            var ok = Assert.IsType<OkObjectResult>(response.Result);
+            var serialized = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+            using var doc = System.Text.Json.JsonDocument.Parse(serialized);
+            var result = Assert.Single(doc.RootElement.EnumerateArray());
+            Assert.Equal("https://www.audible.de", result.GetProperty("sourceUrl").GetString());
+            mockSearch.Verify(s => s.IntelligentSearchAsync("TITLE:Dune", It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), "de", null, It.IsAny<System.Threading.CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        [Trait("Method", "SearchByTitle")]
+        [Trait("Scenario", "UsesConfiguredDefaultRegionForAsinShortCircuit")]
+        public async Task SearchByTitle_AsinWithoutRegion_Uses_ConfiguredDefaultRegion_And_RegionalSourceUrl()
+        {
+            // Given
+            var mockSearch = new Mock<ISearchService>();
+            var stubAudible = new StubAudibleService
+            {
+                BookResponseToReturn = new AudibleBookResponse { Asin = "B0TEST1234", Title = "Localized Result" }
+            };
+            var mockMeta = new Mock<IAudiobookMetadataService>();
+            var mockConfig = new Mock<IConfigurationService>();
+            mockConfig.Setup(c => c.GetApplicationSettingsAsync())
+                      .ReturnsAsync(new ApplicationSettings { DefaultSearchRegion = "br" });
+
+            var controller = CreateController(mockSearch, stubAudible, mockMeta, mockConfig);
+
+            // When
+            var response = await controller.SearchByTitle("B0TEST1234");
+
+            // Then
+            var ok = Assert.IsType<OkObjectResult>(response.Result);
+            var serialized = System.Text.Json.JsonSerializer.Serialize(ok.Value);
+            using var doc = System.Text.Json.JsonDocument.Parse(serialized);
+            var result = Assert.Single(doc.RootElement.EnumerateArray());
+            Assert.Equal("https://www.audible.com.br", result.GetProperty("sourceUrl").GetString());
+            Assert.Equal("br", stubAudible.LastRegion);
+            mockSearch.Verify(s => s.IntelligentSearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<System.Threading.CancellationToken>()), Times.Never);
         }
 
         [Fact]
@@ -264,9 +337,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
                 new() { Asin = "B0SERIES1234", Name = "Some Series", Region = "us" }
             };
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(mockSearch.Object, logger, stubAudible, mockMeta.Object, null);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, stubAudible, mockMeta);
 
             var req = new SearchRequest { Mode = SearchMode.Advanced, Title = "Title", Series = "Some Series" };
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(req);
@@ -292,9 +363,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
                 new() { Asin = "B0FALLBACK123", Name = "Some Series", Region = "de" }
             };
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(mockSearch.Object, logger, stubAudible, mockMeta.Object, null);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, stubAudible, mockMeta);
 
             var req = new SearchRequest { Mode = SearchMode.Advanced, Title = "Title", Series = "Some Series" };
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(req);
@@ -314,14 +383,20 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var mockMeta = new Mock<IAudiobookMetadataService>();
 
             // Simulate IntelligentSearch returning two metadata records, only one in the requested series
-            var md1 = new MetadataSearchResult { Asin = "B1", Title = "Book One", Series = "Target Series" };
-            var md2 = new MetadataSearchResult { Asin = "B2", Title = "Book Two", Series = "Other Series" };
+            var md1 = new MetadataSearchResultBuilder()
+                .WithAsin("B1")
+                .WithTitle("Book One")
+                .WithSeries("Target Series")
+                .Build();
+            var md2 = new MetadataSearchResultBuilder()
+                .WithAsin("B2")
+                .WithTitle("Book Two")
+                .WithSeries("Other Series")
+                .Build();
             mockSearch.Setup(s => s.IntelligentSearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<System.Threading.CancellationToken>()))
                       .ReturnsAsync(new List<MetadataSearchResult> { md1, md2 });
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(mockSearch.Object, logger, stubAudible, mockMeta.Object, null);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, stubAudible, mockMeta);
 
             var req = new SearchRequest { Mode = SearchMode.Advanced, Author = "Some Author", Series = "Target Series" };
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(req);
@@ -350,13 +425,12 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var mockSearch = new Mock<ISearchService>();
             var mockMeta = new Mock<IAudiobookMetadataService>();
 
-            var md = new MetadataSearchResult
-            {
-                Asin = "BAUD1",
-                Title = "Title",
-                IsEnriched = true,
-                ProductUrl = "https://www.amazon.com/dp/BAUD1"
-            };
+            var md = new MetadataSearchResultBuilder()
+                .WithAsin("BAUD1")
+                .WithTitle("Title")
+                .WithProductUrl("https://www.amazon.com/dp/BAUD1")
+                .WithEnriched()
+                .Build();
             mockSearch.Setup(s => s.IntelligentSearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<System.Threading.CancellationToken>()))
                       .ReturnsAsync(new List<MetadataSearchResult> { md });
 
@@ -377,9 +451,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
 
             mockMeta.Setup(m => m.GetAudibleMetadataAsync("BAUD1", It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(audResp);
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(mockSearch.Object, logger, new StubAudibleService(), mockMeta.Object, null);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, metadataService: mockMeta);
 
             var req = new SearchRequest { Mode = SearchMode.Simple, Query = "q", Region = "de" };
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(req);
@@ -419,14 +491,20 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             var mockMeta = new Mock<IAudiobookMetadataService>();
 
             // IntelligentSearch returns results whose Series does NOT match the requested series
-            var md1 = new MetadataSearchResult { Asin = "B1", Title = "Unrelated Book", Series = "Wrong Series" };
-            var md2 = new MetadataSearchResult { Asin = "B2", Title = "Another Unrelated", Series = "Also Wrong" };
+            var md1 = new MetadataSearchResultBuilder()
+                .WithAsin("B1")
+                .WithTitle("Unrelated Book")
+                .WithSeries("Wrong Series")
+                .Build();
+            var md2 = new MetadataSearchResultBuilder()
+                .WithAsin("B2")
+                .WithTitle("Another Unrelated")
+                .WithSeries("Also Wrong")
+                .Build();
             mockSearch.Setup(s => s.IntelligentSearchAsync(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<double>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<System.Threading.CancellationToken>()))
                       .ReturnsAsync(new List<MetadataSearchResult> { md1, md2 });
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(mockSearch.Object, logger, stubAudible, mockMeta.Object, null);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, stubAudible, mockMeta);
 
             var req = new SearchRequest { Mode = SearchMode.Advanced, Author = "Some Author", Series = "Dune" };
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(req);
@@ -466,9 +544,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             mockMeta.Setup(m => m.GetAudibleMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
                     .ReturnsAsync((string asin, string region, bool force) => new AudibleBookResponse { Asin = asin, Title = "Test" });
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(mockSearch.Object, logger, stubAudible, mockMeta.Object, null);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, stubAudible, mockMeta);
 
             // Search with language=english — books with null Language should still be included
             var req = new SearchRequest { Mode = SearchMode.Advanced, Series = "Dune", Region = "us", Language = "english" };
@@ -501,9 +577,7 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             mockMeta.Setup(m => m.GetAudibleMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
                     .ReturnsAsync((string asin, string region, bool force) => new AudibleBookResponse { Asin = asin, Title = "Book in series" });
 
-            var logger = new NullLogger<SearchController>();
-            var controller = new SearchController(mockSearch.Object, logger, stubAudible, mockMeta.Object, null);
-            controller.ControllerContext = new ControllerContext { HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext() };
+            var controller = CreateController(mockSearch, stubAudible, mockMeta);
 
             var req = new SearchRequest { Mode = SearchMode.Advanced, Series = "Test Series", Region = "us" };
             var reqJson = System.Text.Json.JsonSerializer.SerializeToElement(req);

--- a/tests/Features/Api/Features/Search/SearchControllerUnifiedTests.cs
+++ b/tests/Features/Api/Features/Search/SearchControllerUnifiedTests.cs
@@ -20,7 +20,6 @@ using Listenarr.Tests.Builders;
 using Listenarr.Tests.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Listenarr.Tests.Features.Api.Features.Search

--- a/tests/Features/Application/Search/Core/SearchServiceFixesTests.cs
+++ b/tests/Features/Application/Search/Core/SearchServiceFixesTests.cs
@@ -16,6 +16,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Listenarr.Domain.Models.Configurations;
 
 namespace Listenarr.Tests.Features.Application.Search.Core
 {
@@ -103,6 +105,44 @@ namespace Listenarr.Tests.Features.Application.Search.Core
 
             var sr = Listenarr.Domain.Search.SearchResultConverters.ToSearchResult(idx);
             Assert.Null(sr.Quality);
+        }
+
+        [Fact]
+        public async Task SearchByAsinAsync_Uses_Requested_Region_For_Audible_Source_Links()
+        {
+            var configuration = Mock.Of<IConfigurationService>();
+            var audible = new Mock<AudibleService>(new HttpClient(), NullLogger<AudibleService>.Instance);
+            audible
+                .Setup(s => s.GetBookMetadataAsync("B0TEST1234", "de", true, "german"))
+                .ReturnsAsync(new AudibleBookResponse
+                {
+                    Asin = "B0TEST1234",
+                    Region = "de",
+                    Title = "Region Test",
+                    Authors = new List<AudibleAuthor> { new() { Name = "Test Author", Region = "de" } },
+                    Language = "german"
+                });
+
+            var converters = new MetadataConverters(Mock.Of<IImageCacheService>(), NullLogger<MetadataConverters>.Instance);
+            var progress = new SearchProgressReporter(null, NullLogger<SearchProgressReporter>.Instance);
+            var handler = new AsinSearchHandler(
+                NullLogger<AsinSearchHandler>.Instance,
+                configuration,
+                audible.Object,
+                Mock.Of<IAudnexusService>(),
+                converters,
+                progress);
+
+            var results = await handler.SearchByAsinAsync(
+                "B0TEST1234",
+                new List<ApiConfiguration>(),
+                region: "de",
+                language: "german");
+
+            var result = Assert.Single(results);
+            Assert.Equal("https://www.audible.de/pd/B0TEST1234", result.SourceLink);
+            Assert.Equal("https://www.audible.de/pd/B0TEST1234", result.ProductUrl);
+            audible.Verify(s => s.GetBookMetadataAsync("B0TEST1234", "de", true, "german"), Times.Once);
         }
     }
 }

--- a/tests/Features/Application/Search/Core/SearchServiceFixesTests.cs
+++ b/tests/Features/Application/Search/Core/SearchServiceFixesTests.cs
@@ -16,6 +16,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 using Microsoft.Extensions.Logging.Abstractions;
+using Listenarr.Application.Search.Filters;
+using Listenarr.Application.Search.Strategies;
 
 namespace Listenarr.Tests.Features.Application.Search.Core
 {
@@ -116,7 +118,6 @@ namespace Listenarr.Tests.Features.Application.Search.Core
                 .ReturnsAsync(new AudibleBookResponse
                 {
                     Asin = "B0TEST1234",
-                    Region = "de",
                     Title = "Region Test",
                     Authors = new List<AudibleAuthor> { new() { Name = "Test Author", Region = "de" } },
                     Language = "german"
@@ -142,6 +143,125 @@ namespace Listenarr.Tests.Features.Application.Search.Core
             Assert.Equal("https://www.audible.de/pd/B0TEST1234", result.SourceLink);
             Assert.Equal("https://www.audible.de/pd/B0TEST1234", result.ProductUrl);
             audible.Verify(s => s.GetBookMetadataAsync("B0TEST1234", "de", true, "german"), Times.Once);
+        }
+
+        [Fact]
+        public async Task AudibleMetadataStrategy_Uses_Requested_Region_For_Metadata_Lookup()
+        {
+            using var httpClient = new HttpClient();
+            var audible = new Mock<AudibleService>(httpClient, NullLogger<AudibleService>.Instance);
+            audible
+                .Setup(s => s.GetBookMetadataAsync("B0STRATEGY", "de", true, null))
+                .ReturnsAsync(new AudibleBookResponse
+                {
+                    Asin = "B0STRATEGY",
+                    Title = "Strategy Test",
+                    Authors = new List<AudibleAuthor> { new() { Name = "Test Author" } }
+                });
+
+            var strategy = new AudibleMetadataStrategy(
+                audible.Object,
+                new MetadataConverters(Mock.Of<IImageCacheService>(), NullLogger<MetadataConverters>.Instance),
+                NullLogger<AudibleMetadataStrategy>.Instance);
+
+            var metadata = await strategy.FetchMetadataAsync(
+                "B0STRATEGY",
+                new ApiConfiguration { Name = "Audible", BaseUrl = "https://api.audible.com" },
+                "Audible",
+                "de");
+
+            Assert.NotNull(metadata);
+            audible.Verify(s => s.GetBookMetadataAsync("B0STRATEGY", "de", true, null), Times.Once);
+            audible.Verify(s => s.GetBookMetadataAsync("B0STRATEGY", "us", It.IsAny<bool>(), It.IsAny<string?>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task AudnexusStrategy_Uses_Requested_Region_For_Metadata_Lookup()
+        {
+            var audnexus = new Mock<IAudnexusService>();
+            audnexus
+                .Setup(s => s.GetBookMetadataAsync("B0AUDNEXUS", "de", true, false))
+                .ReturnsAsync(new AudnexusBookResponse
+                {
+                    Asin = "B0AUDNEXUS",
+                    Title = "Audnexus Strategy Test",
+                    Authors = new List<AudnexusAuthor> { new() { Name = "Test Author" } }
+                });
+
+            var strategy = new AudnexusStrategy(
+                audnexus.Object,
+                new MetadataConverters(Mock.Of<IImageCacheService>(), NullLogger<MetadataConverters>.Instance),
+                NullLogger<AudnexusStrategy>.Instance);
+
+            var metadata = await strategy.FetchMetadataAsync(
+                "B0AUDNEXUS",
+                new ApiConfiguration { Name = "Audnexus", BaseUrl = "https://api.audnex.us" },
+                "Audible",
+                "de");
+
+            Assert.NotNull(metadata);
+            audnexus.Verify(s => s.GetBookMetadataAsync("B0AUDNEXUS", "de", true, false), Times.Once);
+            audnexus.Verify(s => s.GetBookMetadataAsync("B0AUDNEXUS", "us", It.IsAny<bool>(), It.IsAny<bool>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task EnrichAsinsAsync_Uses_Requested_Region_When_Metadata_Response_Omits_Region()
+        {
+            var strategy = new RegionCapturingMetadataStrategy();
+            var coordinator = new MetadataStrategyCoordinator(
+                new IMetadataStrategy[] { strategy },
+                NullLogger<MetadataStrategyCoordinator>.Instance);
+            var enricher = new AsinEnricher(
+                NullLogger<AsinEnricher>.Instance,
+                coordinator,
+                new MetadataConverters(Mock.Of<IImageCacheService>(), NullLogger<MetadataConverters>.Instance),
+                new SearchResultFilterPipeline(Enumerable.Empty<ISearchResultFilter>(), NullLogger<SearchResultFilterPipeline>.Instance),
+                new SearchProgressReporter(null, NullLogger<SearchProgressReporter>.Instance));
+
+            var result = await enricher.EnrichAsinsAsync(
+                new List<string> { "B0ENRICHED" },
+                new Dictionary<string, (string Title, string Author, string? ImageUrl, string? Language)>
+                {
+                    ["B0ENRICHED"] = ("Enriched Region Test", "Test Author", null, "german")
+                },
+                new Dictionary<string, string> { ["B0ENRICHED"] = "Audible" },
+                new Dictionary<string, OpenLibraryBook>(),
+                new List<ApiConfiguration>
+                {
+                    new() { Name = "Audible", BaseUrl = "https://api.audible.com", IsEnabled = true }
+                },
+                query: "Enriched Region Test",
+                region: "de");
+
+            var enriched = Assert.Single(result.EnrichedResults);
+            Assert.Equal("de", strategy.CapturedRegion);
+            Assert.Equal("https://www.audible.de/pd/B0ENRICHED", enriched.ProductUrl);
+            Assert.Equal("https://www.audible.de/pd/B0ENRICHED", enriched.SourceLink);
+        }
+
+        private sealed class RegionCapturingMetadataStrategy : IMetadataStrategy
+        {
+            public string SourceName => "Audible";
+            public string? CapturedRegion { get; private set; }
+
+            public bool CanHandle(ApiConfiguration source) => true;
+
+            public Task<AudibleBookMetadata?> FetchMetadataAsync(
+                string asin,
+                ApiConfiguration source,
+                string? originalSource,
+                string? region = null)
+            {
+                CapturedRegion = region;
+                return Task.FromResult<AudibleBookMetadata?>(new AudibleBookMetadata
+                {
+                    Asin = asin,
+                    Source = originalSource ?? "Audible",
+                    Title = "Enriched Region Test",
+                    Authors = new List<string> { "Test Author" },
+                    Language = "german"
+                });
+            }
         }
     }
 }

--- a/tests/Features/Application/Search/Core/SearchServiceFixesTests.cs
+++ b/tests/Features/Application/Search/Core/SearchServiceFixesTests.cs
@@ -16,8 +16,6 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
-using Listenarr.Domain.Models.Configurations;
 
 namespace Listenarr.Tests.Features.Application.Search.Core
 {

--- a/tests/Features/Application/Search/Core/SearchServiceFixesTests.cs
+++ b/tests/Features/Application/Search/Core/SearchServiceFixesTests.cs
@@ -111,7 +111,8 @@ namespace Listenarr.Tests.Features.Application.Search.Core
         public async Task SearchByAsinAsync_Uses_Requested_Region_For_Audible_Source_Links()
         {
             var configuration = Mock.Of<IConfigurationService>();
-            var audible = new Mock<AudibleService>(new HttpClient(), NullLogger<AudibleService>.Instance);
+            using var httpClient = new HttpClient();
+            var audible = new Mock<AudibleService>(httpClient, NullLogger<AudibleService>.Instance);
             audible
                 .Setup(s => s.GetBookMetadataAsync("B0TEST1234", "de", true, "german"))
                 .ReturnsAsync(new AudibleBookResponse

--- a/tests/Features/Application/Search/SearchServiceTests.cs
+++ b/tests/Features/Application/Search/SearchServiceTests.cs
@@ -16,14 +16,9 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-using Listenarr.Application.Interfaces;
-using Listenarr.Application.Metadata;
 using Listenarr.Tests.Builders;
 using Listenarr.Tests.Common;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
-using Xunit;
 
 namespace Listenarr.Tests.Features.Application.Search
 {

--- a/tests/Features/Application/Search/SearchServiceTests.cs
+++ b/tests/Features/Application/Search/SearchServiceTests.cs
@@ -1,0 +1,72 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Application.Interfaces;
+using Listenarr.Application.Metadata;
+using Listenarr.Tests.Builders;
+using Listenarr.Tests.Common;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Listenarr.Tests.Features.Application.Search
+{
+    [Trait("Area", "Search")]
+    [Trait("Name", "SearchServiceTests")]
+    [Trait("Category", "SearchService")]
+    public class SearchServiceTests : BaseTests
+    {
+        [Fact]
+        [Trait("Method", "IntelligentSearchAsync")]
+        [Trait("Scenario", "AudibleTitleResultUsesRequestedRegionForLinks")]
+        public async Task IntelligentSearch_TitleAudibleResult_UsesRequestedRegionForProductLinks()
+        {
+            // Given
+            using var httpClient = new HttpClient();
+            var audible = new Mock<AudibleService>(httpClient, NullLogger<AudibleService>.Instance);
+            var audibleResult = new AudibleSearchResultBuilder()
+                .WithAsin("B0DUNE1234")
+                .WithTitle("Dune")
+                .WithAuthor("Frank Herbert")
+                .WithLanguage("german")
+                .Build();
+            var audibleResponse = new AudibleSearchResponseBuilder()
+                .WithResult(audibleResult)
+                .WithTotalResults(1)
+                .Build();
+
+            audible
+                .Setup(service => service.SearchByTitleAsync("Dune", 1, 50, "de", "german"))
+                .ReturnsAsync(audibleResponse);
+
+            Init(services => services.WithSingleton<AudibleService>(audible.Object));
+            var searchService = _provider.GetRequiredService<ISearchService>();
+
+            // When
+            var results = await searchService.IntelligentSearchAsync("TITLE:Dune", region: "de", language: "german");
+
+            // Then
+            var result = Assert.Single(results);
+            Assert.Equal("https://www.audible.de/pd/B0DUNE1234", result.ProductUrl);
+            Assert.Equal("https://www.audible.de/pd/B0DUNE1234", result.SourceLink);
+            Assert.Equal("Audible", result.MetadataSource);
+            audible.Verify(service => service.SearchByTitleAsync("Dune", 1, 50, "de", "german"), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fix Audible region handling so Add New/search uses the configured or ad-hoc region consistently, requests regional metadata, and emits regional Audible/Amazon links.

Fixes #530
Fixes #526

## Changes

### Added
- Add Add New region selectors, region-primary language fallback, and saved default-language preservation.
- Add regression coverage for configured default region fallback, locale headers, regional links, and region preservation in add-library metadata.
- Add a shared backend market-domain resolver for Amazon/Audible regional product URLs.

### Changed
- Thread region/language through Add New search, advanced ASIN lookup, metadata conversion, add-library metadata, and product/source URL generation.
- Resolve omitted `SearchController` request regions from `ApplicationSettings.DefaultSearchRegion` while preserving explicit ad-hoc request regions.
- Preserve/regionalize Audible URLs even when upstream metadata does not include an ASIN.

### Fixed
- Audible product/search API calls now send regional locale headers.
- Audible and Amazon product links now use the selected/result region instead of always using `.com` domains.
- Vitest localStorage/esbuild warnings are removed from the local unit-test path.
- Test-created HTTP resources are disposed deterministically.

## Testing

- `dotnet test Listenarr\listenarr.slnx --filter "FullyQualifiedName~SearchControllerUnifiedTests|FullyQualifiedName~AudibleServiceTests|FullyQualifiedName~SearchServiceFixesTests|FullyQualifiedName~LibraryController_AddToLibraryTests"`
- `npm run type-check`
- `npm run test:unit -- --run src\__tests__\AddNewView.spec.ts src\__tests__\languageMapping.spec.ts src\__tests__\AddLibraryModal.editableMetadata.spec.ts`
- `.husky/pre-commit`
- `git push -u origin bugfix/audible-region` hook: version sync, backend format, frontend type-check, full frontend tests (`71 passed | 1 skipped`, `364 passed`)

## Notes

- Backend test restore still reports the existing SharpCompress `NU1902` warning.