### PR TITLE
feat(search): unified library search across books, series, authors, narrators

### DIFF
--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -68,7 +68,7 @@
           <input
             v-model="searchQuery"
             @input="onSearchInput"
-            @keydown.enter="applyFirstResult"
+            @keydown.enter="goToResults"
             @keydown.escape.prevent="closeSearch"
             ref="searchInputRef"
             class="search-input-inline"
@@ -92,31 +92,43 @@
             class="search-results-inline"
             v-if="searching || suggestions.length > 0 || searchQuery.length > 0"
           >
-            <ul v-if="suggestions.length > 0" class="search-list">
-              <li
-                v-for="s in suggestions"
-                :key="s.id"
-                class="search-result"
-                @click="selectSuggestion(s)"
+            <template v-if="suggestions.length > 0">
+              <div
+                v-for="section in suggestionSections"
+                :key="section.kind"
+                class="search-section"
               >
-                <div style="display: flex; align-items: center; gap: 10px">
-                  <img
-                    v-if="s.imageUrl"
-                    :src="getProtectedImageSrc(s.imageUrl, getPlaceholderUrl())"
-                    @error="handleImageError"
-                    alt="cover"
-                    class="result-thumb"
-                    loading="lazy"
-                    decoding="async"
-                  />
-                  <img v-else :src="getPlaceholderUrl()" alt="cover" class="result-thumb" />
-                  <div>
-                    <div class="result-title">{{ s.title }}</div>
-                    <div class="result-sub">{{ s.author }}</div>
-                  </div>
-                </div>
-              </li>
-            </ul>
+                <div class="search-section-header">{{ section.label }}</div>
+                <ul class="search-list">
+                  <li
+                    v-for="s in section.items"
+                    :key="s.key"
+                    class="search-result"
+                    @click="selectSuggestion(s)"
+                  >
+                    <div style="display: flex; align-items: center; gap: 10px">
+                      <img
+                        v-if="s.imageUrl"
+                        :src="getProtectedImageSrc(s.imageUrl, getPlaceholderUrl())"
+                        @error="handleImageError"
+                        alt="cover"
+                        class="result-thumb"
+                        loading="lazy"
+                        decoding="async"
+                      />
+                      <img v-else :src="getPlaceholderUrl()" alt="cover" class="result-thumb" />
+                      <div>
+                        <div class="result-title">{{ s.label }}</div>
+                        <div class="result-sub">{{ s.sublabel }}</div>
+                      </div>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+              <button type="button" class="search-see-all" @click="goToResults">
+                See all results for "{{ searchQuery.trim() }}"
+              </button>
+            </template>
 
             <div v-else class="search-empty-overlay">
               <div class="overlay-spinner" v-if="searching" aria-hidden="true"></div>
@@ -562,6 +574,12 @@ import { useAuthStore } from '@/stores/auth'
 import { apiService } from '@/services/api'
 import { getStartupConfigCached } from '@/services/startupConfigCache'
 import { handleImageError } from '@/utils/imageFallback'
+import {
+  buildLibraryFacets,
+  matchLibraryBooks,
+  matchLibraryFacets,
+  type LibraryFacetMatch,
+} from '@/utils/librarySearch'
 import { Pill } from '@/components/base'
 import { getPlaceholderUrl } from '@/utils/placeholder'
 import { useProtectedImages } from '@/composables/useProtectedImages'
@@ -950,9 +968,21 @@ router.afterEach(() => {
   pendingNavPath.value = null
 })
 const searchQuery = vueRef('')
-const suggestions = vueRef<
-  Array<{ id: number; title: string; author?: string; imageUrl?: string }>
->([])
+
+// A unified library-search suggestion. `kind` drives both the overlay grouping and
+// where a click navigates: books open the detail page, the other kinds open their
+// collection page (/collection/<kind>/<name>). Keys are composite (kind + id/name)
+// because collection suggestions have no numeric id.
+type SearchSuggestionKind = 'book' | 'series' | 'author' | 'narrator'
+type SearchSuggestion = {
+  kind: SearchSuggestionKind
+  key: string
+  label: string
+  sublabel?: string
+  imageUrl?: string
+  to: string | { name: string; params: Record<string, string> }
+}
+const suggestions = vueRef<SearchSuggestion[]>([])
 const searching = vueRef(false)
 const searchInputRef = vueRef<HTMLInputElement | null>(null)
 
@@ -984,6 +1014,15 @@ const handleSearchDocumentClick = (e: MouseEvent) => {
   }
 }
 
+// Distinct series / authors / narrators across the library, each with a book count
+// and a sample cover. Computed once and cached by Vue until the library changes, so
+// each keystroke filters this prepared index instead of re-scanning every book.
+const libraryFacets = computed(() => buildLibraryFacets(libraryStore.audiobooks))
+
+const BOOK_SUGGESTION_LIMIT = 5
+const FACET_SUGGESTION_LIMIT = 4
+const facetSub = (count: number) => `${count} book${count !== 1 ? 's' : ''}`
+
 let searchDebounceTimer: number | undefined
 const onSearchInput = async () => {
   if (searchDebounceTimer) clearTimeout(searchDebounceTimer)
@@ -998,25 +1037,42 @@ const onSearchInput = async () => {
       if (libraryStore.audiobooks.length === 0) {
         await libraryStore.fetchLibrary()
       }
-      const lib = libraryStore.audiobooks
-      const lower = q.toLowerCase()
-      const localMatches = lib.filter(
-        (b) =>
-          (b.title || '').toLowerCase().includes(lower) ||
-          (Array.isArray(b.authors) ? b.authors.join(' ').toLowerCase() : '').includes(lower),
-      )
-      if (localMatches.length > 0) {
-        // Only show local library matches in the header search
-        suggestions.value = localMatches.slice(0, 8).map((b) => ({
-          id: b.id!,
-          title: b.title || 'Unknown',
-          author: Array.isArray(b.authors) ? b.authors[0] || '' : '',
-          imageUrl: b.imageUrl || '',
-        }))
-      } else {
-        // No fallback to indexers from header search; leave suggestions empty
-        suggestions.value = []
+      const out: SearchSuggestion[] = []
+
+      // Books — title or any author contains the query.
+      for (const b of matchLibraryBooks(libraryStore.audiobooks, q, BOOK_SUGGESTION_LIMIT)) {
+        out.push({
+          kind: 'book',
+          key: `book:${b.id}`,
+          label: b.title,
+          sublabel: b.author,
+          imageUrl: b.imageUrl,
+          to: { name: 'audiobook-detail', params: { id: String(b.id) } },
+        })
       }
+
+      // Series / authors / narrators — normalized substring match, most-books first.
+      const facets = libraryFacets.value
+      const pushFacets = (
+        arr: LibraryFacetMatch[],
+        kind: Exclude<SearchSuggestionKind, 'book'>,
+      ) => {
+        for (const f of matchLibraryFacets(arr, q, FACET_SUGGESTION_LIMIT)) {
+          out.push({
+            kind,
+            key: `${kind}:${f.normKey}`,
+            label: f.name,
+            sublabel: facetSub(f.count),
+            imageUrl: f.imageUrl,
+            to: `/collection/${kind}/${encodeURIComponent(f.name)}`,
+          })
+        }
+      }
+      pushFacets(facets.series, 'series')
+      pushFacets(facets.authors, 'author')
+      pushFacets(facets.narrators, 'narrator')
+
+      suggestions.value = out
     } catch (err) {
       logger.error('Header search failed', err)
       suggestions.value = []
@@ -1026,30 +1082,42 @@ const onSearchInput = async () => {
   }, 250)
 }
 
-const selectSuggestion = (s: { id: number; title: string; author?: string }) => {
-  // Navigate to audiobook detail if local (id > 0), else open search view
+// Section grouping for the overlay (Books / Series / Authors / Narrators).
+const SUGGESTION_SECTION_LABELS: Record<SearchSuggestionKind, string> = {
+  book: 'Books',
+  series: 'Series',
+  author: 'Authors',
+  narrator: 'Narrators',
+}
+const suggestionSections = computed(() => {
+  const order: SearchSuggestionKind[] = ['book', 'series', 'author', 'narrator']
+  return order
+    .map((kind) => ({
+      kind,
+      label: SUGGESTION_SECTION_LABELS[kind],
+      items: suggestions.value.filter((s) => s.kind === kind),
+    }))
+    .filter((section) => section.items.length > 0)
+})
+
+const selectSuggestion = (s: SearchSuggestion) => {
   if (!s) return
   searchQuery.value = ''
   suggestions.value = []
-  if (s.id && s.id > 0) {
-    // Navigate to audiobook detail page (router name: 'audiobook-detail')
-    void router.push({ name: 'audiobook-detail', params: { id: String(s.id) } })
-  } else {
-    // Use the general search page for indexer results
-    void router.push({ name: 'search', query: { q: s.title } })
-  }
+  searchOpen.value = false
+  void router.push(s.to)
 }
 
-const applyFirstResult = () => {
-  if (suggestions.value.length > 0) selectSuggestion(suggestions.value[0]!)
+// Enter (or the "See all results" row) opens the full results page — the single
+// place that lists every matching book, series, author and narrator.
+const goToResults = () => {
+  const q = searchQuery.value.trim()
+  if (!q) return
+  searchQuery.value = ''
+  suggestions.value = []
+  searchOpen.value = false
+  void router.push({ name: 'search', query: { q } })
 }
-
-watch(
-  () => suggestions.value.length,
-  () => {
-    // Native lazy loading covers search suggestions automatically
-  },
-)
 
 const parseAuthEnabledFromStartupConfig = (raw: unknown): boolean | null => {
   if (typeof raw === 'boolean') return raw
@@ -2355,6 +2423,40 @@ these are not present, the Google Fonts import in `fe/index.html` will be used a
   padding: 8px 10px;
   color: #9aa0a6;
   font-size: 0.9rem;
+}
+
+.search-section + .search-section {
+  margin-top: 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.04);
+  padding-top: 4px;
+}
+
+.search-section-header {
+  padding: 6px 10px 2px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #8a929a;
+}
+
+.search-see-all {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 10px;
+  margin-top: 4px;
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  background: transparent;
+  color: #2196f3;
+  font-size: 0.88rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.search-see-all:hover {
+  background: rgba(255, 255, 255, 0.03);
 }
 
 /* Mobile search overlay */

--- a/fe/src/__tests__/librarySearch.spec.ts
+++ b/fe/src/__tests__/librarySearch.spec.ts
@@ -1,0 +1,144 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  buildLibraryFacets,
+  matchLibraryBooks,
+  matchLibraryFacets,
+  type LibrarySearchInput,
+} from '@/utils/librarySearch'
+
+const library: LibrarySearchInput[] = [
+  {
+    id: 1,
+    title: 'Project Hail Mary',
+    authors: ['Andy Weir'],
+    narrators: ['Ray Porter'],
+    series: undefined,
+    imageUrl: 'phm.jpg',
+  },
+  {
+    id: 2,
+    title: 'The Martian',
+    authors: ['Andy Weir'],
+    narrators: ['R. C. Bray'],
+    series: undefined,
+    imageUrl: 'martian.jpg',
+  },
+  {
+    id: 3,
+    title: 'Skyward',
+    authors: ['Brandon Sanderson'],
+    // Same narrator with different casing/punctuation must merge with book 4.
+    narrators: ['Suzy Jackson'],
+    series: 'Skyward',
+    imageUrl: 'skyward.jpg',
+  },
+  {
+    id: 4,
+    title: 'Starsight',
+    authors: ['Brandon Sanderson'],
+    narrators: ['suzy  jackson', 'Full Cast'],
+    series: 'Skyward',
+    imageUrl: 'starsight.jpg',
+  },
+  {
+    id: 5,
+    title: 'The Sandman',
+    authors: ['Neil Gaiman'],
+    // Dramatized — every credit but the production token is a real person.
+    narrators: ['James McAvoy', 'A Full Cast'],
+    series: undefined,
+    imageUrl: 'sandman.jpg',
+  },
+]
+
+describe('buildLibraryFacets', () => {
+  it('fans a book out across each narrator and merges normalized duplicates', () => {
+    const { narrators } = buildLibraryFacets(library)
+    const suzy = narrators.find((n) => n.normKey === 'suzy jackson')
+    expect(suzy).toBeDefined()
+    // Books 3 and 4 both credit Suzy Jackson despite casing/spacing differences.
+    expect(suzy?.count).toBe(2)
+    expect(suzy?.name).toBe('Suzy Jackson') // first-seen display casing
+  })
+
+  it('excludes non-person narrator credits ("Full Cast")', () => {
+    const { narrators } = buildLibraryFacets(library)
+    const keys = narrators.map((n) => n.normKey)
+    expect(keys).not.toContain('full cast')
+    expect(keys).not.toContain('a full cast')
+    // The real co-narrator on a dramatized book is still surfaced.
+    expect(keys).toContain('james mcavoy')
+  })
+
+  it('counts authors and series book-centrically', () => {
+    const { authors, series } = buildLibraryFacets(library)
+    expect(authors.find((a) => a.normKey === 'andy weir')?.count).toBe(2)
+    expect(authors.find((a) => a.normKey === 'brandon sanderson')?.count).toBe(2)
+    expect(series.find((s) => s.normKey === 'skyward')?.count).toBe(2)
+  })
+
+  it('counts a name once per book even when listed twice (matches .some() filter)', () => {
+    const dupe: LibrarySearchInput[] = [
+      { id: 9, title: 'Dup', authors: ['Jane Doe', 'jane  doe'], narrators: ['Ray Porter', 'Ray Porter'] },
+    ]
+    const { authors, narrators } = buildLibraryFacets(dupe)
+    expect(authors.find((a) => a.normKey === 'jane doe')?.count).toBe(1)
+    expect(narrators.find((n) => n.normKey === 'ray porter')?.count).toBe(1)
+  })
+})
+
+describe('matchLibraryBooks', () => {
+  it('matches on title or author, case-insensitively', () => {
+    expect(matchLibraryBooks(library, 'martian').map((b) => b.id)).toEqual([2])
+    expect(matchLibraryBooks(library, 'weir').map((b) => b.id).sort()).toEqual([1, 2])
+  })
+
+  it('honors the result limit', () => {
+    expect(matchLibraryBooks(library, 'the', 1)).toHaveLength(1)
+  })
+
+  it('parses a release year from publishYear or publishedDate', () => {
+    const books: LibrarySearchInput[] = [
+      { id: 1, title: 'Y From Field', authors: ['A'], publishYear: '2011' },
+      { id: 2, title: 'Y From Date', authors: ['A'], publishedDate: '2008-05-01' },
+      { id: 3, title: 'Y Missing', authors: ['A'] },
+    ]
+    const byId = Object.fromEntries(matchLibraryBooks(books, 'y ').map((b) => [b.id, b.year]))
+    expect(byId[1]).toBe(2011)
+    expect(byId[2]).toBe(2008)
+    expect(byId[3]).toBeUndefined()
+  })
+})
+
+describe('matchLibraryFacets', () => {
+  it('matches normalized substrings ranked by book count then name', () => {
+    const { authors } = buildLibraryFacets(library)
+    const hits = matchLibraryFacets(authors, 'an')
+    // All three contain "an"; Weir(2) and Sanderson(2) outrank Gaiman(1), and the
+    // two-book tie breaks alphabetically — so order is deterministic.
+    expect(hits.map((h) => h.name)).toEqual(['Andy Weir', 'Brandon Sanderson', 'Neil Gaiman'])
+  })
+
+  it('returns nothing for a blank/punctuation-only query', () => {
+    const { authors } = buildLibraryFacets(library)
+    expect(matchLibraryFacets(authors, '   ')).toEqual([])
+    expect(matchLibraryFacets(authors, '!!!')).toEqual([])
+  })
+})

--- a/fe/src/router/index.ts
+++ b/fe/src/router/index.ts
@@ -51,6 +51,12 @@ const routes = [
     meta: { requiresAuth: true },
   },
   {
+    path: '/search',
+    name: 'search',
+    component: () => import('../views/library/LibrarySearchView.vue'),
+    meta: { requiresAuth: true },
+  },
+  {
     path: '/add-new',
     name: 'add-new',
     component: () => import('../views/content/AddNewView.vue'),

--- a/fe/src/utils/librarySearch.ts
+++ b/fe/src/utils/librarySearch.ts
@@ -1,0 +1,172 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { normalizeCollectionText, isNonPersonNarrator } from './textUtils'
+
+/**
+ * Unified library search — matches a single query against the books the user
+ * already owns across four dimensions (books, series, authors, narrators) and
+ * returns each grouped. Shared by the header search overlay and the full results
+ * page so both rank and bucket results identically.
+ *
+ * Collection facets (series/authors/narrators) are keyed with the same
+ * normalizer the collection pages use, so a result's book count matches the page
+ * it links to. Non-person narrator credits ("Full Cast") are excluded — they are
+ * not browsable people.
+ */
+
+// The subset of an Audiobook this module reads. Kept structural so it does not
+// couple to the full Audiobook type.
+export interface LibrarySearchInput {
+  id?: number
+  title?: string
+  authors?: string[]
+  narrators?: string[]
+  series?: string
+  imageUrl?: string
+  publishYear?: string | number
+  publishedDate?: string
+}
+
+export type LibrarySearchKind = 'book' | 'series' | 'author' | 'narrator'
+
+export interface LibraryBookMatch {
+  id: number
+  title: string
+  author: string
+  imageUrl: string
+  year?: number
+}
+
+export interface LibraryFacetMatch {
+  name: string
+  normKey: string
+  count: number
+  imageUrl?: string
+}
+
+export interface LibraryFacets {
+  series: LibraryFacetMatch[]
+  authors: LibraryFacetMatch[]
+  narrators: LibraryFacetMatch[]
+}
+
+/**
+ * Build the distinct series / author / narrator index for a library, each with a
+ * book count and a sample cover. Pure and dependency-free so a caller can compute
+ * it once (e.g. a cached computed) and reuse it across many queries.
+ */
+export function buildLibraryFacets(books: readonly LibrarySearchInput[]): LibraryFacets {
+  const series = new Map<string, LibraryFacetMatch>()
+  const authors = new Map<string, LibraryFacetMatch>()
+  const narrators = new Map<string, LibraryFacetMatch>()
+
+  // `seen` dedupes within a single book so a book that lists the same name twice
+  // still counts once — matching the collection page's `.some()` filter and the
+  // grouped-grid fan-out, so counts stay identical across all three surfaces.
+  const add = (
+    map: Map<string, LibraryFacetMatch>,
+    raw: string | undefined,
+    cover: string,
+    seen: Set<string>,
+  ) => {
+    const display = (raw ?? '').trim()
+    if (!display) return
+    const normKey = normalizeCollectionText(display)
+    if (!normKey || seen.has(normKey)) return
+    seen.add(normKey)
+    let facet = map.get(normKey)
+    if (!facet) {
+      facet = { name: display, normKey, count: 0, imageUrl: cover || undefined }
+      map.set(normKey, facet)
+    }
+    facet.count++
+    if (!facet.imageUrl && cover) facet.imageUrl = cover
+  }
+
+  for (const book of books) {
+    const cover = book.imageUrl || ''
+    if (book.series) add(series, book.series, cover, new Set())
+    const authorsSeen = new Set<string>()
+    for (const author of book.authors ?? []) add(authors, author, cover, authorsSeen)
+    const narratorsSeen = new Set<string>()
+    for (const narrator of book.narrators ?? []) {
+      if (!isNonPersonNarrator(narrator)) add(narrators, narrator, cover, narratorsSeen)
+    }
+  }
+
+  return {
+    series: [...series.values()],
+    authors: [...authors.values()],
+    narrators: [...narrators.values()],
+  }
+}
+
+/** Best-effort 4-digit release year from publishYear or publishedDate. */
+function parsePublishYear(book: LibrarySearchInput): number | undefined {
+  if (book.publishYear != null && book.publishYear !== '') {
+    const y = Number.parseInt(String(book.publishYear), 10)
+    if (Number.isFinite(y)) return y
+  }
+  const match = (book.publishedDate || '').match(/\d{4}/)
+  return match ? Number.parseInt(match[0], 10) : undefined
+}
+
+/** Books whose title or any author contains the query (case-insensitive). */
+export function matchLibraryBooks(
+  books: readonly LibrarySearchInput[],
+  rawQuery: string,
+  limit?: number,
+): LibraryBookMatch[] {
+  const lower = rawQuery.trim().toLowerCase()
+  if (!lower) return []
+  const matches: LibraryBookMatch[] = []
+  for (const book of books) {
+    const titleHit = (book.title || '').toLowerCase().includes(lower)
+    const authorHit = (Array.isArray(book.authors) ? book.authors.join(' ').toLowerCase() : '').includes(
+      lower,
+    )
+    if (!titleHit && !authorHit) continue
+    matches.push({
+      id: book.id ?? 0,
+      title: book.title || 'Unknown',
+      author: Array.isArray(book.authors) ? book.authors[0] || '' : '',
+      imageUrl: book.imageUrl || '',
+      year: parsePublishYear(book),
+    })
+    if (limit != null && matches.length >= limit) break
+  }
+  return matches
+}
+
+/**
+ * Filter a prepared facet list by a normalized-substring match, ranked
+ * most-books-first then alphabetically.
+ */
+export function matchLibraryFacets(
+  facets: readonly LibraryFacetMatch[],
+  rawQuery: string,
+  limit?: number,
+): LibraryFacetMatch[] {
+  const nq = normalizeCollectionText(rawQuery)
+  if (!nq) return []
+  const matched = facets
+    .filter((facet) => facet.normKey.includes(nq))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+  return limit != null ? matched.slice(0, limit) : matched
+}

--- a/fe/src/utils/textUtils.ts
+++ b/fe/src/utils/textUtils.ts
@@ -115,3 +115,46 @@ export function stripHtmlAndNormalize(text: string | undefined | null): string {
 
   return decodeHtmlEntities(raw)
 }
+
+/**
+ * Normalizes a collection/display name (series, author, narrator) to a stable
+ * comparison key: strips diacritics, lowercases, and collapses any run of
+ * non-alphanumerics to a single space. Used so the same name matches regardless
+ * of punctuation/accents, and so a header-search suggestion's count lines up with
+ * the collection page it links to (both key off this function).
+ */
+export function normalizeCollectionText(value: string | undefined | null): string {
+  if (!value) return ''
+  return value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+// Compared against normalizeCollectionText output.
+const NON_PERSON_NARRATOR_TOKENS = new Set([
+  'full cast',
+  'a full cast',
+  'full cast production',
+  'full cast dramatization',
+  'various',
+  'various narrators',
+  'uncredited',
+])
+
+/**
+ * True when a narrator credit isn't a real, browsable person (e.g. "Full Cast").
+ * Used to exclude such tokens from narrator grouping and unified search so the
+ * library doesn't sprout pseudo-narrator pages. Empty/blank credits count as
+ * non-person too. Not applied to the collection-page filter: you only reach a
+ * narrator page by clicking a real card, so there is nothing to exclude there.
+ */
+export function isNonPersonNarrator(name: string | undefined | null): boolean {
+  const normalized = normalizeCollectionText(name)
+  if (!normalized) return true
+  if (NON_PERSON_NARRATOR_TOKENS.has(normalized)) return true
+  // Catch "... full cast ..." phrasings not in the explicit set.
+  return normalized.includes('full cast')
+}

--- a/fe/src/views/library/LibrarySearchView.vue
+++ b/fe/src/views/library/LibrarySearchView.vue
@@ -1,0 +1,699 @@
+<!--
+  Listenarr - Audiobook Management System
+  Copyright (C) 2024-2026 Listenarr Contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<!--
+  Unified library search results — the single page that lists everything the user
+  owns matching a query, grouped by Books / Series / Authors / Narrators. Distinct
+  from content/SearchView.vue, which searches external metadata to add new books.
+
+  Tabs (with counts) double as a result summary and let the user isolate one
+  category; the "All" tab is a capped overview so a large Books result never
+  buries the other categories. A grid/list toggle and category-appropriate sort
+  mirror the controls on the library and collection pages.
+-->
+<template>
+  <div class="library-search-view">
+    <header class="search-header">
+      <h1><PhMagnifyingGlass /> Search results</h1>
+      <p v-if="query" class="search-subtitle">
+        for <strong>"{{ query }}"</strong>
+      </p>
+    </header>
+
+    <div v-if="!query" class="search-state">Type a query to search your library.</div>
+
+    <div v-else-if="libraryStore.loading && libraryStore.audiobooks.length === 0" class="search-state">
+      Loading your library…
+    </div>
+
+    <div v-else-if="totalResults === 0" class="search-state">
+      No matches in your library for "{{ query }}".
+    </div>
+
+    <template v-else>
+      <div class="search-toolbar">
+        <!-- Tabs double as the result summary: each shows its count. -->
+        <div class="search-tabs" role="tablist">
+          <button
+            v-for="tab in tabs"
+            :key="tab.key"
+            class="search-tab"
+            :class="{ active: activeTab === tab.key }"
+            role="tab"
+            :aria-selected="activeTab === tab.key"
+            @click="activeTab = tab.key"
+          >
+            {{ tab.label }}
+            <span class="search-tab-count">{{ tab.count }}</span>
+          </button>
+        </div>
+
+        <div class="search-view-controls">
+          <div v-if="activeTab !== 'all'" class="sort-control">
+            <label class="sr-only" :for="sortSelectId">Sort by</label>
+            <select :id="sortSelectId" v-model="sortKey" class="sort-select">
+              <option v-for="opt in sortOptions" :key="opt.value" :value="opt.value">
+                {{ opt.label }}
+              </option>
+            </select>
+            <button
+              class="icon-btn"
+              type="button"
+              :title="sortDir === 'asc' ? 'Ascending' : 'Descending'"
+              :aria-label="sortDir === 'asc' ? 'Sort ascending' : 'Sort descending'"
+              @click="sortDir = sortDir === 'asc' ? 'desc' : 'asc'"
+            >
+              <PhArrowUp v-if="sortDir === 'asc'" />
+              <PhArrowDown v-else />
+            </button>
+          </div>
+          <div class="view-toggle" role="group" aria-label="View mode">
+            <button
+              class="icon-btn"
+              type="button"
+              :class="{ active: viewMode === 'grid' }"
+              title="Grid view"
+              aria-label="Grid view"
+              @click="setViewMode('grid')"
+            >
+              <PhSquaresFour />
+            </button>
+            <button
+              class="icon-btn"
+              type="button"
+              :class="{ active: viewMode === 'list' }"
+              title="List view"
+              aria-label="List view"
+              @click="setViewMode('list')"
+            >
+              <PhListBullets />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <section v-for="section in visibleSections" :key="section.kind" class="result-section">
+        <div class="result-section-head">
+          <h2 class="result-section-title">
+            {{ section.label }} <span class="section-count">{{ section.total }}</span>
+          </h2>
+          <button
+            v-if="section.truncated"
+            class="see-all-link"
+            type="button"
+            @click="activeTab = section.kind"
+          >
+            See all {{ section.total }} →
+          </button>
+        </div>
+
+        <!-- Books -->
+        <template v-if="section.kind === 'book'">
+          <div v-if="viewMode === 'grid'" class="card-grid">
+            <RouterLink
+              v-for="book in section.books"
+              :key="`book-${book.id}`"
+              class="result-card"
+              :to="{ name: 'audiobook-detail', params: { id: String(book.id) } }"
+            >
+              <img
+                class="card-cover"
+                :src="getProtectedImageSrc(book.imageUrl, getPlaceholderUrl())"
+                :alt="book.title"
+                loading="lazy"
+                decoding="async"
+                @error="handleImageError"
+              />
+              <div class="card-label" :title="book.title">{{ book.title }}</div>
+              <div v-if="book.author" class="card-sub" :title="book.author">{{ book.author }}</div>
+            </RouterLink>
+          </div>
+          <div v-else class="result-list">
+            <RouterLink
+              v-for="book in section.books"
+              :key="`book-row-${book.id}`"
+              class="result-row"
+              :to="{ name: 'audiobook-detail', params: { id: String(book.id) } }"
+            >
+              <img
+                class="row-thumb"
+                :src="getProtectedImageSrc(book.imageUrl, getPlaceholderUrl())"
+                :alt="book.title"
+                loading="lazy"
+                decoding="async"
+                @error="handleImageError"
+              />
+              <div class="row-main">
+                <div class="row-title">{{ book.title }}</div>
+                <div class="row-sub">{{ [book.author, book.year].filter(Boolean).join(' · ') }}</div>
+              </div>
+            </RouterLink>
+          </div>
+        </template>
+
+        <!-- Series / Authors / Narrators -->
+        <template v-else>
+          <div v-if="viewMode === 'grid'" class="card-grid">
+            <RouterLink
+              v-for="facet in section.facets"
+              :key="`${section.kind}-${facet.normKey}`"
+              class="result-card"
+              :to="`/collection/${section.kind}/${encodeURIComponent(facet.name)}`"
+            >
+              <img
+                class="card-cover"
+                :src="getProtectedImageSrc(facet.imageUrl || '', getPlaceholderUrl())"
+                :alt="facet.name"
+                loading="lazy"
+                decoding="async"
+                @error="handleImageError"
+              />
+              <div class="card-label" :title="facet.name">{{ facet.name }}</div>
+              <div class="card-sub">{{ facet.count }} book{{ facet.count !== 1 ? 's' : '' }}</div>
+            </RouterLink>
+          </div>
+          <div v-else class="result-list">
+            <RouterLink
+              v-for="facet in section.facets"
+              :key="`${section.kind}-row-${facet.normKey}`"
+              class="result-row"
+              :to="`/collection/${section.kind}/${encodeURIComponent(facet.name)}`"
+            >
+              <img
+                class="row-thumb"
+                :src="getProtectedImageSrc(facet.imageUrl || '', getPlaceholderUrl())"
+                :alt="facet.name"
+                loading="lazy"
+                decoding="async"
+                @error="handleImageError"
+              />
+              <div class="row-main">
+                <div class="row-title">{{ facet.name }}</div>
+                <div class="row-sub">{{ facet.count }} book{{ facet.count !== 1 ? 's' : '' }}</div>
+              </div>
+            </RouterLink>
+          </div>
+        </template>
+      </section>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+import { RouterLink } from 'vue-router'
+import {
+  PhMagnifyingGlass,
+  PhSquaresFour,
+  PhListBullets,
+  PhArrowUp,
+  PhArrowDown,
+} from '@phosphor-icons/vue'
+import { useLibraryStore } from '@/stores/library'
+import { useProtectedImages } from '@/composables/useProtectedImages'
+import { getPlaceholderUrl } from '@/utils/placeholder'
+import { handleImageError } from '@/utils/imageFallback'
+import {
+  buildLibraryFacets,
+  matchLibraryBooks,
+  matchLibraryFacets,
+  type LibraryBookMatch,
+  type LibraryFacetMatch,
+} from '@/utils/librarySearch'
+
+type FacetKind = 'series' | 'author' | 'narrator'
+type TabKey = 'all' | 'book' | FacetKind
+type SortDir = 'asc' | 'desc'
+
+// In the "All" overview, cap each section so a large Books result can't bury the
+// other categories — a "See all" link jumps to that category's tab for the rest.
+const ALL_PREVIEW_LIMIT = 12
+const VIEWMODE_KEY = 'listenarr.search.viewMode'
+
+const route = useRoute()
+const libraryStore = useLibraryStore()
+const { getProtectedImageSrc } = useProtectedImages()
+
+const sortSelectId = 'library-search-sort'
+const activeTab = ref<TabKey>('all')
+const viewMode = ref<'grid' | 'list'>('grid')
+const bookSortKey = ref<'title' | 'author' | 'year'>('title')
+const facetSortKey = ref<'count' | 'name'>('count')
+const sortDir = ref<SortDir>('asc')
+
+const query = computed(() => {
+  const q = route.query.q
+  return (typeof q === 'string' ? q : Array.isArray(q) ? q[0] || '' : '').trim()
+})
+
+const results = computed(() => {
+  const q = query.value
+  if (!q) {
+    return {
+      books: [] as LibraryBookMatch[],
+      series: [] as LibraryFacetMatch[],
+      authors: [] as LibraryFacetMatch[],
+      narrators: [] as LibraryFacetMatch[],
+    }
+  }
+  const books = libraryStore.audiobooks
+  const facets = buildLibraryFacets(books)
+  return {
+    books: matchLibraryBooks(books, q),
+    series: matchLibraryFacets(facets.series, q),
+    authors: matchLibraryFacets(facets.authors, q),
+    narrators: matchLibraryFacets(facets.narrators, q),
+  }
+})
+
+const totalResults = computed(
+  () =>
+    results.value.books.length +
+    results.value.series.length +
+    results.value.authors.length +
+    results.value.narrators.length,
+)
+
+const tabs = computed(() => {
+  const out: { key: TabKey; label: string; count: number }[] = [
+    { key: 'all', label: 'All', count: totalResults.value },
+  ]
+  if (results.value.books.length) out.push({ key: 'book', label: 'Books', count: results.value.books.length })
+  if (results.value.series.length) out.push({ key: 'series', label: 'Series', count: results.value.series.length })
+  if (results.value.authors.length) out.push({ key: 'author', label: 'Authors', count: results.value.authors.length })
+  if (results.value.narrators.length)
+    out.push({ key: 'narrator', label: 'Narrators', count: results.value.narrators.length })
+  return out
+})
+
+// If a query change empties the active category, fall back to the overview.
+watch(tabs, (list) => {
+  if (!list.some((t) => t.key === activeTab.value)) activeTab.value = 'all'
+})
+
+const sortOptions = computed(() =>
+  activeTab.value === 'book'
+    ? [
+        { value: 'title', label: 'Title' },
+        { value: 'author', label: 'Author' },
+        { value: 'year', label: 'Year' },
+      ]
+    : [
+        { value: 'count', label: 'Books' },
+        { value: 'name', label: 'Name' },
+      ],
+)
+
+// One v-model that proxies to whichever per-category key applies, so each tab
+// remembers its own sort. Switching to a category seeds a sensible default dir.
+const sortKey = computed<string>({
+  get: () => (activeTab.value === 'book' ? bookSortKey.value : facetSortKey.value),
+  set: (value) => {
+    if (activeTab.value === 'book') bookSortKey.value = value as 'title' | 'author' | 'year'
+    else facetSortKey.value = value as 'count' | 'name'
+  },
+})
+
+function sortBooks(list: LibraryBookMatch[], byDefault: boolean): LibraryBookMatch[] {
+  const key = byDefault ? 'title' : bookSortKey.value
+  const dir = byDefault ? 1 : sortDir.value === 'asc' ? 1 : -1
+  return [...list].sort((a, b) => {
+    if (key === 'year') {
+      const ay = a.year ?? -Infinity
+      const by = b.year ?? -Infinity
+      return ay === by ? a.title.localeCompare(b.title) : (ay - by) * dir
+    }
+    const av = key === 'author' ? a.author : a.title
+    const bv = key === 'author' ? b.author : b.title
+    return av.localeCompare(bv) * dir || a.title.localeCompare(b.title)
+  })
+}
+
+function sortFacets(list: LibraryFacetMatch[], byDefault: boolean): LibraryFacetMatch[] {
+  const key = byDefault ? 'count' : facetSortKey.value
+  const dir = byDefault ? 1 : sortDir.value === 'asc' ? 1 : -1
+  return [...list].sort((a, b) => {
+    if (key === 'count') {
+      // Default (byDefault) keeps the most-books-first ranking the util produced.
+      return (b.count - a.count) * (byDefault ? 1 : dir === 1 ? 1 : -1) || a.name.localeCompare(b.name)
+    }
+    return a.name.localeCompare(b.name) * dir || b.count - a.count
+  })
+}
+
+interface VisibleSection {
+  kind: TabKey & ('book' | FacetKind)
+  label: string
+  total: number
+  truncated: boolean
+  books?: LibraryBookMatch[]
+  facets?: LibraryFacetMatch[]
+}
+
+const visibleSections = computed<VisibleSection[]>(() => {
+  const all = activeTab.value === 'all'
+  const out: VisibleSection[] = []
+  const wantBooks = all || activeTab.value === 'book'
+  const wantSeries = all || activeTab.value === 'series'
+  const wantAuthors = all || activeTab.value === 'author'
+  const wantNarrators = all || activeTab.value === 'narrator'
+
+  if (wantBooks && results.value.books.length) {
+    const sorted = sortBooks(results.value.books, all)
+    out.push({
+      kind: 'book',
+      label: 'Books',
+      total: results.value.books.length,
+      truncated: all && sorted.length > ALL_PREVIEW_LIMIT,
+      books: all ? sorted.slice(0, ALL_PREVIEW_LIMIT) : sorted,
+    })
+  }
+  const facetSection = (kind: FacetKind, label: string, list: LibraryFacetMatch[]) => {
+    if (!((all || activeTab.value === kind) && list.length)) return
+    const sorted = sortFacets(list, all)
+    out.push({
+      kind,
+      label,
+      total: list.length,
+      truncated: all && sorted.length > ALL_PREVIEW_LIMIT,
+      facets: all ? sorted.slice(0, ALL_PREVIEW_LIMIT) : sorted,
+    })
+  }
+  if (wantSeries) facetSection('series', 'Series', results.value.series)
+  if (wantAuthors) facetSection('author', 'Authors', results.value.authors)
+  if (wantNarrators) facetSection('narrator', 'Narrators', results.value.narrators)
+  return out
+})
+
+function setViewMode(mode: 'grid' | 'list') {
+  viewMode.value = mode
+  try {
+    localStorage.setItem(VIEWMODE_KEY, mode)
+  } catch {
+    /* ignore localStorage errors (e.g. privacy mode) */
+  }
+}
+
+onMounted(() => {
+  try {
+    const stored = localStorage.getItem(VIEWMODE_KEY)
+    if (stored === 'grid' || stored === 'list') viewMode.value = stored
+  } catch {
+    /* ignore */
+  }
+  if (libraryStore.audiobooks.length === 0) {
+    void libraryStore.fetchLibrary()
+  }
+})
+</script>
+
+<style scoped>
+.library-search-view {
+  padding: 24px;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.search-header {
+  margin-bottom: 16px;
+}
+
+.search-header h1 {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 1.6rem;
+  margin: 0;
+}
+
+.search-subtitle {
+  margin: 6px 0 0;
+  color: var(--text-secondary, #bfc8cf);
+}
+
+.search-state {
+  padding: 48px 12px;
+  text-align: center;
+  color: var(--text-secondary, #9aa0a6);
+}
+
+.search-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 20px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.search-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.search-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  background: transparent;
+  color: var(--text-secondary, #bfc8cf);
+  font-size: 0.88rem;
+  cursor: pointer;
+}
+
+.search-tab:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.search-tab.active {
+  background: #2196f3;
+  border-color: #2196f3;
+  color: #fff;
+}
+
+.search-tab-count {
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(0, 0, 0, 0.18);
+  border-radius: 10px;
+  padding: 0 7px;
+}
+
+.search-tab.active .search-tab-count {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.search-view-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.sort-control {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.sort-select {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary, #e6eef6);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  padding: 6px 8px;
+  font-size: 0.85rem;
+}
+
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary, #bfc8cf);
+  cursor: pointer;
+}
+
+.icon-btn:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.icon-btn.active {
+  background: #2196f3;
+  border-color: #2196f3;
+  color: #fff;
+}
+
+.view-toggle {
+  display: flex;
+  gap: 4px;
+}
+
+.result-section {
+  margin-bottom: 32px;
+}
+
+.result-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.result-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.section-count {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-secondary, #8a929a);
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+  padding: 1px 8px;
+}
+
+.see-all-link {
+  background: transparent;
+  border: none;
+  color: #2196f3;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.see-all-link:hover {
+  text-decoration: underline;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 16px;
+}
+
+.result-card {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: inherit;
+  border-radius: 8px;
+  transition: transform 120ms ease;
+}
+
+.result-card:hover {
+  transform: translateY(-2px);
+}
+
+.card-cover {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 8px;
+  background: #2a2a2a;
+}
+
+.card-label {
+  margin-top: 8px;
+  font-weight: 500;
+  font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.card-sub {
+  font-size: 0.8rem;
+  color: var(--text-secondary, #bfc8cf);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.result-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.result-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.result-row:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.row-thumb {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 6px;
+  flex-shrink: 0;
+  background: #2a2a2a;
+}
+
+.row-main {
+  min-width: 0;
+}
+
+.row-title {
+  font-weight: 500;
+  font-size: 0.92rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row-sub {
+  font-size: 0.82rem;
+  color: var(--text-secondary, #bfc8cf);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>


### PR DESCRIPTION
## What this adds

Unified **library** search — searching what you already own, not the outward-facing "Add new" metadata search.

- The header search now matches across four dimensions at once — **Books / Series / Authors / Narrators** — grouping suggestions by kind. Each suggestion links where you'd expect: books to the detail page, the rest to their collection page.
- Enter (or a new **"See all results"** row) opens a dedicated results page at **`/search`** (`LibrarySearchView`) listing every match in sectioned groups.
- Matching logic lives in `utils/librarySearch`, shared by the overlay and the page and keyed off a shared normalizer so a suggestion's count always matches the page it links to. Entirely client-side over the loaded library, with the distinct-name index memoized so typing stays responsive. Non-person narrator credits ("Full Cast", "Various", uncredited) are excluded so the library doesn't sprout pseudo-pages.

It also **repairs a currently-dangling navigation**: the header already did `router.push({ name: 'search' })`, but no route named `search` exists on the current tree (`content/SearchView.vue` is orphaned), so that push silently failed. This PR makes it resolve.

## This is coordinated with in-flight work — not a blind feature drop

I checked this against the open FE PRs before opening it. Calling out the overlaps explicitly so review is easy:

- **#673 (author group-key normalization, @s3ntin3l8)** — heads up: #673 and this PR **independently introduce an identical `normalizeCollectionText` in `fe/src/utils/textUtils.ts`** (byte-for-byte the same NFKD→strip-diacritics→lowercase→collapse helper). That's a duplicate-export collision if both land as-is. I'd suggest landing **one** of them and having the other consume it — I'm happy to drop mine and rebase onto #673's, or vice-versa, whatever's easier for the maintainers. This PR adds one more helper alongside it (`isNonPersonNarrator`) which is search-specific.
- **#674 / #676 (list-view sort headers + virtual-scroller, @s3ntin3l8)** — both churn `fe/src/views/library/AudiobooksView.vue`. **This PR deliberately does not touch that file.** Browse-by-narrator (which does touch it) is intentionally split into a separate follow-up so it doesn't collide with #674/#676; I'd rather land those first.
- **#679 (dependency/build stabilization, @therobbiedavis)** — extracts `services/routerInstance.ts` out of `router/index.ts`. This PR's only router change is a **single additive route block**, so it rebases onto that refactor trivially. Happy to sequence after #679 lands.
- **#677 / #678 (architecture priorities)** — aware of the direction toward separating auth state and router redirects. This change is additive and route-local; it doesn't move auth or guard logic, so it shouldn't cut across that work.

## On timing

I know the current iteration is scoped to critical bugs and reviewer bandwidth is tight, so no rush expected on my end. The reason I'm raising it now rather than sitting on it: the router (#679) and the architecture issues (#677/#678) are about to reshape the files this touches, and #673 is already duplicating the normalizer — so coordinating now is cheaper than rebasing a stale branch later. Totally fine to park this until the next iteration opens up; I mainly want the overlap visible so nobody rebuilds it.

## Testing

- `vue-tsc` type-check: clean.
- Full FE unit suite: **387 passed**, 1 skipped (unchanged from base).
- 9 new tests for `librarySearch` (book/series/author/narrator matching, normalization, non-person-narrator exclusion, counts).

## Files

| File | Change |
|---|---|
| `fe/src/utils/librarySearch.ts` | new — shared matching/faceting |
| `fe/src/views/library/LibrarySearchView.vue` | new — `/search` results page |
| `fe/src/__tests__/librarySearch.spec.ts` | new — unit tests |
| `fe/src/utils/textUtils.ts` | +`normalizeCollectionText` (see #673 note), +`isNonPersonNarrator` |
| `fe/src/router/index.ts` | +`/search` route |
| `fe/src/App.vue` | header overlay: grouped suggestions + "See all results" |
