### PR TITLE
fix(library): stabilize list-view virtual scroller (#675)

### DIFF
--- a/fe/src/__tests__/AudiobooksView.spec.ts
+++ b/fe/src/__tests__/AudiobooksView.spec.ts
@@ -796,3 +796,229 @@ describe('AudiobooksView Grouping', () => {
     expect(wrapper.find('.series-bottom-placard').exists()).toBe(true)
   })
 })
+
+describe('AudiobooksView list-view virtual scroll', () => {
+  type ScrollVm = {
+    viewMode: 'grid' | 'list'
+    showItemDetails: boolean
+    measuredRowHeight: number | null
+    visibleRange: { start: number; end: number }
+    totalHeight: number
+    getRowHeight: () => number
+    updateVisibleRange: () => void
+    onScroll: () => void
+    sortKey: string
+    sortOrder: 'asc' | 'desc'
+  }
+
+  const ensureBrowserGlobals = () => {
+    if (
+      typeof (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver === 'undefined'
+    ) {
+      ;(globalThis as unknown as Record<string, unknown>).ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    }
+    if (typeof (globalThis as unknown as { WebSocket?: unknown }).WebSocket === 'undefined') {
+      ;(globalThis as unknown as Record<string, unknown>).WebSocket = function () {
+        /* noop */
+      }
+    }
+  }
+
+  const mountListView = async (count: number) => {
+    ensureBrowserGlobals()
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'home', component: { template: '<div />' } },
+        { path: '/audiobooks', name: 'audiobooks', component: AudiobooksView },
+      ],
+    })
+    await router.push('/audiobooks')
+    await router.isReady().catch(() => {})
+
+    const store = useLibraryStore()
+    store.audiobooks = Array.from({ length: count }, (_, index) => ({
+      id: index + 1,
+      title: `Book ${index + 1}`,
+      authors: [`Author ${index % 5}`],
+      imageUrl: `cover${index + 1}.jpg`,
+      files: [],
+    })) as unknown as import('@/types').Audiobook[]
+    store.fetchLibrary = vi.fn(async () => undefined)
+
+    localStorage.setItem('listenarr.groupBy', 'books')
+    localStorage.setItem('listenarr.showItemDetails', 'false')
+
+    const wrapper = mount(AudiobooksView, {
+      global: {
+        plugins: [pinia, router],
+        stubs: [
+          'BulkEditModal',
+          'EditAudiobookModal',
+          'CustomFilterModal',
+          'FiltersDropdown',
+          'CustomSelect',
+        ],
+      },
+    })
+    await new Promise((r) => setTimeout(r, 0))
+
+    const vm = wrapper.vm as unknown as ScrollVm
+    vm.viewMode = 'list'
+    await new Promise((r) => setTimeout(r, 0))
+    return { wrapper, vm, store }
+  }
+
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('uses a fixed list row height and ignores a stale grid measuredRowHeight (no oversized scroll area)', async () => {
+    const { vm } = await mountListView(50)
+
+    // Simulate an inflated grid measurement leaking into list view via the shared ref.
+    vm.measuredRowHeight = 240
+
+    expect(vm.viewMode).toBe('list')
+    // Must be the fixed list constant, not the leaked 240px grid measurement.
+    expect(vm.getRowHeight()).toBe(80)
+  })
+
+  it('uses a taller fixed row height when show-details is enabled', async () => {
+    const { vm } = await mountListView(10)
+
+    vm.showItemDetails = true
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(vm.getRowHeight()).toBe(120)
+  })
+
+  it('reserves space for the list header in totalHeight so the last row stays reachable', async () => {
+    const { vm } = await mountListView(50)
+
+    // n rows (80px) plus the always-present column header (40px). Without
+    // reserving the header height the last row sits below the scrollable area
+    // and cannot be fully scrolled into view.
+    expect(vm.totalHeight).toBe(80 * 50 + 40)
+  })
+
+  it('keeps the list scroll geometry stable when the sort order changes (sort-then-scroll)', async () => {
+    const { vm } = await mountListView(50)
+
+    // Simulate a tall row having been sampled, then the user re-sorts (e.g. Author
+    // Z->A). The reorder must not let that stale sample — or the reshuffle of which
+    // row renders first — change the fixed list row height or the scroll area; that
+    // interaction was what locked up the page on the next scroll.
+    vm.measuredRowHeight = 240
+    vm.sortKey = 'author-last'
+    vm.sortOrder = 'desc'
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(vm.sortOrder).toBe('desc')
+    expect(vm.getRowHeight()).toBe(80)
+    expect(vm.totalHeight).toBe(80 * 50 + 40)
+  })
+
+  it('does not reassign visibleRange when the computed range is unchanged', async () => {
+    const { vm } = await mountListView(50)
+
+    vm.updateVisibleRange()
+    const firstRange = vm.visibleRange
+    vm.updateVisibleRange()
+    const secondRange = vm.visibleRange
+
+    // Stable identity → no needless watcher fires / re-renders on every scroll tick.
+    expect(secondRange).toBe(firstRange)
+  })
+
+  it('coalesces rapid scroll events into a single animation frame', async () => {
+    const { vm } = await mountListView(50)
+
+    const rafCallbacks: FrameRequestCallback[] = []
+    const rafSpy = vi
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        rafCallbacks.push(cb)
+        return rafCallbacks.length
+      })
+
+    try {
+      vm.onScroll()
+      vm.onScroll()
+      vm.onScroll()
+      // Three scroll events, one scheduled frame.
+      expect(rafSpy).toHaveBeenCalledTimes(1)
+
+      // Flushing the frame allows the next scroll to schedule again.
+      rafCallbacks[0]?.(0)
+      vm.onScroll()
+      expect(rafSpy).toHaveBeenCalledTimes(2)
+    } finally {
+      rafSpy.mockRestore()
+    }
+  })
+
+  it('widens the visible slice to the rows scrolled into view', async () => {
+    const { wrapper, vm } = await mountListView(50)
+    const el = wrapper.find('.audiobooks-scroll-container').element as HTMLElement
+    // jsdom has no layout, so force the scroll geometry the math reads.
+    Object.defineProperty(el, 'clientHeight', { value: 800, configurable: true })
+    Object.defineProperty(el, 'scrollTop', { value: 800, configurable: true })
+
+    vm.updateVisibleRange()
+
+    // scrollTop 800 / 80px rows = row 10, ±BUFFER_ROWS(2), 10 viewport rows.
+    expect(vm.visibleRange).toEqual({ start: 8, end: 22 })
+  })
+
+  it('applies the new range only when the scheduled animation frame runs', async () => {
+    const { wrapper, vm } = await mountListView(50)
+    const el = wrapper.find('.audiobooks-scroll-container').element as HTMLElement
+    Object.defineProperty(el, 'clientHeight', { value: 800, configurable: true })
+    Object.defineProperty(el, 'scrollTop', { value: 800, configurable: true })
+
+    const frames: FrameRequestCallback[] = []
+    const rafSpy = vi
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation((cb: FrameRequestCallback) => {
+        frames.push(cb)
+        return frames.length
+      })
+
+    try {
+      const before = { ...vm.visibleRange }
+      vm.onScroll()
+      // Deferred: nothing changes until the frame fires.
+      expect(vm.visibleRange).toEqual(before)
+
+      frames[0]?.(0)
+      expect(vm.visibleRange).toEqual({ start: 8, end: 22 })
+    } finally {
+      rafSpy.mockRestore()
+    }
+  })
+
+  it('cancels a pending scroll animation frame on unmount', async () => {
+    const { wrapper, vm } = await mountListView(50)
+
+    const rafSpy = vi
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation(() => 123 as unknown as number)
+    const cancelSpy = vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {})
+
+    try {
+      vm.onScroll() // schedules frame 123 (mock never runs it)
+      wrapper.unmount()
+      expect(cancelSpy).toHaveBeenCalledWith(123)
+    } finally {
+      rafSpy.mockRestore()
+      cancelSpy.mockRestore()
+    }
+  })
+})

--- a/fe/src/views/library/AudiobooksView.vue
+++ b/fe/src/views/library/AudiobooksView.vue
@@ -404,7 +404,7 @@
       v-else
       ref="scrollContainer"
       :class="['audiobooks-scroll-container', { 'has-selection': selectedCount > 0 }]"
-      @scroll="updateVisibleRange"
+      @scroll="onScroll"
     >
       <div class="audiobooks-scroll-spacer" :style="{ height: totalHeight + 'px' }">
         <div
@@ -543,6 +543,7 @@
             @keydown.enter="navigateToDetail(audiobook.id)"
             class="audiobook-list-item"
             :class="{
+              'show-details': showItemDetails,
               selected: libraryStore.isSelected(audiobook.id),
               'status-no-file': getAudiobookStatus(audiobook) === 'no-file',
               'status-quality-mismatch': getAudiobookStatus(audiobook) === 'quality-mismatch',
@@ -1630,6 +1631,8 @@ const hasRootFolderConfigured = computed(() => {
 const scrollContainer = ref<HTMLElement | null>(null)
 const ITEMS_PER_ROW = ref(4) // Will be recalculated for grid; list uses 1
 const LIST_ROW_HEIGHT = 80
+const LIST_ROW_HEIGHT_DETAILS = 120 // taller fixed row when "show details" is on (must match CSS)
+const LIST_HEADER_HEIGHT = 40 // fixed height of the list-view column header (must match CSS)
 const GRID_ROW_HEIGHT_FALLBACK = 220
 const GRID_DETAILS_EXTRA_HEIGHT = 64 // extra height for showing details under poster
 const GRID_GAP = 20
@@ -1702,26 +1705,31 @@ function toggleItemDetails() {
 }
 
 function getRowHeight() {
+  // List rows are a fixed height (enforced in CSS), so the scroll math is fully
+  // deterministic and never depends on a sampled height shared with grid view.
+  // Sampling a single variable-height row was what made the scroll area oversized.
+  if (viewMode.value === 'list') {
+    return showItemDetails.value ? LIST_ROW_HEIGHT_DETAILS : LIST_ROW_HEIGHT
+  }
+
+  // Grid cards are variable, so they are measured from the DOM where possible.
   if (measuredRowHeight.value && measuredRowHeight.value > 0) {
     return measuredRowHeight.value
   }
 
-  if (viewMode.value === 'grid') {
-    if (scrollContainer.value && ITEMS_PER_ROW.value > 0) {
-      const contentWidth = Math.max(0, scrollContainer.value.clientWidth - 40)
-      const cardWidth = Math.max(
-        0,
-        Math.floor((contentWidth - GRID_GAP * (ITEMS_PER_ROW.value - 1)) / ITEMS_PER_ROW.value),
-      )
+  if (scrollContainer.value && ITEMS_PER_ROW.value > 0) {
+    const contentWidth = Math.max(0, scrollContainer.value.clientWidth - 40)
+    const cardWidth = Math.max(
+      0,
+      Math.floor((contentWidth - GRID_GAP * (ITEMS_PER_ROW.value - 1)) / ITEMS_PER_ROW.value),
+    )
 
-      if (cardWidth > 0) {
-        return cardWidth + GRID_GAP + (showItemDetails.value ? GRID_DETAILS_EXTRA_HEIGHT : 0)
-      }
+    if (cardWidth > 0) {
+      return cardWidth + GRID_GAP + (showItemDetails.value ? GRID_DETAILS_EXTRA_HEIGHT : 0)
     }
-
-    return GRID_ROW_HEIGHT_FALLBACK + (showItemDetails.value ? GRID_DETAILS_EXTRA_HEIGHT : 0)
   }
-  return LIST_ROW_HEIGHT
+
+  return GRID_ROW_HEIGHT_FALLBACK + (showItemDetails.value ? GRID_DETAILS_EXTRA_HEIGHT : 0)
 }
 
 function syncMeasuredRowHeight() {
@@ -1777,7 +1785,25 @@ const updateVisibleRange = () => {
   const startIndex = Math.max(0, startRow * ITEMS_PER_ROW.value)
   const endIndex = Math.min(endRow * ITEMS_PER_ROW.value, audiobooks.value.length)
 
-  visibleRange.value = { start: startIndex, end: endIndex }
+  // Only publish a new range when it actually changes. Assigning a fresh object
+  // on every scroll tick needlessly re-fires the visibleRange watcher and forces
+  // re-renders, which (together with re-measuring) caused the scroll-time freeze.
+  const current = visibleRange.value
+  if (current.start !== startIndex || current.end !== endIndex) {
+    visibleRange.value = { start: startIndex, end: endIndex }
+  }
+}
+
+// Coalesce scroll events into one update per animation frame. updateVisibleRange
+// reads layout, so running it synchronously on every scroll event caused layout
+// thrash and stalls during fast flinging.
+let scrollRafId: number | null = null
+function onScroll() {
+  if (scrollRafId !== null) return
+  scrollRafId = requestAnimationFrame(() => {
+    scrollRafId = null
+    updateVisibleRange()
+  })
 }
 
 // Padding for offset positioning
@@ -1786,10 +1812,17 @@ const topPadding = computed(() => {
   return firstVisibleRow * getRowHeight()
 })
 
-// Total scroll height so the container scrollbar reflects the full list
+// Total scroll height so the container scrollbar reflects the full list.
+// The list view renders an always-present column header inside the scrolled
+// area, so reserve its height — otherwise the last row is pushed below the
+// scrollable region and can't be fully scrolled into view.
 const totalHeight = computed(() => {
   const totalRows = Math.ceil(audiobooks.value.length / ITEMS_PER_ROW.value)
-  return totalRows * getRowHeight()
+  let height = totalRows * getRowHeight()
+  if (viewMode.value === 'list' && audiobooks.value.length > 0) {
+    height += LIST_HEADER_HEIGHT
+  }
+  return height
 })
 
 const deleting = ref(false)
@@ -1875,11 +1908,14 @@ async function initializeVirtualScroller() {
     stopVisibleRangeWatch = watch(
       () => visibleRange.value,
       async () => {
+        // List rows are fixed-height and never need measuring. For grid, measure
+        // once when a row first renders; re-measuring on every range change (i.e.
+        // on every scroll) is what created the scroll → measure → resize → scroll
+        // feedback loop that made the page unresponsive.
+        if (viewMode.value !== 'grid') return
+        if (measuredRowHeight.value !== null) return
         await nextTick()
-        if (syncMeasuredRowHeight()) {
-          updateVisibleRange()
-          await nextTick()
-        }
+        if (syncMeasuredRowHeight()) updateVisibleRange()
       },
     )
   }
@@ -1934,6 +1970,13 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  if (scrollRafId !== null) {
+    try {
+      cancelAnimationFrame(scrollRafId)
+    } catch {}
+    scrollRafId = null
+  }
+
   try {
     resizeObserver?.disconnect()
   } catch {}
@@ -3794,6 +3837,17 @@ defineExpose({
     transform 0.12s;
   border-bottom: 1px solid rgba(255, 255, 255, 0.03);
   cursor: pointer;
+  /* Fixed height keeps the virtual scroller's row math deterministic; the value
+     must match LIST_ROW_HEIGHT in the script. overflow:hidden clips any content
+     that would otherwise grow a row and desync the scroll height. */
+  box-sizing: border-box;
+  height: 80px;
+  overflow: hidden;
+}
+
+/* Taller fixed row when extra details are shown — must match LIST_ROW_HEIGHT_DETAILS. */
+.audiobook-list-item.show-details {
+  height: 120px;
 }
 
 .audiobook-list-item:hover {
@@ -3856,7 +3910,8 @@ defineExpose({
   justify-self: end;
 }
 
-/* Header row to mimic table columns */
+/* Header row to mimic table columns. Fixed height must match LIST_HEADER_HEIGHT
+   in the script so the virtual scroller can reserve exactly this much space. */
 .list-header {
   display: grid;
   grid-template-columns: 40px 64px 1fr auto 120px;
@@ -3866,6 +3921,8 @@ defineExpose({
   font-size: 12px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.04);
   align-items: center;
+  box-sizing: border-box;
+  height: 40px;
 }
 
 .list-header .col-cover {
@@ -3891,14 +3948,12 @@ defineExpose({
   justify-self: start;
 }
 
-/* Stack badges vertically on screens 768px and below */
+/* Keep badges in a single row on narrow screens too — list rows are a fixed
+   height, so stacking them vertically would only get clipped. */
 @media (max-width: 978px) {
   .list-badges {
-    flex-direction: column;
     gap: 4px;
-    align-items: flex-start;
     margin-left: 0;
-    margin-top: 8px;
   }
 }
 


### PR DESCRIPTION
Closes #675

## Summary
The audiobooks **list view** uses a hand-rolled, uniform-height virtual scroller in `AudiobooksView.vue`. On a library of a few hundred books it produced an **oversized scroll area** (large empty region below the last item), let you **overscroll past both ends**, left the **last row partially unreachable**, and **froze the page** ("infinite loading") on fast scrolling. Changing the **sort order** (toolbar or the clickable column headers) and then scrolling triggered the same freeze.

This reproduces on a clean `canary` checkout (the list view + scroller already ship there; it is not specific to the grouped-list-view PR #585). The sort-then-scroll variant reproduces via the toolbar sort on `canary` and via the clickable sort headers downstream — it is the same bug, not a separate one.

## Root cause
- **Single-sample uniform height for variable rows.** `syncMeasuredRowHeight()` measures only the *first* rendered `.audiobook-list-item` and applies that height to every row via `getRowHeight()` → `totalHeight = ceil(n) × getRowHeight()`. `measuredRowHeight` is a single ref **shared with grid view** (grid rows ≈ 220–240px). An inflated/stale sample sticks → oversized scroll area. Re-sorting reshuffles which row is sampled first, re-arming the problem.
- **Unthrottled scroll handler.** `@scroll="updateVisibleRange"` ran on every scroll event and always assigned a new `visibleRange` object, so the `visibleRange` watcher fired every tick and forced a synchronous `getBoundingClientRect` reflow per event — layout thrash on a fast fling.
- **Self-referential measurement loop.** That watcher re-measured and re-called `updateVisibleRange()`; with variable row heights there is no stable fixpoint, so it oscillated (overscroll) and saturated the main thread (freeze).
- **Header excluded from scroll height.** The always-present `.list-header` lives inside the `translateY`-shifted list but wasn't counted in `totalHeight`, pushing the last row below the scrollable region.

## Changes
- List rows are a **fixed height** (CSS `height` + `box-sizing` + `overflow:hidden`); `getRowHeight()` returns that constant directly for list view and no longer consults `measuredRowHeight` (measurement stays grid-only). A taller fixed constant is used for the "show details" mode. This makes `totalHeight` deterministic and kills the oversize/oscillation by construction.
- **rAF-throttle** the scroll handler so `updateVisibleRange` runs at most once per animation frame; the pending frame is cancelled on unmount.
- `updateVisibleRange` only reassigns `visibleRange` when the computed range actually changes (no per-tick object churn).
- The `visibleRange` watcher measures grid rows **once** instead of on every scroll-driven range change, breaking the scroll → measure → resize → scroll loop.
- **Reserve the fixed header height** in `totalHeight` so the last row stays fully scrollable.

## Deliberate tradeoffs (reviewer note)
- List rows are now a fixed height with `overflow:hidden`, so content that would exceed the row is clipped (titles already ellipsize; the show-details row uses a taller constant sized for its two detail lines).
- On narrow screens (≤978px), badges now stay in a single row instead of stacking vertically — stacking would only be clipped under the fixed row height. Grid view is unchanged except where it also benefits from the throttle/no-churn fixes.

## Tests
Adds Vitest coverage in `AudiobooksView.spec.ts` for: the deterministic list row-height (ignoring a stale/leaked `measuredRowHeight`), the taller show-details height, header-space reservation in `totalHeight`, **sort-invariant scroll geometry**, no-churn vs. applied `visibleRange` updates, scroll-event coalescing, and rAF cleanup on unmount. Full frontend suite, `type-check`, and `lint` pass.

## Verification
Reproduced on a clean `canary` checkout (fast-fling + sort-then-scroll), confirmed fixed after the change: scrolling clamps at both ends, the scroll area matches the item count, the last row is fully reachable, and no freeze — including after changing sort.
