### PR TITLE
fix(frontend): load root folders on mount so cold first add isn't falsely rejected

### DIFF
--- a/fe/src/__tests__/AddNewView.spec.ts
+++ b/fe/src/__tests__/AddNewView.spec.ts
@@ -768,4 +768,21 @@ describe('AddNewView pagination', () => {
     expect(addBtn.text()).toContain('Added')
     expect(addBtn.attributes('disabled')).toBeDefined()
   })
+
+  // Regression: cold-add "root folder not configured" false negative.
+  // The addToLibrary() guard reads rootFoldersStore.folders synchronously, so
+  // the store must be populated on mount; otherwise the first add after a fresh
+  // page load wrongly redirects to /settings.
+  it('loads root folders on mount so the cold first add is not falsely rejected', async () => {
+    const apiModule = await import('@/services/api')
+    const getRootFolders = apiModule.apiService.getRootFolders as unknown as Mock
+    getRootFolders.mockClear()
+    getRootFolders.mockResolvedValue([{ id: 1, name: 'Books', path: '/books', isDefault: true }])
+
+    const router = createTestRouter()
+    mount(AddNewView, { global: { plugins: [createPinia(), router] } })
+    await flushPromises()
+
+    expect(getRootFolders).toHaveBeenCalled()
+  })
 })

--- a/fe/src/stores/rootFolders.ts
+++ b/fe/src/stores/rootFolders.ts
@@ -38,7 +38,9 @@ export const useRootFoldersStore = defineStore('rootFolders', () => {
       }
     } catch (err) {
       logger.debug('Failed to load root folders:', err)
-      folders.value = []
+      // Preserve any previously-loaded folders on transient failure: a failed
+      // reload must not masquerade as "no root folders configured" (folders
+      // starts as [], so a first-ever failure still yields an empty list).
     } finally {
       loading.value = false
     }

--- a/fe/src/views/content/AddNewView.vue
+++ b/fe/src/views/content/AddNewView.vue
@@ -2998,6 +2998,11 @@ onMounted(async () => {
   await configStore.loadApplicationSettings()
   await configStore.loadApiConfigurations()
 
+  // Ensure root folders are loaded before addToLibrary()'s guard reads them.
+  // Without this, the first add after a cold page load sees an empty store and
+  // falsely reports "Root folder not configured" until a redirect populates it.
+  if (rootFoldersStore.folders.length === 0) await rootFoldersStore.load()
+
   const defaultRegion = normalizeSearchRegion(configStore.applicationSettings?.defaultSearchRegion)
   const defaultLanguage = normalizePreferredSearchLanguage(
     configStore.applicationSettings?.defaultSearchLanguage,

--- a/fe/src/views/library/AudiobookDetailView.vue
+++ b/fe/src/views/library/AudiobookDetailView.vue
@@ -1171,6 +1171,10 @@ onMounted(async () => {
   syncActiveTabFromRoute()
   document.addEventListener('click', handleClickOutside)
 
+  // The path preview falls back to rootFoldersStore.defaultFolder; load it so a
+  // cold page load shows the correct destination rather than the legacy outputPath.
+  if (rootFoldersStore.folders.length === 0) await rootFoldersStore.load()
+
   await loadAudiobook()
 
   // subscribe to scan job updates

--- a/fe/src/views/library/AudiobooksView.vue
+++ b/fe/src/views/library/AudiobooksView.vue
@@ -1911,6 +1911,9 @@ onMounted(async () => {
     libraryStore.fetchLibrary(),
     configStore.loadApplicationSettings(),
     loadQualityProfiles(),
+    // hasRootFolderConfigured gates the empty-state CTA on this store; load it
+    // so an empty library doesn't falsely show "Root Folder Not Configured".
+    rootFoldersStore.folders.length === 0 ? rootFoldersStore.load() : Promise.resolve(),
   ])
 
   // Load persisted view mode (if available) before layout calc


### PR DESCRIPTION
## Summary

Fixes the **cold-start "Root folder not configured" false negative**. After a fresh page load (or after the app has been idle long enough that the SPA is re-initialised), the *first* attempt to add an audiobook reports **"Root folder not configured"** and redirects to Settings — even though a root folder *is* configured. Going **browser-back and trying again works**, which is the tell-tale symptom.

**Root cause.** `rootFoldersStore` is only ever populated by an explicit `load()` call. Several views read `rootFoldersStore.folders` *synchronously* to gate UI, but nothing loads the store on a cold SPA start — not `App.vue`, not the router, not these views' `onMounted`. So the guard sees an empty list and assumes no folder is configured. The redirect to `/settings` happens to load the store, which is why the second attempt succeeds.

The same un-loaded-store read affects two more views (found while tracing the root cause).

## Changes

### Changed
- **`AddNewView.vue`** — load root folders in `onMounted` before `addToLibrary()`'s guard can read them. This is the primary cold-add fix.
- **`AudiobooksView.vue`** — `hasRootFolderConfigured` drives a "Root Folder Not Configured" empty-state CTA; load the store on mount so an empty library doesn't falsely show it.
- **`AudiobookDetailView.vue`** — the path-preview computed falls back to `rootFoldersStore.defaultFolder`; load the store on mount so a cold load previews the correct destination instead of the legacy `outputPath`.
- All three mirror the existing pattern already used in `LibraryImportView.vue` and `UnmatchedFilesModal.vue` (`if (folders.length === 0) await load()`).

### Fixed
- **`stores/rootFolders.ts`** — `load()` no longer resets `folders` to `[]` inside its `catch`. Previously a transient API failure on *reload* wiped already-loaded folders, making a failed load indistinguishable from "no folders configured". `folders` still starts as `[]`, so a first-ever failure naturally yields an empty list.

### Added
- Regression test in `AddNewView.spec.ts` asserting the view fetches root folders on mount.

## Testing

- Full frontend suite green (**363 passed, 1 skipped**), including the new regression test.
- `vue-tsc --noEmit` and `eslint` clean on all changed files.

## Notes

- The guard at `AddNewView.vue` also accepts a configured `applicationSettings.outputPath` as an alternative to a root folder; that path was already loaded on mount, so only the root-folder half was failing.
- `load()` has no in-flight de-dupe; the `if (folders.length === 0)` caller-side guard keeps this to a single fetch per cold load, consistent with the existing call sites. A store-level loading guard would be a reasonable follow-up but is out of scope here.
