### PR TITLE
Bump version to 1.0.9

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "listenarr-fe",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "listenarr-fe",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "hasInstallScript": true,
       "dependencies": {
         "@material/material-color-utilities": "^0.4.0",

--- a/fe/package.json
+++ b/fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listenarr-fe",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "type": "module",
   "engines": {

--- a/listenarr.api/Listenarr.Api.csproj
+++ b/listenarr.api/Listenarr.Api.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>1.0.8</Version>
-    <AssemblyVersion>1.0.8</AssemblyVersion>
+    <Version>1.0.9</Version>
+    <AssemblyVersion>1.0.9</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefaultItemExcludes>$(DefaultItemExcludes);bin\**;bin/**;artifacts\**;artifacts/**;docker-publish\**;docker-publish/**;publish\**;publish/**</DefaultItemExcludes>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "listenarr",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "listenarr",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "dependencies": {
         "concurrently": "^9.2.1",
         "wait-on": "^9.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "listenarr",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "description": "Listenarr - Automated audiobook downloading and management",
   "scripts": {


### PR DESCRIPTION
This PR bumps the application version to 1.0.9.
The change was produced automatically by the CI canary workflow.