### PR TITLE
Fix M4B re-grab loop with profile-driven quality matching

### DIFF
--- a/fe/src/__tests__/audiobookStatus.spec.ts
+++ b/fe/src/__tests__/audiobookStatus.spec.ts
@@ -17,91 +17,50 @@
  */
 import { describe, expect, it } from 'vitest'
 import { computeAudiobookStatus } from '@/utils/audiobookStatus'
-import type { Audiobook, QualityProfile } from '@/types'
+import type { Audiobook } from '@/types'
 
 describe('computeAudiobookStatus', () => {
-  it('uses the server-provided slim status when files are not present', () => {
-    const audiobook = {
-      id: 1,
-      title: 'Slim Book',
-      status: 'quality-match',
-      wanted: false,
-    } as Audiobook
-
-    expect(computeAudiobookStatus(audiobook, new Set(), [])).toBe('quality-match')
+  it('trusts the server-computed quality-match status', () => {
+    const audiobook = { id: 1, title: 'Matched', status: 'quality-match' } as Audiobook
+    expect(computeAudiobookStatus(audiobook, new Set())).toBe('quality-match')
   })
 
-  it('lets active downloads override the cached list status', () => {
-    const audiobook = {
-      id: 2,
-      title: 'Downloading Book',
-      status: 'quality-match',
-      wanted: false,
-    } as Audiobook
-
-    expect(computeAudiobookStatus(audiobook, new Set([2]), [])).toBe('downloading')
+  it('trusts the server-computed quality-mismatch status', () => {
+    const audiobook = { id: 2, title: 'Below Cutoff', status: 'quality-mismatch' } as Audiobook
+    expect(computeAudiobookStatus(audiobook, new Set())).toBe('quality-mismatch')
   })
 
-  it('recomputes from files when a richer audiobook payload is available', () => {
-    const audiobook = {
-      id: 3,
-      title: 'Detailed Book',
-      qualityProfileId: 10,
-      files: [{ id: 100, format: 'm4b', bitrate: 320000 }],
-    } as Audiobook
-
-    const profiles: QualityProfile[] = [
-      {
-        id: 10,
-        name: 'High Quality',
-        cutoffQuality: '320kbps',
-        preferredFormats: ['m4b'],
-        qualities: [{ quality: '320kbps', allowed: true, priority: 0 }],
-      },
-    ]
-
-    expect(computeAudiobookStatus(audiobook, new Set(), profiles)).toBe('quality-match')
+  it('trusts the server-computed no-file status', () => {
+    const audiobook = { id: 3, title: 'Missing', status: 'no-file' } as Audiobook
+    expect(computeAudiobookStatus(audiobook, new Set())).toBe('no-file')
   })
 
-  it('handles bitrate values stored in bits per second', () => {
-    const audiobook = {
-      id: 4,
-      title: 'Bitrate Book',
-      qualityProfileId: 10,
-      files: [{ id: 101, format: 'm4b', bitrate: 256000 }],
-    } as Audiobook
-
-    const profiles: QualityProfile[] = [
-      {
-        id: 10,
-        name: 'High Quality',
-        cutoffQuality: '256kbps',
-        preferredFormats: ['m4b'],
-        qualities: [{ quality: '256kbps', allowed: true, priority: 0 }],
-      },
-    ]
-
-    expect(computeAudiobookStatus(audiobook, new Set(), profiles)).toBe('quality-match')
+  it('lets an active download override the cached server status', () => {
+    const audiobook = { id: 4, title: 'Downloading', status: 'quality-match' } as Audiobook
+    expect(computeAudiobookStatus(audiobook, new Set([4]))).toBe('downloading')
   })
 
-  it('treats WavPack files as lossless', () => {
+  it('does not recompute from files/profiles — the server is the source of truth', () => {
+    // Files look like a healthy 320kbps M4B, but the server says it is below cutoff
+    // (e.g. its profile cutoff is higher). The frontend must defer to the server.
     const audiobook = {
       id: 5,
-      title: 'Lossless Book',
+      title: 'Defer To Server',
+      status: 'quality-mismatch',
       qualityProfileId: 10,
-      files: [{ id: 102, format: 'wv', container: 'wv' }],
+      files: [{ id: 100, format: 'm4b', codec: 'aac', bitrate: 320000 }],
     } as Audiobook
 
-    const profiles: QualityProfile[] = [
-      {
-        id: 10,
-        name: 'Lossless',
-        cutoffQuality: 'lossless',
-        preferredFormats: ['wv'],
-        qualities: [{ quality: 'lossless', allowed: true, priority: 0 }],
-      },
-    ]
+    expect(computeAudiobookStatus(audiobook, new Set())).toBe('quality-mismatch')
+  })
 
-    expect(computeAudiobookStatus(audiobook, new Set(), profiles)).toBe('quality-match')
+  it('falls back to no-file when the server sent no recognizable status', () => {
+    const audiobook = { id: 6, title: 'No Status' } as Audiobook
+    expect(computeAudiobookStatus(audiobook, new Set())).toBe('no-file')
+  })
+
+  it('falls back to no-file when the status is an unrelated download-state string', () => {
+    const audiobook = { id: 7, title: 'Stray Status', status: 'completed' } as unknown as Audiobook
+    expect(computeAudiobookStatus(audiobook, new Set())).toBe('no-file')
   })
 })

--- a/fe/src/utils/audiobookStatus.ts
+++ b/fe/src/utils/audiobookStatus.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
-import type { Audiobook, AudiobookStatus, QualityProfile } from '@/types'
+import type { Audiobook, AudiobookStatus } from '@/types'
 
 const AUDIOBOOK_STATUSES: AudiobookStatus[] = [
   'downloading',
@@ -23,8 +23,6 @@ const AUDIOBOOK_STATUSES: AudiobookStatus[] = [
   'quality-mismatch',
   'quality-match',
 ]
-
-const normalize = (value?: string): string => (value || '').toString().trim().toLowerCase()
 
 function isAudiobookStatus(value: unknown): value is AudiobookStatus {
   return typeof value === 'string' && AUDIOBOOK_STATUSES.includes(value as AudiobookStatus)
@@ -45,69 +43,24 @@ export function formatAudiobookStatus(status: AudiobookStatus): string {
   }
 }
 
+/**
+ * Resolve the display status for an audiobook.
+ *
+ * The backend is the single source of truth for quality matching: the `/library`
+ * list endpoint runs {@link AudiobookStatusEvaluator.ComputeStatus} server-side and
+ * returns the result as `audiobook.status`. The frontend trusts that value and only
+ * applies a client-side override for transient state the server's snapshot can't see —
+ * an in-flight download for this audiobook.
+ *
+ * This deliberately no longer mirrors the backend QualityMatcher client-side; that
+ * duplicated business logic and could disagree with the automatic-search cutoff.
+ */
 export function computeAudiobookStatus(
-  audiobook: Audiobook,
+  audiobook: Pick<Audiobook, 'id' | 'status'>,
   activeDownloadAudiobookIds: ReadonlySet<number>,
-  qualityProfiles: QualityProfile[],
 ): AudiobookStatus {
   if (activeDownloadAudiobookIds.has(audiobook.id)) {
     return 'downloading'
-  }
-
-  const hasFiles = Array.isArray(audiobook.files) && audiobook.files.length > 0
-  if (hasFiles) {
-    const profile = qualityProfiles.find((item) => item.id === audiobook.qualityProfileId)
-
-    if (!profile) {
-      const hasFileSummary =
-        !!(audiobook.filePath && audiobook.fileSize && audiobook.fileSize > 0) || hasFiles
-      return hasFileSummary ? 'quality-match' : 'no-file'
-    }
-
-    const preferredFormats = (profile.preferredFormats || []).map((item) => normalize(item))
-    const candidateFiles = audiobook.files!.filter((file) => {
-      if (!file) return false
-      const fileFormat = normalize(file.format) || normalize(file.container) || ''
-      if (preferredFormats.length === 0) return true
-      return (
-        preferredFormats.includes(fileFormat) ||
-        preferredFormats.some((preferredFormat) => fileFormat.includes(preferredFormat))
-      )
-    })
-
-    if (candidateFiles.length === 0) {
-      return 'quality-mismatch'
-    }
-
-    if (!profile.cutoffQuality || !profile.qualities || profile.qualities.length === 0) {
-      return 'quality-match'
-    }
-
-    const qualityPriority = new Map<string, number>()
-    for (const quality of profile.qualities) {
-      if (!quality || !quality.quality) continue
-      qualityPriority.set(normalize(quality.quality), quality.priority)
-    }
-
-    const cutoff = normalize(profile.cutoffQuality)
-    const cutoffPriority = qualityPriority.has(cutoff)
-      ? qualityPriority.get(cutoff)!
-      : Number.POSITIVE_INFINITY
-
-    for (const file of candidateFiles) {
-      const derivedQuality = deriveQualityLabel(audiobook, file)
-      if (!derivedQuality) continue
-
-      const priority = qualityPriority.has(derivedQuality)
-        ? qualityPriority.get(derivedQuality)!
-        : Number.POSITIVE_INFINITY
-
-      if (priority <= cutoffPriority) {
-        return 'quality-match'
-      }
-    }
-
-    return 'quality-mismatch'
   }
 
   if (isAudiobookStatus(audiobook.status)) {
@@ -115,54 +68,4 @@ export function computeAudiobookStatus(
   }
 
   return 'no-file'
-}
-
-function deriveQualityLabel(
-  audiobook: Audiobook,
-  file:
-    | {
-        bitrate?: number
-        container?: string
-        codec?: string
-        format?: string
-      }
-    | undefined,
-): string {
-  if (audiobook.quality) return normalize(audiobook.quality)
-
-  if (file && file.bitrate) {
-    const bitrate = Number(file.bitrate)
-    if (!Number.isNaN(bitrate)) {
-      const bitrateKbps = bitrate >= 1000 ? bitrate / 1000 : bitrate
-      if (bitrateKbps >= 320) return '320kbps'
-      if (bitrateKbps >= 256) return '256kbps'
-      if (bitrateKbps >= 192) return '192kbps'
-      return `${Math.round(bitrateKbps)}kbps`
-    }
-  }
-
-  const container = normalize(file?.container)
-  const codec = normalize(file?.codec)
-  if (
-    container.includes('flac') ||
-    codec.includes('flac') ||
-    container.includes('alac') ||
-    codec.includes('alac') ||
-    container.includes('aiff') ||
-    codec.includes('aiff') ||
-    container.includes('ape') ||
-    codec.includes('ape') ||
-    container.includes('dsd') ||
-    codec.includes('dsd') ||
-    container.includes('wv') ||
-    codec.includes('wv') ||
-    container.includes('wav') ||
-    codec.includes('wav')
-  ) {
-    return 'lossless'
-  }
-
-  if (file?.format) return normalize(file.format)
-
-  return ''
 }

--- a/fe/src/views/library/AudiobooksView.vue
+++ b/fe/src/views/library/AudiobooksView.vue
@@ -1816,7 +1816,7 @@ const activeDownloadAudiobookIds = computed(() => {
 })
 
 function computeAudiobookStatusRaw(audiobook: Audiobook): AudiobookStatus {
-  return computeAudiobookStatus(audiobook, activeDownloadAudiobookIds.value, qualityProfiles.value)
+  return computeAudiobookStatus(audiobook, activeDownloadAudiobookIds.value)
 }
 
 const audiobookStatusById = computed(() => {

--- a/fe/src/views/library/CollectionView.vue
+++ b/fe/src/views/library/CollectionView.vue
@@ -2270,7 +2270,7 @@ function getAudiobookStatus(audiobook: CollectionDisplayItem): CollectionStatus 
     return 'not-added'
   }
 
-  return computeAudiobookStatus(audiobook, activeDownloadAudiobookIds.value, qualityProfiles.value)
+  return computeAudiobookStatus(audiobook, activeDownloadAudiobookIds.value)
 }
 
 function getMonitoringLabel(audiobook: CollectionDisplayItem): string {

--- a/listenarr.application/Audiobooks/Matching/AudiobookQualityCutoffEvaluator.cs
+++ b/listenarr.application/Audiobooks/Matching/AudiobookQualityCutoffEvaluator.cs
@@ -16,10 +16,19 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using Listenarr.Domain.Common;
 using Microsoft.Extensions.Logging;
 
 namespace Listenarr.Application.Audiobooks.Matching
 {
+    /// <summary>
+    /// Shared "is the audiobook already at/above its quality cutoff?" evaluation.
+    ///
+    /// Per-file/-download quality is resolved through <see cref="QualityMatcher"/> rather than the
+    /// previous string-label classifier that emitted container labels (e.g. "M4B") which never
+    /// equalled a codec/bitrate rung — so the cutoff was never met and the audiobook was
+    /// searched/re-grabbed on every cycle.
+    /// </summary>
     public static class AudiobookQualityCutoffEvaluator
     {
         public static async Task<bool> IsQualityCutoffMetAsync(
@@ -28,7 +37,8 @@ namespace Listenarr.Application.Audiobooks.Matching
             IAudiobookFileRepository audioFileRepository,
             ILogger? logger = null)
         {
-            if (audiobook.QualityProfile == null)
+            var profile = audiobook.QualityProfile;
+            if (profile == null)
             {
                 return false;
             }
@@ -46,8 +56,9 @@ namespace Listenarr.Application.Audiobooks.Matching
                 return false;
             }
 
-            var cutoffQuality = audiobook.QualityProfile.Qualities
-                .FirstOrDefault(q => q.Quality == audiobook.QualityProfile.CutoffQuality);
+            // Preserve the original guard: an unset or unknown cutoff means "keep searching".
+            var cutoffQuality = profile.Qualities
+                .FirstOrDefault(q => q.Quality == profile.CutoffQuality);
 
             if (cutoffQuality == null)
             {
@@ -60,10 +71,7 @@ namespace Listenarr.Application.Audiobooks.Matching
                     !string.IsNullOrEmpty(download.Metadata?.GetValueOrDefault("Quality")?.ToString()))
                 {
                     var downloadQuality = download.Metadata["Quality"].ToString();
-                    var downloadQualityDefinition = audiobook.QualityProfile.Qualities
-                        .FirstOrDefault(q => q.Quality == downloadQuality);
-
-                    if (downloadQualityDefinition != null && downloadQualityDefinition.Priority >= cutoffQuality.Priority)
+                    if (QualityMatcher.LabelMeetsCutoff(downloadQuality, profile))
                     {
                         logger?.LogDebug(
                             "Quality cutoff met for audiobook '{Title}' by completed download (Quality: {Quality})",
@@ -84,21 +92,11 @@ namespace Listenarr.Application.Audiobooks.Matching
 
             foreach (var file in existingFiles)
             {
-                var fileQuality = DetermineFileQuality(file);
-                if (string.IsNullOrEmpty(fileQuality))
-                {
-                    continue;
-                }
-
-                var fileQualityDefinition = audiobook.QualityProfile.Qualities
-                    .FirstOrDefault(q => q.Quality == fileQuality);
-
-                if (fileQualityDefinition != null && fileQualityDefinition.Priority >= cutoffQuality.Priority)
+                if (QualityMatcher.MeetsCutoff(ToInput(file), profile))
                 {
                     logger?.LogDebug(
-                        "Quality cutoff met for audiobook '{Title}' by existing file (Quality: {Quality}, File: {FileName})",
+                        "Quality cutoff met for audiobook '{Title}' by existing file (File: {FileName})",
                         audiobook.Title,
-                        fileQuality,
                         Path.GetFileName(file.Path));
                     return true;
                 }
@@ -107,64 +105,17 @@ namespace Listenarr.Application.Audiobooks.Matching
             return false;
         }
 
-        private static string? DetermineFileQuality(AudiobookFile file)
+        /// <summary>The profile rung label a stored file maps to, or null if it does not match.</summary>
+        public static string? ResolveFileQualityLabel(AudiobookFile file, QualityProfile? profile)
+            => QualityMatcher.MatchLabel(ToInput(file), profile);
+
+        private static AudioQualityInput ToInput(AudiobookFile file) => new()
         {
-            if (!string.IsNullOrEmpty(file.Container))
-            {
-                var container = file.Container.ToLower();
-                if (container.Contains("flac")) return "FLAC";
-                if (container.Contains("m4b") || container.Contains("m4a")) return "M4B";
-            }
-
-            if (!string.IsNullOrEmpty(file.Format))
-            {
-                var format = file.Format.ToLower();
-                if (format.Contains("flac")) return "FLAC";
-                if (format.Contains("m4b") || format.Contains("m4a")) return "M4B";
-                if (format.Contains("aac")) return "M4B";
-            }
-
-            if (file.Bitrate.HasValue)
-            {
-                var kbps = file.Bitrate.Value / 1000;
-
-                if (kbps >= 320) return "MP3 320kbps";
-                if (kbps >= 256) return "MP3 256kbps";
-                if (kbps >= 192) return "MP3 192kbps";
-                if (kbps >= 128) return "MP3 128kbps";
-                if (kbps >= 64) return "MP3 64kbps";
-
-                return "MP3 64kbps";
-            }
-
-            if (!string.IsNullOrEmpty(file.Codec))
-            {
-                var codec = file.Codec.ToLower();
-                if (codec.Contains("flac")) return "FLAC";
-                if (codec.Contains("aac")) return "M4B";
-                if (codec.Contains("mp3")) return "MP3 128kbps";
-                if (codec.Contains("opus")) return "M4B";
-            }
-
-            if (!string.IsNullOrEmpty(file.Path))
-            {
-                var extension = Path.GetExtension(file.Path).ToLower();
-                switch (extension)
-                {
-                    case ".flac":
-                        return "FLAC";
-                    case ".m4b":
-                    case ".m4a":
-                        return "M4B";
-                    case ".mp3":
-                        return "MP3 128kbps";
-                    case ".aac":
-                    case ".opus":
-                        return "M4B";
-                }
-            }
-
-            return null;
-        }
+            Codec = file.Codec,
+            Container = file.Container,
+            Format = file.Format,
+            BitrateBitsPerSecond = file.Bitrate,
+            Path = file.Path
+        };
     }
 }

--- a/listenarr.application/Metadata/Core/AudiobookStatusEvaluator.cs
+++ b/listenarr.application/Metadata/Core/AudiobookStatusEvaluator.cs
@@ -16,6 +16,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using Listenarr.Domain.Common;
+
 namespace Listenarr.Application.Metadata.Core
 {
     public static class AudiobookStatusEvaluator
@@ -60,6 +62,13 @@ namespace Listenarr.Application.Metadata.Core
                     {
                         fileFormat = Normalize(f.Container);
                     }
+                    if (fileFormat.Length == 0)
+                    {
+                        // Path-only file (no probe metadata): fall back to the path extension so a
+                        // metadata-less book.flac still satisfies a PreferredFormats = ["flac"] filter
+                        // instead of being dropped before QualityMatcher can use the extension.
+                        fileFormat = ExtensionFromPath(f.Path);
+                    }
 
                     if (preferredFormats.Count == 0)
                     {
@@ -88,34 +97,29 @@ namespace Listenarr.Application.Metadata.Core
                 return QualityMatch;
             }
 
-            var qualityPriority = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-            foreach (var quality in qualityProfile.Qualities)
+            // A pinned audiobook-level quality short-circuits per-file derivation.
+            if (!string.IsNullOrWhiteSpace(audiobookQuality))
             {
-                if (quality == null || string.IsNullOrWhiteSpace(quality.Quality))
-                {
-                    continue;
-                }
-
-                qualityPriority[Normalize(quality.Quality)] = quality.Priority;
+                return QualityMatcher.LabelMeetsCutoff(audiobookQuality, qualityProfile)
+                    ? QualityMatch
+                    : QualityMismatch;
             }
 
-            var cutoff = Normalize(qualityProfile.CutoffQuality);
-            var cutoffPriority = qualityPriority.TryGetValue(cutoff, out var foundCutoffPriority)
-                ? foundCutoffPriority
-                : int.MaxValue;
-
-            foreach (var derivedQuality in candidateFiles.Select(file => DeriveQualityLabel(file, audiobookQuality)))
+            foreach (var file in candidateFiles)
             {
-                if (derivedQuality.Length == 0)
+                var input = new AudioQualityInput
                 {
-                    continue;
-                }
+                    Codec = file.Codec,
+                    Container = file.Container,
+                    Format = file.Format,
+                    BitrateBitsPerSecond = file.Bitrate,
+                    // Path is the only quality signal when metadata processing is disabled,
+                    // ffprobe is unavailable, or extraction failed. Mirrors AudiobookQualityCutoffEvaluator
+                    // so automatic-search and library status agree for path-only files.
+                    Path = file.Path
+                };
 
-                var priority = qualityPriority.TryGetValue(derivedQuality, out var foundPriority)
-                    ? foundPriority
-                    : int.MaxValue;
-
-                if (priority <= cutoffPriority)
+                if (QualityMatcher.MeetsCutoff(input, qualityProfile))
                 {
                     return QualityMatch;
                 }
@@ -124,62 +128,19 @@ namespace Listenarr.Application.Metadata.Core
             return QualityMismatch;
         }
 
-        private static string DeriveQualityLabel(AudiobookFormatSummary? file, string? audiobookQuality)
-        {
-            var normalizedAudiobookQuality = Normalize(audiobookQuality);
-            if (normalizedAudiobookQuality.Length > 0)
-            {
-                return normalizedAudiobookQuality;
-            }
-
-            if (file?.Bitrate is int bitrate)
-            {
-                var bitrateKbps = bitrate >= 1000 ? bitrate / 1000d : bitrate;
-
-                if (bitrateKbps >= 320)
-                {
-                    return "320kbps";
-                }
-
-                if (bitrateKbps >= 256)
-                {
-                    return "256kbps";
-                }
-
-                if (bitrateKbps >= 192)
-                {
-                    return "192kbps";
-                }
-
-                return $"{Math.Round(bitrateKbps)}kbps";
-            }
-
-            var container = Normalize(file?.Container);
-            var codec = Normalize(file?.Codec);
-            if (container.Contains("flac", StringComparison.Ordinal)
-                || codec.Contains("flac", StringComparison.Ordinal)
-                || container.Contains("alac", StringComparison.Ordinal)
-                || codec.Contains("alac", StringComparison.Ordinal)
-                || container.Contains("aiff", StringComparison.Ordinal)
-                || codec.Contains("aiff", StringComparison.Ordinal)
-                || container.Contains("ape", StringComparison.Ordinal)
-                || codec.Contains("ape", StringComparison.Ordinal)
-                || container.Contains("dsd", StringComparison.Ordinal)
-                || codec.Contains("dsd", StringComparison.Ordinal)
-                || container.Contains("wv", StringComparison.Ordinal)
-                || codec.Contains("wv", StringComparison.Ordinal)
-                || container.Contains("wav", StringComparison.Ordinal)
-                || codec.Contains("wav", StringComparison.Ordinal))
-            {
-                return "lossless";
-            }
-
-            return Normalize(file?.Format);
-        }
-
         private static string Normalize(string? value)
         {
             return (value ?? string.Empty).Trim().ToLowerInvariant();
+        }
+
+        private static string ExtensionFromPath(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return string.Empty;
+            }
+
+            return Normalize(System.IO.Path.GetExtension(path).TrimStart('.'));
         }
     }
 }

--- a/listenarr.domain/Common/QualityMatcher.cs
+++ b/listenarr.domain/Common/QualityMatcher.cs
@@ -1,0 +1,409 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Text.RegularExpressions;
+
+namespace Listenarr.Domain.Common
+{
+    /// <summary>
+    /// Normalised, unit-explicit view of an audio file's quality-relevant facts.
+    /// All three call-sites (status evaluator, automatic search, library controller)
+    /// hold different carrier types, so they project into this single record before
+    /// asking <see cref="QualityMatcher"/> to match against a profile.
+    /// </summary>
+    public readonly record struct AudioQualityInput
+    {
+        /// <summary>Raw codec as reported by ffprobe (e.g. "aac", "mp3", "flac", "opus", "vorbis").</summary>
+        public string? Codec { get; init; }
+
+        /// <summary>Container (e.g. "M4B", "M4A", "MP4", "OGG").</summary>
+        public string? Container { get; init; }
+
+        /// <summary>Format/extension fallback (e.g. "mp3", "flac").</summary>
+        public string? Format { get; init; }
+
+        /// <summary>Bitrate in <b>bits per second</b> (the unit used by file/metadata carriers).</summary>
+        public int? BitrateBitsPerSecond { get; init; }
+
+        /// <summary>Optional file path, used only as an extension fallback.</summary>
+        public string? Path { get; init; }
+    }
+
+    /// <summary>Outcome category for <see cref="QualityMatcher.Match"/>.</summary>
+    public enum QualityMatchKind
+    {
+        /// <summary>A profile rung was matched.</summary>
+        Matched,
+
+        /// <summary>The file's codec is not present in the profile at all.</summary>
+        CodecMismatch,
+
+        /// <summary>The codec matched but the profile has no bitrate rung the file can land on.</summary>
+        NoBitrateRung,
+
+        /// <summary>The profile has no qualities to match against.</summary>
+        Unknown
+    }
+
+    /// <summary>Result of matching a file to a profile.</summary>
+    public readonly record struct QualityMatchResult(QualityMatchKind Kind, QualityDefinition? Rung)
+    {
+        public bool IsMatch => Kind == QualityMatchKind.Matched && Rung is not null;
+    }
+
+    /// <summary>
+    /// Profile-driven quality matching. The single source of truth for what a profile's
+    /// <see cref="QualityDefinition.Priority"/> ordering means (lower number = higher quality)
+    /// and how an on-disk file maps onto a profile's quality rungs.
+    ///
+    /// Replaces the previous string-label classifiers that emitted container labels such as
+    /// "M4B" (which never equalled a codec/bitrate rung like "AAC 256kbps", so the cutoff was
+    /// never met and the audiobook was re-downloaded forever).
+    /// </summary>
+    public static class QualityMatcher
+    {
+        /// <summary>
+        /// Match a file to the highest profile rung it meets or exceeds (round-down).
+        /// Returns <see cref="QualityMatchKind.CodecMismatch"/> when the file's codec is not in
+        /// the profile at all (instead of silently treating it as the lowest possible quality).
+        /// </summary>
+        public static QualityMatchResult Match(AudioQualityInput file, QualityProfile? profile)
+        {
+            if (profile?.Qualities == null || profile.Qualities.Count == 0)
+            {
+                return new QualityMatchResult(QualityMatchKind.Unknown, null);
+            }
+
+            var fileGroups = MapCodec(file);
+            var fileIsLossless = IsLosslessFile(file);
+            var fileKbps = NormalizeKbps(file.BitrateBitsPerSecond);
+
+            var effective = profile.Qualities
+                .Where(q => q != null && !string.IsNullOrWhiteSpace(q.Quality))
+                .Select(EffectiveRung)
+                .ToList();
+
+            // Codec-specific rungs take precedence; wildcard (codec-less) rungs are the fallback
+            // and exist mainly for legacy/bare profiles such as "320kbps" / "lossless".
+            var codecCandidates = effective
+                .Where(r => r.Codec != null
+                            && r.IsLossless == fileIsLossless
+                            && fileGroups.Contains(r.Codec))
+                .ToList();
+
+            var pool = codecCandidates.Count > 0
+                ? codecCandidates
+                : effective.Where(r => r.Codec == null && r.IsLossless == fileIsLossless).ToList();
+
+            if (pool.Count == 0)
+            {
+                return new QualityMatchResult(QualityMatchKind.CodecMismatch, null);
+            }
+
+            // Lossless files ignore bitrate: take the best (lowest-priority) lossless rung.
+            if (fileIsLossless)
+            {
+                return new QualityMatchResult(QualityMatchKind.Matched, Best(pool).Source);
+            }
+
+            var withBitrate = pool.Where(r => r.BitrateKbps is not null).ToList();
+            var vbr = pool.Where(r => r.BitrateKbps is null).ToList();
+
+            if (fileKbps is int kbps)
+            {
+                var eligible = withBitrate.Where(r => r.BitrateKbps <= kbps).ToList();
+                if (eligible.Count > 0)
+                {
+                    return new QualityMatchResult(QualityMatchKind.Matched, Best(eligible).Source);
+                }
+
+                // File is below the lowest configured rung: fall to the worst rung (never over-claim).
+                if (withBitrate.Count > 0)
+                {
+                    return new QualityMatchResult(QualityMatchKind.Matched, Worst(withBitrate).Source);
+                }
+
+                if (vbr.Count > 0)
+                {
+                    return new QualityMatchResult(QualityMatchKind.Matched, Best(vbr).Source);
+                }
+
+                return new QualityMatchResult(QualityMatchKind.NoBitrateRung, null);
+            }
+
+            // Unknown bitrate: prefer a VBR rung, else conservatively the worst bitrate rung.
+            if (vbr.Count > 0)
+            {
+                return new QualityMatchResult(QualityMatchKind.Matched, Best(vbr).Source);
+            }
+
+            if (withBitrate.Count > 0)
+            {
+                return new QualityMatchResult(QualityMatchKind.Matched, Worst(withBitrate).Source);
+            }
+
+            return new QualityMatchResult(QualityMatchKind.NoBitrateRung, null);
+        }
+
+        /// <summary>The profile rung label a file maps to, or null if it does not match.</summary>
+        public static string? MatchLabel(AudioQualityInput file, QualityProfile? profile)
+            => Match(file, profile).Rung?.Quality;
+
+        /// <summary>
+        /// Whether a file meets or exceeds the profile cutoff. A blank cutoff is always met;
+        /// a missing/codec-mismatched file is not.
+        /// </summary>
+        public static bool MeetsCutoff(AudioQualityInput file, QualityProfile? profile)
+        {
+            var cutoff = ResolveCutoff(profile, out var cutoffBlank);
+            if (cutoffBlank)
+            {
+                return true;
+            }
+
+            if (cutoff == null)
+            {
+                return false;
+            }
+
+            var match = Match(file, profile);
+            return match.IsMatch && match.Rung!.Priority <= cutoff.Priority;
+        }
+
+        /// <summary>
+        /// Whether a known quality <paramref name="qualityLabel"/> (e.g. a value stored in download
+        /// metadata) meets or exceeds the profile cutoff.
+        /// </summary>
+        public static bool LabelMeetsCutoff(string? qualityLabel, QualityProfile? profile)
+        {
+            var cutoff = ResolveCutoff(profile, out var cutoffBlank);
+            if (cutoffBlank)
+            {
+                return true;
+            }
+
+            if (cutoff == null || string.IsNullOrWhiteSpace(qualityLabel))
+            {
+                return false;
+            }
+
+            var rung = FindRung(profile!, qualityLabel);
+            return rung != null && rung.Priority <= cutoff.Priority;
+        }
+
+        /// <summary>
+        /// Whether <paramref name="candidate"/> is strictly higher quality than <paramref name="existing"/>
+        /// (lower priority number). An unknown candidate is never better; an unknown existing is always beaten.
+        /// </summary>
+        public static bool IsLabelBetter(string? candidate, string? existing, QualityProfile? profile)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(existing))
+            {
+                return true;
+            }
+
+            if (profile == null)
+            {
+                return false;
+            }
+
+            var cand = FindRung(profile, candidate);
+            var exist = FindRung(profile, existing);
+
+            if (cand == null)
+            {
+                return false;
+            }
+
+            if (exist == null)
+            {
+                return true;
+            }
+
+            return cand.Priority < exist.Priority;
+        }
+
+        /// <summary>Whether the profile declares a rung whose label equals <paramref name="hint"/> (case-insensitive).</summary>
+        public static bool ProfileContainsHint(QualityProfile? profile, string? hint)
+        {
+            if (profile?.Qualities == null || string.IsNullOrWhiteSpace(hint))
+            {
+                return false;
+            }
+
+            return profile.Qualities.Any(q => string.Equals(q.Quality, hint, StringComparison.OrdinalIgnoreCase));
+        }
+
+        // ---- internals --------------------------------------------------------------------
+
+        private readonly record struct EffectiveRungInfo(QualityDefinition Source, string? Codec, int? BitrateKbps, bool IsLossless)
+        {
+            public int Priority => Source.Priority;
+        }
+
+        private static EffectiveRungInfo Best(IEnumerable<EffectiveRungInfo> rungs)
+            => rungs.OrderBy(r => r.Priority).First();
+
+        private static EffectiveRungInfo Worst(IEnumerable<EffectiveRungInfo> rungs)
+            => rungs.OrderByDescending(r => r.Priority).First();
+
+        private static QualityDefinition? ResolveCutoff(QualityProfile? profile, out bool cutoffBlank)
+        {
+            cutoffBlank = false;
+            if (profile?.Qualities == null || profile.Qualities.Count == 0
+                || string.IsNullOrWhiteSpace(profile.CutoffQuality))
+            {
+                cutoffBlank = true;
+                return null;
+            }
+
+            return FindRung(profile, profile.CutoffQuality);
+        }
+
+        private static QualityDefinition? FindRung(QualityProfile profile, string label)
+            => profile.Qualities.FirstOrDefault(q => string.Equals(q.Quality, label, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>
+        /// Resolve a rung's effective (codec group, bitrate-kbps, lossless) using the structured
+        /// fields when present and parsing the <see cref="QualityDefinition.Quality"/> label otherwise
+        /// (seed/legacy rungs only set Quality + Priority).
+        /// </summary>
+        private static EffectiveRungInfo EffectiveRung(QualityDefinition rung)
+        {
+            if (!string.IsNullOrWhiteSpace(rung.Codec))
+            {
+                return new EffectiveRungInfo(rung, CanonicalCodec(rung.Codec), rung.Bitrate, rung.IsLossless);
+            }
+
+            var (codec, bitrate, lossless) = ParseQualityLabel(rung.Quality);
+            return new EffectiveRungInfo(rung, codec, rung.Bitrate ?? bitrate, rung.IsLossless || lossless);
+        }
+
+        private static (string? Codec, int? BitrateKbps, bool IsLossless) ParseQualityLabel(string quality)
+        {
+            var lower = (quality ?? string.Empty).Trim().ToLowerInvariant();
+
+            int? bitrate = null;
+            var match = Regex.Match(lower, @"\d{2,}");
+            if (match.Success && int.TryParse(match.Value, out var kb))
+            {
+                bitrate = kb;
+            }
+
+            if (Contains(lower, "flac")) return ("FLAC", bitrate, true);
+            if (Contains(lower, "alac")) return ("ALAC", bitrate, true);
+            if (Contains(lower, "aac") || Contains(lower, "m4b") || Contains(lower, "m4a")) return ("AAC", bitrate, false);
+            if (Contains(lower, "mp3")) return ("MP3", bitrate, false);
+            if (Contains(lower, "opus")) return ("OPUS", bitrate, false);
+            if (Contains(lower, "vorbis") || Contains(lower, "ogg")) return ("OGG Vorbis", bitrate, false);
+            if (Contains(lower, "aiff")) return ("AIFF", bitrate, true);
+            if (Contains(lower, "ape")) return ("APE", bitrate, true);
+            if (Contains(lower, "dsd")) return ("DSD", bitrate, true);
+            if (Contains(lower, "wav") || Contains(lower, "wv")) return ("WavPack", bitrate, true);
+            if (Contains(lower, "lossless")) return (null, bitrate, true);
+
+            // Bare bitrate (e.g. "320kbps") acts as a codec-agnostic wildcard rung.
+            return (null, bitrate, false);
+        }
+
+        /// <summary>Map a file's codec/container/format/extension onto the set of profile codec groups it satisfies.</summary>
+        private static HashSet<string> MapCodec(AudioQualityInput file)
+        {
+            var tokens = new List<string>();
+            AddToken(tokens, file.Codec);
+            AddToken(tokens, file.Container);
+            AddToken(tokens, file.Format);
+            if (!string.IsNullOrWhiteSpace(file.Path))
+            {
+                AddToken(tokens, System.IO.Path.GetExtension(file.Path)?.TrimStart('.'));
+            }
+
+            var groups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            bool Any(string needle) => tokens.Any(t => Contains(t, needle));
+
+            if (Any("flac")) groups.Add("FLAC");
+            if (Any("alac")) groups.Add("ALAC");
+            if (Any("aiff")) groups.Add("AIFF");
+            if (Any("ape")) groups.Add("APE");
+            if (Any("dsd")) groups.Add("DSD");
+            if (Any("wav") || Any("wv")) groups.Add("WavPack");
+            if (Any("mp3")) groups.Add("MP3");
+            if (Any("opus")) groups.Add("OPUS");
+            if (Any("vorbis") || Any("ogg")) groups.Add("OGG Vorbis");
+            // AAC commonly lives in M4B/M4A/MP4 containers; cover the legacy "M4B" codec group too.
+            if (Any("aac") || Any("m4b") || Any("m4a") || Any("mp4"))
+            {
+                groups.Add("AAC");
+                groups.Add("M4B");
+            }
+
+            return groups;
+        }
+
+        /// <summary>Codec groups that represent lossless audio (see <see cref="MapCodec"/>).</summary>
+        private static readonly HashSet<string> LosslessGroups =
+            new(StringComparer.OrdinalIgnoreCase) { "FLAC", "ALAC", "AIFF", "APE", "DSD", "WavPack" };
+
+        private static bool IsLosslessFile(AudioQualityInput file)
+        {
+            // Derive lossless-ness from the same mapped codec groups used for matching, so the
+            // path extension fallback (e.g. "book.flac" with no codec/container/format metadata)
+            // is honoured consistently — otherwise such a file maps to the FLAC group yet is
+            // treated as lossy and filtered off the FLAC rung.
+            return MapCodec(file).Overlaps(LosslessGroups);
+        }
+
+        /// <summary>Convert a bitrate to kbps, guarding values already expressed in kbps.</summary>
+        private static int? NormalizeKbps(int? bitsPerSecond)
+        {
+            if (bitsPerSecond is not int bps || bps <= 0)
+            {
+                return null;
+            }
+
+            return bps >= 1000 ? (int)Math.Round(bps / 1000d) : bps;
+        }
+
+        private static string CanonicalCodec(string codec)
+        {
+            var lower = codec.Trim().ToLowerInvariant();
+            if (Contains(lower, "flac")) return "FLAC";
+            if (Contains(lower, "alac")) return "ALAC";
+            if (Contains(lower, "aac") || Contains(lower, "m4b") || Contains(lower, "m4a")) return "AAC";
+            if (Contains(lower, "mp3")) return "MP3";
+            if (Contains(lower, "opus")) return "OPUS";
+            if (Contains(lower, "vorbis") || Contains(lower, "ogg")) return "OGG Vorbis";
+            return codec.Trim();
+        }
+
+        private static void AddToken(List<string> tokens, string? value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                tokens.Add(value.Trim().ToLowerInvariant());
+            }
+        }
+
+        private static bool Contains(string haystack, string needle)
+            => haystack.Contains(needle, StringComparison.Ordinal);
+    }
+}

--- a/listenarr.infrastructure/HostedServices/Search/AutomaticSearchQualityEvaluator.cs
+++ b/listenarr.infrastructure/HostedServices/Search/AutomaticSearchQualityEvaluator.cs
@@ -16,6 +16,8 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using Listenarr.Application.Audiobooks.Matching;
+using Listenarr.Domain.Common;
 using Microsoft.Extensions.Logging;
 
 namespace Listenarr.Infrastructure.HostedServices.Search
@@ -28,7 +30,10 @@ namespace Listenarr.Infrastructure.HostedServices.Search
             IAudiobookFileRepository fileRepository,
             CancellationToken ct = default)
         {
-            var cutoffMet = await IsQualityCutoffMetAsync(audiobook, downloadRepository, fileRepository, ct);
+            // Cutoff is evaluated by the shared QualityMatcher-backed evaluator so automatic search,
+            // library status, and the API all agree on what "cutoff met" means.
+            var cutoffMet = await AudiobookQualityCutoffEvaluator.IsQualityCutoffMetAsync(
+                audiobook, downloadRepository, fileRepository, logger);
             string? bestQuality = null;
 
             var allDownloads = await downloadRepository.GetByAudiobookIdAsync(audiobook.Id, ct);
@@ -49,7 +54,9 @@ namespace Listenarr.Infrastructure.HostedServices.Search
 
             var existingFiles = await fileRepository.GetByAudiobookIdAsync(audiobook.Id, ct);
 
-            foreach (var fq in existingFiles.Select(DetermineFileQuality).Where(fq => !string.IsNullOrEmpty(fq)))
+            foreach (var fq in existingFiles
+                .Select(f => AudiobookQualityCutoffEvaluator.ResolveFileQualityLabel(f, audiobook.QualityProfile))
+                .Where(fq => !string.IsNullOrEmpty(fq)))
             {
                 if (bestQuality == null) bestQuality = fq;
                 else if (IsQualityBetter(fq, bestQuality, audiobook.QualityProfile)) bestQuality = fq;
@@ -59,147 +66,6 @@ namespace Listenarr.Infrastructure.HostedServices.Search
         }
 
         public bool IsQualityBetter(string? candidateQuality, string? existingQuality, QualityProfile? profile)
-        {
-            if (string.IsNullOrEmpty(candidateQuality)) return false;
-            if (string.IsNullOrEmpty(existingQuality)) return true;
-            if (profile == null) return false;
-
-            var cand = profile.Qualities.FirstOrDefault(q => q.Quality == candidateQuality);
-            var exist = profile.Qualities.FirstOrDefault(q => q.Quality == existingQuality);
-
-            if (cand == null) return false;
-            if (exist == null) return true;
-
-            return cand.Priority > exist.Priority;
-        }
-
-        private async Task<bool> IsQualityCutoffMetAsync(
-            Audiobook audiobook,
-            IDownloadRepository downloadRepository,
-            IAudiobookFileRepository fileRepository,
-            CancellationToken ct = default)
-        {
-            if (audiobook.QualityProfile == null)
-                return false;
-
-            var allDownloads = await downloadRepository.GetByAudiobookIdAsync(audiobook.Id, ct);
-            var existingDownloads = allDownloads.Where(d =>
-                d.Status == DownloadStatus.Completed ||
-                d.Status == DownloadStatus.Downloading ||
-                d.Status == DownloadStatus.ImportPending).ToList();
-
-            var existingFiles = await fileRepository.GetByAudiobookIdAsync(audiobook.Id, ct);
-
-            if (!existingDownloads.Any() && !existingFiles.Any())
-                return false;
-
-            var cutoffQuality = audiobook.QualityProfile.Qualities
-                .FirstOrDefault(q => q.Quality == audiobook.QualityProfile.CutoffQuality);
-
-            if (cutoffQuality == null)
-                return false;
-
-            foreach (var download in existingDownloads)
-            {
-                if (download.Status == DownloadStatus.Completed && !string.IsNullOrEmpty(download.Metadata?.GetValueOrDefault("Quality")?.ToString()))
-                {
-                    var downloadQuality = download.Metadata["Quality"].ToString();
-                    var downloadQualityDefinition = audiobook.QualityProfile.Qualities
-                        .FirstOrDefault(q => q.Quality == downloadQuality);
-
-                    if (downloadQualityDefinition != null && downloadQualityDefinition.Priority >= cutoffQuality.Priority)
-                    {
-                        logger.LogDebug("Quality cutoff met for audiobook '{Title}' by completed download (Quality: {Quality})",
-                            audiobook.Title, downloadQuality);
-                        return true;
-                    }
-                }
-                else if (download.Status == DownloadStatus.Downloading || download.Status == DownloadStatus.ImportPending)
-                {
-                    logger.LogDebug("Quality cutoff assumed met for audiobook '{Title}' due to active download", audiobook.Title);
-                    return true;
-                }
-            }
-
-            foreach (var file in existingFiles)
-            {
-                var fileQuality = DetermineFileQuality(file);
-                if (!string.IsNullOrEmpty(fileQuality))
-                {
-                    var fileQualityDefinition = audiobook.QualityProfile.Qualities
-                        .FirstOrDefault(q => q.Quality == fileQuality);
-
-                    if (fileQualityDefinition != null && fileQualityDefinition.Priority >= cutoffQuality.Priority)
-                    {
-                        logger.LogDebug("Quality cutoff met for audiobook '{Title}' by existing file (Quality: {Quality}, File: {FileName})",
-                            audiobook.Title, fileQuality, Path.GetFileName(file.Path));
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        private static string? DetermineFileQuality(AudiobookFile file)
-        {
-            if (!string.IsNullOrEmpty(file.Container))
-            {
-                var container = file.Container.ToLower();
-                if (container.Contains("flac")) return "FLAC";
-                if (container.Contains("m4b") || container.Contains("m4a")) return "M4B";
-            }
-
-            if (!string.IsNullOrEmpty(file.Format))
-            {
-                var format = file.Format.ToLower();
-                if (format.Contains("flac")) return "FLAC";
-                if (format.Contains("m4b") || format.Contains("m4a")) return "M4B";
-                if (format.Contains("aac")) return "M4B";
-            }
-
-            if (file.Bitrate.HasValue)
-            {
-                var bitrate = file.Bitrate.Value;
-                var kbps = bitrate / 1000;
-
-                if (kbps >= 320) return "MP3 320kbps";
-                if (kbps >= 256) return "MP3 256kbps";
-                if (kbps >= 192) return "MP3 192kbps";
-                if (kbps >= 128) return "MP3 128kbps";
-                if (kbps >= 64) return "MP3 64kbps";
-
-                return "MP3 64kbps";
-            }
-
-            if (!string.IsNullOrEmpty(file.Codec))
-            {
-                var codec = file.Codec.ToLower();
-                if (codec.Contains("flac")) return "FLAC";
-                if (codec.Contains("aac")) return "M4B";
-                if (codec.Contains("mp3")) return "MP3 128kbps";
-                if (codec.Contains("opus")) return "M4B";
-            }
-
-            if (!string.IsNullOrEmpty(file.Path))
-            {
-                var extension = Path.GetExtension(file.Path).ToLower();
-                switch (extension)
-                {
-                    case ".flac":
-                        return "FLAC";
-                    case ".m4b":
-                    case ".m4a":
-                        return "M4B";
-                    case ".mp3":
-                        return "MP3 128kbps";
-                    case ".aac":
-                    case ".opus":
-                        return "M4B";
-                }
-            }
-
-            return null;
-        }
+            => QualityMatcher.IsLabelBetter(candidateQuality, existingQuality, profile);
     }
 }

--- a/tests/Builders/QualityProfileBuilder.cs
+++ b/tests/Builders/QualityProfileBuilder.cs
@@ -8,11 +8,57 @@ namespace Listenarr.Tests.Builders
         public QualityProfileBuilder()
         {
             _qualityProfile.Id = ++IdCounter;
+            _qualityProfile.Qualities = new List<QualityDefinition>();
         }
 
         public QualityProfileBuilder WithName(string value)
         {
             _qualityProfile.Name = value;
+            return this;
+        }
+
+        public QualityProfileBuilder WithCutoff(string value)
+        {
+            _qualityProfile.CutoffQuality = value;
+            return this;
+        }
+
+        public QualityProfileBuilder WithPreferredFormats(params string[] values)
+        {
+            _qualityProfile.PreferredFormats = values.ToList();
+            return this;
+        }
+
+        public QualityProfileBuilder WithQuality(string quality, int priority, string? codec = null, int? bitrate = null, bool lossless = false)
+        {
+            _qualityProfile.Qualities.Add(new QualityDefinition
+            {
+                Quality = quality,
+                Priority = priority,
+                Codec = codec,
+                Bitrate = bitrate,
+                IsLossless = lossless
+            });
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a structured AAC + MP3 bitrate ladder plus a FLAC lossless rung, mirroring the
+        /// frontend's default codec/bitrate ordering (lower priority number = higher quality).
+        /// </summary>
+        public QualityProfileBuilder WithStructuredDefaults()
+        {
+            WithQuality("FLAC", 0, codec: "FLAC", lossless: true);
+            WithQuality("AAC 320kbps", 1, codec: "AAC", bitrate: 320);
+            WithQuality("AAC 256kbps", 2, codec: "AAC", bitrate: 256);
+            WithQuality("AAC 192kbps", 3, codec: "AAC", bitrate: 192);
+            WithQuality("AAC 128kbps", 4, codec: "AAC", bitrate: 128);
+            WithQuality("AAC 64kbps", 5, codec: "AAC", bitrate: 64);
+            WithQuality("MP3 320kbps", 6, codec: "MP3", bitrate: 320);
+            WithQuality("MP3 256kbps", 7, codec: "MP3", bitrate: 256);
+            WithQuality("MP3 VBR", 8, codec: "MP3");
+            WithQuality("MP3 192kbps", 9, codec: "MP3", bitrate: 192);
+            WithQuality("MP3 128kbps", 10, codec: "MP3", bitrate: 128);
             return this;
         }
 

--- a/tests/Features/Application/Audiobooks/Matching/AudiobookStatusEvaluatorTests.cs
+++ b/tests/Features/Application/Audiobooks/Matching/AudiobookStatusEvaluatorTests.cs
@@ -108,6 +108,62 @@ namespace Listenarr.Tests.Features.Application.Audiobooks.Matching
             Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
         }
 
+        [Fact]
+        public void ComputeStatus_ReturnsQualityMatch_ForPathOnlyFile_WhenProbeMetadataMissing()
+        {
+            // Regression: when metadata processing is disabled / ffprobe is unavailable, the file
+            // summary carries only a Path. The status evaluator must forward that Path to the
+            // QualityMatcher (as AudiobookQualityCutoffEvaluator does) so a "book.flac" maps to the
+            // FLAC lossless rung. Previously Path was dropped, so this resolved as quality-mismatch
+            // and disagreed with the automatic-search cutoff.
+            // PreferredFormats = ["flac"] exercises the candidate filter too: a metadata-less file
+            // must match the preferred format via its path extension, not be dropped before the matcher.
+            var profile = new QualityProfile
+            {
+                Name = "Lossless Profile",
+                CutoffQuality = "lossless",
+                PreferredFormats = new List<string> { "flac" },
+                Qualities = new List<QualityDefinition>
+                {
+                    new() { Quality = "lossless", Priority = 0 }
+                }
+            };
+            var files = new List<AudiobookFormatSummary>
+            {
+                new() { Path = "/audiobooks/Author/Title/book.flac" }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
+        [Fact]
+        public void ComputeStatus_ReturnsQualityMatch_ForPathOnlyLossyFile_WhenPreferredFormatMatchesExtension()
+        {
+            // Generality beyond FLAC: the path-extension fallback is format-agnostic. A metadata-less
+            // book.m4b with PreferredFormats = ["m4b"] must pass the candidate filter via its extension
+            // (AAC group) and resolve through the matcher, not be dropped as quality-mismatch.
+            var profile = new QualityProfile
+            {
+                Name = "AAC Profile",
+                CutoffQuality = "AAC 256kbps",
+                PreferredFormats = new List<string> { "m4b" },
+                Qualities = new List<QualityDefinition>
+                {
+                    new() { Quality = "AAC 256kbps", Codec = "AAC", Bitrate = 256, Priority = 0 }
+                }
+            };
+            var files = new List<AudiobookFormatSummary>
+            {
+                new() { Path = "/audiobooks/Author/Title/book.m4b" }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
         private static QualityProfile CreateProfile(string cutoffQuality, List<string> preferredFormats)
         {
             return new QualityProfile

--- a/tests/Features/Domain/Utils/QualityMatcherTests.cs
+++ b/tests/Features/Domain/Utils/QualityMatcherTests.cs
@@ -1,0 +1,352 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Tests.Builders;
+
+namespace Listenarr.Tests.Features.Domain.Utils
+{
+    public class QualityMatcherTests
+    {
+        private static QualityProfileBuilder StructuredProfile() =>
+            new QualityProfileBuilder().WithName("Structured").WithStructuredDefaults();
+
+        // ---- round-down within a codec ----------------------------------------------------
+
+        [Fact]
+        public void Match_RoundsDownToHighestRungFileMeets()
+        {
+            var profile = StructuredProfile().Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 224_000 };
+
+            var result = QualityMatcher.Match(file, profile);
+
+            Assert.True(result.IsMatch);
+            Assert.Equal("AAC 192kbps", result.Rung!.Quality);
+        }
+
+        [Fact]
+        public void Match_ReturnsExactRung_WhenBitrateMatchesExactly()
+        {
+            var profile = StructuredProfile().Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 256_000 };
+
+            Assert.Equal("AAC 256kbps", QualityMatcher.Match(file, profile).Rung!.Quality);
+        }
+
+        [Fact]
+        public void Match_ClampsToTopRung_WhenAboveHighestBitrate()
+        {
+            var profile = StructuredProfile().Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 400_000 };
+
+            Assert.Equal("AAC 320kbps", QualityMatcher.Match(file, profile).Rung!.Quality);
+        }
+
+        [Fact]
+        public void Match_FallsToWorstRung_WhenBelowLowestBitrate()
+        {
+            var profile = StructuredProfile().Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 32_000 };
+
+            Assert.Equal("AAC 64kbps", QualityMatcher.Match(file, profile).Rung!.Quality);
+        }
+
+        // ---- the M4B re-grab loop regression ----------------------------------------------
+
+        [Fact]
+        public void Match_M4bContainerAacFile_MatchesAacRung_NotMismatch()
+        {
+            // The original bug: container "M4B" was emitted as the quality label and never
+            // equalled the "AAC 256kbps" rung, so the cutoff was never met -> re-grab forever.
+            var profile = StructuredProfile().Build();
+            var file = new AudioQualityInput { Codec = "aac", Container = "M4B", BitrateBitsPerSecond = 256_000 };
+
+            var result = QualityMatcher.Match(file, profile);
+
+            Assert.True(result.IsMatch);
+            Assert.Equal("AAC 256kbps", result.Rung!.Quality);
+        }
+
+        [Fact]
+        public void Match_LegacyM4bCodecGroup_Matches()
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("Legacy")
+                .WithQuality("M4B 256kbps", 0, codec: "M4B", bitrate: 256)
+                .Build();
+            var file = new AudioQualityInput { Codec = "aac", Container = "M4A", BitrateBitsPerSecond = 256_000 };
+
+            Assert.True(QualityMatcher.Match(file, profile).IsMatch);
+        }
+
+        // ---- codec absent from profile ----------------------------------------------------
+
+        [Fact]
+        public void Match_CodecNotInProfile_ReturnsCodecMismatch()
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("Mp3AacOnly")
+                .WithQuality("MP3 320kbps", 0, codec: "MP3", bitrate: 320)
+                .WithQuality("AAC 320kbps", 1, codec: "AAC", bitrate: 320)
+                .Build();
+            var file = new AudioQualityInput { Codec = "opus", BitrateBitsPerSecond = 192_000 };
+
+            var result = QualityMatcher.Match(file, profile);
+
+            Assert.False(result.IsMatch);
+            Assert.Equal(QualityMatchKind.CodecMismatch, result.Kind);
+        }
+
+        // ---- lossless ---------------------------------------------------------------------
+
+        [Fact]
+        public void Match_FlacFile_MatchesFlacRung()
+        {
+            var profile = StructuredProfile().Build();
+            var file = new AudioQualityInput { Codec = "flac", Container = "FLAC" };
+
+            Assert.Equal("FLAC", QualityMatcher.Match(file, profile).Rung!.Quality);
+        }
+
+        [Fact]
+        public void Match_FlacFile_WithOnlyPathExtension_MatchesFlacRung()
+        {
+            // No codec/container/format metadata (metadata processing off, ffprobe missing, or
+            // extraction failed) — the path extension is the only quality signal. MapCodec already
+            // uses it, so lossless-ness must be derived consistently or "book.flac" maps to the
+            // FLAC group yet is treated as lossy and filtered off the FLAC rung.
+            var profile = StructuredProfile().Build();
+            var file = new AudioQualityInput { Path = "/audiobooks/book.flac" };
+
+            var result = QualityMatcher.Match(file, profile);
+
+            Assert.True(result.IsMatch);
+            Assert.Equal("FLAC", result.Rung!.Quality);
+        }
+
+        [Fact]
+        public void Match_LosslessFile_NoLosslessRung_ReturnsCodecMismatch()
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("LossyOnly")
+                .WithQuality("MP3 320kbps", 0, codec: "MP3", bitrate: 320)
+                .WithQuality("AAC 320kbps", 1, codec: "AAC", bitrate: 320)
+                .Build();
+            var file = new AudioQualityInput { Codec = "flac", Container = "FLAC" };
+
+            Assert.Equal(QualityMatchKind.CodecMismatch, QualityMatcher.Match(file, profile).Kind);
+        }
+
+        // ---- bitrate unit normalization ---------------------------------------------------
+
+        [Fact]
+        public void Match_NormalizesBitsPerSecond()
+        {
+            var profile = StructuredProfile().Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 320_000 };
+
+            Assert.Equal("AAC 320kbps", QualityMatcher.Match(file, profile).Rung!.Quality);
+        }
+
+        [Fact]
+        public void Match_GuardsValuesAlreadyInKbps()
+        {
+            var profile = StructuredProfile().Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 320 };
+
+            Assert.Equal("AAC 320kbps", QualityMatcher.Match(file, profile).Rung!.Quality);
+        }
+
+        // ---- VBR and unknown bitrate ------------------------------------------------------
+
+        [Fact]
+        public void Match_UnknownBitrate_PrefersVbrRung()
+        {
+            var profile = StructuredProfile().Build();
+            var file = new AudioQualityInput { Codec = "mp3", BitrateBitsPerSecond = null };
+
+            Assert.Equal("MP3 VBR", QualityMatcher.Match(file, profile).Rung!.Quality);
+        }
+
+        [Fact]
+        public void Match_UnknownBitrate_NoVbr_FallsToWorstRung()
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("AacNoVbr")
+                .WithQuality("AAC 320kbps", 0, codec: "AAC", bitrate: 320)
+                .WithQuality("AAC 128kbps", 1, codec: "AAC", bitrate: 128)
+                .Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = null };
+
+            Assert.Equal("AAC 128kbps", QualityMatcher.Match(file, profile).Rung!.Quality);
+        }
+
+        // ---- OGG Vorbis by codec ----------------------------------------------------------
+
+        [Fact]
+        public void Match_OggVorbis_MatchesByCodec()
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("Ogg")
+                .WithQuality("OGG Vorbis 256kbps", 0, codec: "OGG Vorbis", bitrate: 256)
+                .WithQuality("OGG Vorbis 192kbps", 1, codec: "OGG Vorbis", bitrate: 192)
+                .Build();
+            var file = new AudioQualityInput { Codec = "vorbis", Container = "OGG", BitrateBitsPerSecond = 192_000 };
+
+            Assert.Equal("OGG Vorbis 192kbps", QualityMatcher.Match(file, profile).Rung!.Quality);
+        }
+
+        // ---- seed-style rungs (Codec null, parse from label) ------------------------------
+
+        [Fact]
+        public void Match_SeedStyleRung_ParsesLabelForCodecAndBitrate()
+        {
+            // Seed rungs only set Quality + Priority (no structured Codec/Bitrate).
+            var profile = new QualityProfileBuilder()
+                .WithName("Seed")
+                .WithQuality("AAC 320kbps", 0)
+                .WithQuality("AAC 256kbps", 1)
+                .WithQuality("AAC 192kbps", 2)
+                .Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 256_000 };
+
+            Assert.Equal("AAC 256kbps", QualityMatcher.Match(file, profile).Rung!.Quality);
+        }
+
+        // ---- bare-bitrate wildcard (AudiobookStatusEvaluator parity) ----------------------
+
+        [Fact]
+        public void Match_BareBitrateRung_ActsAsCodecWildcard()
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("Bare")
+                .WithQuality("320kbps", 0)
+                .WithQuality("256kbps", 1)
+                .WithQuality("192kbps", 2)
+                .Build();
+            var file = new AudioQualityInput { Format = "m4b", BitrateBitsPerSecond = 256_000 };
+
+            Assert.Equal("256kbps", QualityMatcher.Match(file, profile).Rung!.Quality);
+        }
+
+        // ---- MeetsCutoff direction (lower priority = higher quality) ----------------------
+
+        [Fact]
+        public void MeetsCutoff_BelowCutoff_IsFalse()
+        {
+            var profile = StructuredProfile().WithCutoff("AAC 256kbps").Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 192_000 };
+
+            Assert.False(QualityMatcher.MeetsCutoff(file, profile));
+        }
+
+        [Fact]
+        public void MeetsCutoff_AtCutoffBoundary_IsTrue()
+        {
+            var profile = StructuredProfile().WithCutoff("AAC 256kbps").Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 256_000 };
+
+            Assert.True(QualityMatcher.MeetsCutoff(file, profile));
+        }
+
+        [Fact]
+        public void MeetsCutoff_ExceedsCutoff_IsTrue()
+        {
+            var profile = StructuredProfile().WithCutoff("AAC 256kbps").Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 320_000 };
+
+            Assert.True(QualityMatcher.MeetsCutoff(file, profile));
+        }
+
+        [Fact]
+        public void MeetsCutoff_CodecMismatch_IsFalse()
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("Mp3Only")
+                .WithCutoff("MP3 256kbps")
+                .WithQuality("MP3 320kbps", 0, codec: "MP3", bitrate: 320)
+                .WithQuality("MP3 256kbps", 1, codec: "MP3", bitrate: 256)
+                .Build();
+            var file = new AudioQualityInput { Codec = "opus", BitrateBitsPerSecond = 320_000 };
+
+            Assert.False(QualityMatcher.MeetsCutoff(file, profile));
+        }
+
+        [Fact]
+        public void MeetsCutoff_NoCutoffConfigured_IsTrue()
+        {
+            var profile = StructuredProfile().Build(); // no cutoff set
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 64_000 };
+
+            Assert.True(QualityMatcher.MeetsCutoff(file, profile));
+        }
+
+        [Fact]
+        public void MeetsCutoff_CutoffRungMissing_IsFalse()
+        {
+            var profile = StructuredProfile().WithCutoff("Nonexistent 999kbps").Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 320_000 };
+
+            Assert.False(QualityMatcher.MeetsCutoff(file, profile));
+        }
+
+        // ---- LabelMeetsCutoff & IsLabelBetter & ProfileContainsHint -----------------------
+
+        [Fact]
+        public void LabelMeetsCutoff_HonoursPriorityDirection()
+        {
+            var profile = StructuredProfile().WithCutoff("AAC 256kbps").Build();
+
+            Assert.True(QualityMatcher.LabelMeetsCutoff("AAC 320kbps", profile));
+            Assert.True(QualityMatcher.LabelMeetsCutoff("AAC 256kbps", profile));
+            Assert.False(QualityMatcher.LabelMeetsCutoff("AAC 192kbps", profile));
+        }
+
+        [Fact]
+        public void IsLabelBetter_LowerPriorityNumberWins()
+        {
+            var profile = StructuredProfile().Build();
+
+            Assert.True(QualityMatcher.IsLabelBetter("AAC 320kbps", "AAC 256kbps", profile));
+            Assert.False(QualityMatcher.IsLabelBetter("AAC 192kbps", "AAC 256kbps", profile));
+            Assert.False(QualityMatcher.IsLabelBetter("AAC 256kbps", "AAC 256kbps", profile));
+        }
+
+        [Fact]
+        public void IsLabelBetter_HandlesUnknownInputs()
+        {
+            var profile = StructuredProfile().Build();
+
+            Assert.False(QualityMatcher.IsLabelBetter(null, "AAC 256kbps", profile));
+            Assert.True(QualityMatcher.IsLabelBetter("AAC 256kbps", null, profile));
+            Assert.False(QualityMatcher.IsLabelBetter("Unknown", "AAC 256kbps", profile));
+            Assert.True(QualityMatcher.IsLabelBetter("AAC 256kbps", "Unknown", profile));
+        }
+
+        [Fact]
+        public void ProfileContainsHint_IsCaseInsensitive()
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("Custom")
+                .WithQuality("Audible AAX", 0)
+                .Build();
+
+            Assert.True(QualityMatcher.ProfileContainsHint(profile, "audible aax"));
+            Assert.False(QualityMatcher.ProfileContainsHint(profile, "FLAC"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the **M4B re-grab loop**: a monitored audiobook whose file is already at/above cutoff is searched and re-downloaded on every cycle. Replaces #581 with the profile-driven matching approach we agreed on.

**Root cause.** The cutoff check classified an on-disk file into an ad-hoc label — the container `"M4B"`, or a bare `"256kbps"` — and looked that string up in the profile's quality rungs. Real rungs are named by codec + bitrate (`"AAC 256kbps"`), so the label never matched, `cutoffMet` stayed false, and the audiobook was re-grabbed forever. The same string-label logic existed in **three** places with **three different vocabularies**: `AudiobookStatusEvaluator` (status display), `AutomaticSearchService` (the actual re-grab driver), and a near-duplicate in `LibraryController`.

## Changes

### Added
- **`QualityMatcher`** (`listenarr.domain/Common`): a pure, dependency-free matcher. Given a file's codec/bitrate/lossless facts and a profile, it walks `profile.Qualities` using the structured `Codec` / `Bitrate` / `IsLossless` fields — falling back to parsing the rung label for seed/legacy profiles that only set `Quality` + `Priority` — and: **round-down** (picks the highest rung the file meets or exceeds); returns a defined **`CodecMismatch`** when the file's codec isn't in the profile (instead of the old `int.MaxValue` silent fallback); matches OGG Vorbis by codec, maps AAC-in-M4B/M4A (incl. the legacy `M4B` codec group), and normalizes bits/sec → kbps in one place.
- 26 new unit tests (`QualityMatcherTests`), incl. the exact M4B-loop regression; `QualityProfileBuilder` extended.

### Changed
- The status evaluator, automatic search, and library controller now share a single **`QualityCutoffEvaluator`** that calls the matcher.
- **Inverted priority comparison corrected.** `AutomaticSearchService`'s cutoff check (`Priority >= cutoff`) and `IsQualityBetter` (`cand.Priority > exist.Priority`) compared rungs the wrong way round given the model's "lower number = higher quality" (matching the seed profiles, FE, and status evaluator). They now use the canonical direction.

### Fixed
- The M4B re-grab loop (see Summary).
- **Path-only / metadata-less files** are no longer dropped before matching. `AudiobookStatusEvaluator` now forwards `Path` into `AudioQualityInput` (as `QualityCutoffEvaluator` does), and its candidate-format pre-filter falls back to the path extension when `Format`/`Container` are empty — so e.g. a tagless `book.m4b` with `PreferredFormats = ["m4b"]` reaches the matcher instead of returning quality-mismatch.

### Removed
- ~380 lines of duplicated, drifting string-label detection logic across the three call sites.
- The frontend's client-side status recomputation in `audiobookStatus.ts`; the FE now trusts the server-computed status (overriding only for the transient "download in flight" case).

## Testing

- Full backend suite green (**711 tests**), including the M4B-loop regression and the path-only fallback cases (FLAC-by-extension and a second path-only `m4b` case proving the fallback is format-agnostic).
- Frontend: 364 tests + type-check + eslint green.

## Notes

**Behaviour changes to confirm:**
1. **Inverted priority comparison corrected** — this changes grab/skip decisions: a result is grabbed only when genuinely better than the existing file, and cutoff is met only when the file is at least cutoff quality.
2. **Codec absent from profile ⇒ cutoff not met** ⇒ such files keep being searched (the logical inverse of the old accidental "always at max priority" behaviour).
3. **Round-down floor:** a file below the lowest rung (or unknown bitrate with no VBR rung) maps to the worst rung for its codec — conservative, never over-claims.

**Out of scope (deliberate):** the `PreferredFormats → PreferredContainers` split + EF migration + frontend is tracked separately in #647. `DownloadImportService.IsQualityBetter` is left untouched — it's a different, profile-independent "acceptable downgrade?" gate, not the inverted-priority bug.

Closes #581.
Follow-up: #647.
