### PR TITLE
fix(metadata): restore author/series catalog cache on SQLite

### DIFF
--- a/listenarr.infrastructure/Persistence/Repositories/AudiobookRepository.cs
+++ b/listenarr.infrastructure/Persistence/Repositories/AudiobookRepository.cs
@@ -223,7 +223,9 @@ namespace Listenarr.Infrastructure.Persistence.Repositories
 
             return await _db.AuthorCacheEntries
                 .AsNoTracking()
-                .OrderByDescending(entry => entry.LastFetchedAt.GetValueOrDefault(entry.UpdatedAt))
+                // COALESCE form — SQLite EF can't translate Nullable.GetValueOrDefault (it throws,
+                // and the caller's best-effort catch then silently disables this cache).
+                .OrderByDescending(entry => entry.LastFetchedAt ?? entry.UpdatedAt)
                 .FirstOrDefaultAsync(entry =>
                     entry.AuthorNameNormalized == normalizedName &&
                     entry.Region == normalizedRegion);
@@ -241,7 +243,9 @@ namespace Listenarr.Infrastructure.Persistence.Repositories
 
             return await _db.AuthorCacheEntries
                 .AsNoTracking()
-                .OrderByDescending(entry => entry.LastFetchedAt.GetValueOrDefault(entry.UpdatedAt))
+                // COALESCE form — SQLite EF can't translate Nullable.GetValueOrDefault (it throws,
+                // and the caller's best-effort catch then silently disables this cache).
+                .OrderByDescending(entry => entry.LastFetchedAt ?? entry.UpdatedAt)
                 .FirstOrDefaultAsync(entry =>
                     entry.AuthorAsin != null &&
                     entry.AuthorAsin.ToUpper() == normalizedAsin &&
@@ -326,7 +330,9 @@ namespace Listenarr.Infrastructure.Persistence.Repositories
 
             return await _db.SeriesCacheEntries
                 .AsNoTracking()
-                .OrderByDescending(entry => entry.LastFetchedAt.GetValueOrDefault(entry.UpdatedAt))
+                // COALESCE form — SQLite EF can't translate Nullable.GetValueOrDefault (it throws,
+                // and the caller's best-effort catch then silently disables this cache).
+                .OrderByDescending(entry => entry.LastFetchedAt ?? entry.UpdatedAt)
                 .FirstOrDefaultAsync(entry =>
                     entry.SeriesNameNormalized == normalizedName &&
                     entry.Region == normalizedRegion);
@@ -344,7 +350,9 @@ namespace Listenarr.Infrastructure.Persistence.Repositories
 
             return await _db.SeriesCacheEntries
                 .AsNoTracking()
-                .OrderByDescending(entry => entry.LastFetchedAt.GetValueOrDefault(entry.UpdatedAt))
+                // COALESCE form — SQLite EF can't translate Nullable.GetValueOrDefault (it throws,
+                // and the caller's best-effort catch then silently disables this cache).
+                .OrderByDescending(entry => entry.LastFetchedAt ?? entry.UpdatedAt)
                 .FirstOrDefaultAsync(entry =>
                     entry.SeriesAsin != null &&
                     entry.SeriesAsin.ToUpper() == normalizedAsin &&

--- a/tests/Features/Infrastructure/Repositories/AudiobookRepository_CatalogCacheReadTests.cs
+++ b/tests/Features/Infrastructure/Repositories/AudiobookRepository_CatalogCacheReadTests.cs
@@ -1,0 +1,140 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Listenarr.Infrastructure.Persistence.Repositories;
+
+namespace Listenarr.Tests.Features.Infrastructure.Repositories
+{
+    // Regression for the author/series catalog cache read paths.
+    //
+    // These deliberately use the real SQLite provider (not the EF InMemory provider) so that
+    // query translation is actually exercised. The cache reads order by recency; using
+    // Nullable.GetValueOrDefault there is not translatable by the SQLite provider and throws
+    // at runtime, which the cache callers swallow as a best-effort miss — silently disabling
+    // the cache so every author/series page re-fetched from Audible. The InMemory provider
+    // tolerates that LINQ, so it cannot catch this class of bug.
+    public class AudiobookRepository_CatalogCacheReadTests
+    {
+        private sealed class TestDb : IDisposable
+        {
+            private readonly SqliteConnection _connection;
+            public ListenArrDbContext Db { get; }
+
+            public TestDb()
+            {
+                _connection = new SqliteConnection("DataSource=:memory:");
+                _connection.Open();
+                Db = new ListenArrDbContext(
+                    new DbContextOptionsBuilder<ListenArrDbContext>().UseSqlite(_connection).Options);
+                Db.Database.EnsureCreated();
+            }
+
+            public void Dispose()
+            {
+                Db.Dispose();
+                _connection.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task GetCachedAuthorByName_ReadsBackUnderSqlite()
+        {
+            using var ctx = new TestDb();
+            var repository = new AudiobookRepository(ctx.Db);
+
+            await repository.UpsertCachedAuthorAsync(new AuthorCacheEntry
+            {
+                AuthorName = "Brandon Sanderson",
+                AuthorAsin = "B001IGFHW6",
+                Region = "us"
+            });
+
+            var byName = await repository.GetCachedAuthorByNameAsync("Brandon Sanderson", "us");
+            var byAsin = await repository.GetCachedAuthorByAsinAsync("B001IGFHW6", "us");
+
+            Assert.NotNull(byName);
+            Assert.Equal("B001IGFHW6", byName!.AuthorAsin);
+            Assert.NotNull(byAsin);
+            Assert.Equal("Brandon Sanderson", byAsin!.AuthorName);
+        }
+
+        [Fact]
+        public async Task GetCachedSeriesByName_ReadsBackUnderSqlite()
+        {
+            using var ctx = new TestDb();
+            var repository = new AudiobookRepository(ctx.Db);
+
+            await repository.UpsertCachedSeriesAsync(new SeriesCacheEntry
+            {
+                SeriesName = "The Stormlight Archive",
+                SeriesAsin = "B00INWST01",
+                Region = "us"
+            });
+
+            var byName = await repository.GetCachedSeriesByNameAsync("The Stormlight Archive", "us");
+            var byAsin = await repository.GetCachedSeriesByAsinAsync("B00INWST01", "us");
+
+            Assert.NotNull(byName);
+            Assert.Equal("The Stormlight Archive", byName!.SeriesName);
+            Assert.NotNull(byAsin);
+            Assert.Equal("The Stormlight Archive", byAsin!.SeriesName);
+        }
+
+        [Fact]
+        public async Task GetCachedSeriesByAsin_OrdersByRecency_WhenLastFetchedAtIsNull()
+        {
+            using var ctx = new TestDb();
+            var db = ctx.Db;
+            var repository = new AudiobookRepository(db);
+
+            // Two distinct series rows can legitimately share one ASIN (e.g. two name slugs
+            // resolved to the same Audible series), so the by-ASIN read orders by recency to
+            // return the freshest. Insert directly to control LastFetchedAt/UpdatedAt — the
+            // (SeriesNameNormalized, Region) uniqueness only allows this on differing names.
+            db.SeriesCacheEntries.Add(new SeriesCacheEntry
+            {
+                SeriesNameNormalized = "mistborn",
+                SeriesName = "Mistborn",
+                SeriesAsin = "B00SHARED1",
+                Region = "us",
+                LastFetchedAt = DateTime.UtcNow.AddDays(-2),
+                CreatedAt = DateTime.UtcNow.AddDays(-2),
+                UpdatedAt = DateTime.UtcNow.AddDays(-2)
+            });
+            // Newer row with no LastFetchedAt: recency must coalesce to UpdatedAt (the branch
+            // GetValueOrDefault could not translate), and the query must not throw.
+            db.SeriesCacheEntries.Add(new SeriesCacheEntry
+            {
+                SeriesNameNormalized = "the final empire",
+                SeriesName = "The Final Empire (newer)",
+                SeriesAsin = "B00SHARED1",
+                Region = "us",
+                LastFetchedAt = null,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow.AddDays(1)
+            });
+            await db.SaveChangesAsync();
+
+            var resolved = await repository.GetCachedSeriesByAsinAsync("B00SHARED1", "us");
+
+            Assert.NotNull(resolved);
+            Assert.Equal("The Final Empire (newer)", resolved!.SeriesName);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The persisted author/series metadata cache never returned a hit on SQLite, so every author and series page re-fetched the full catalog from Audible on each load. The cache-read query ordered by `Nullable<DateTime>.GetValueOrDefault(...)`, which the SQLite EF Core provider can't translate — the query throws, each caller's best-effort `catch` swallows it as a cache miss, and the cache is effectively dead. This switches the ordering to a translatable `COALESCE` (`??`) and adds regression coverage that runs against the real SQLite provider.

## Changes

### Fixed
- The four catalog-cache reads in `AudiobookRepository` (`GetCachedAuthorByNameAsync`, `GetCachedAuthorByAsinAsync`, `GetCachedSeriesByNameAsync`, `GetCachedSeriesByAsinAsync`) now order by `entry.LastFetchedAt ?? entry.UpdatedAt` (maps to SQL `COALESCE`) instead of `LastFetchedAt.GetValueOrDefault(UpdatedAt)`, which the SQLite EF provider cannot translate and throws on at execution time. Identical freshest-first ordering, but it no longer throws — so the author/series cache actually returns hits instead of re-fetching from Audible on every page load. An inline comment at each site records why, to prevent the pattern regressing.

## Testing
- New `AudiobookRepository_CatalogCacheReadTests` exercises the four reads against the **real** SQLite provider (`Microsoft.Data.Sqlite` `:memory:`) rather than the EF InMemory provider, which tolerates the untranslatable LINQ and so cannot reproduce the failure. The tests fail on the pre-fix code with `Translation of method 'System.DateTime?.GetValueOrDefault' failed` and pass with the fix.
- Full suite green: `dotnet test` (1015/1015).

## Notes
- No changes to the cache *write* paths or schema — behavior is identical apart from the cache now actually being read.
- Rebased onto current `canary`; the `CHANGELOG.md` entry was removed per review (the project no longer tracks `CHANGELOG.md`).
