### PR TITLE
fix(FolderBrowser): commit manually-typed inline path to v-model (#523)

### DIFF
--- a/fe/src/__tests__/FolderBrowser.inlineInput.spec.ts
+++ b/fe/src/__tests__/FolderBrowser.inlineInput.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+import { mount } from '@vue/test-utils'
+import { vi, describe, it, expect } from 'vitest'
+
+// Avoid network calls from browse/validate during interaction.
+vi.mock('@/services/api', () => ({
+  apiService: {
+    browseDirectory: vi.fn().mockResolvedValue({ currentPath: '', parentPath: null, items: [] }),
+    validatePath: vi.fn().mockResolvedValue({ isValid: true, message: 'Valid' }),
+  },
+}))
+
+import FolderBrowser from '@/components/ui/FolderBrowser.vue'
+
+describe('FolderBrowser inline input (issue #523)', () => {
+  it('commits a manually-typed path via update:modelValue when autoSelect is on', async () => {
+    const wrapper = mount(FolderBrowser, {
+      props: { inline: true },
+    })
+
+    const input = wrapper.find('input.browser-input')
+    expect(input.exists()).toBe(true)
+
+    await input.setValue('/mnt/media/audiobooks')
+
+    const emitted = wrapper.emitted('update:modelValue')
+    expect(emitted).toBeTruthy()
+    expect(emitted?.at(-1)).toEqual(['/mnt/media/audiobooks'])
+  })
+
+  it('stays silent on update:modelValue when autoSelect is false (draft only)', async () => {
+    const wrapper = mount(FolderBrowser, {
+      props: { inline: true, autoSelect: false },
+    })
+
+    const input = wrapper.find('input.browser-input')
+    expect(input.exists()).toBe(true)
+
+    await input.setValue('/mnt/media/audiobooks')
+
+    // No finalized selection...
+    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+    // ...but the typed value still surfaces as a draft for modal consumers.
+    const draft = wrapper.emitted('path-draft')
+    expect(draft).toBeTruthy()
+    expect(draft?.at(-1)).toEqual(['/mnt/media/audiobooks'])
+  })
+})

--- a/fe/src/components/ui/FolderBrowser.vue
+++ b/fe/src/components/ui/FolderBrowser.vue
@@ -47,6 +47,7 @@
         class="browser-input form-input"
         type="text"
         placeholder="Enter path..."
+        @input="onInlinePathInput"
         @keydown.enter.prevent="browseDirectory(localPath)"
         aria-label="Path"
       />
@@ -229,6 +230,17 @@ watch(
     emit('path-draft', v ?? '')
   },
 )
+
+// Commit a manually-typed path to the parent's v-model. Without this, typed
+// values only surface as `path-draft` and a parent binding via `v-model`
+// (which listens for `update:modelValue`) never receives them — so the value
+// is dropped on submit. Gated on `autoSelect` so modal-embedded browsers
+// (autoSelect=false) keep their draft-only semantics. (issue #523)
+function onInlinePathInput() {
+  if (props.inline && props.autoSelect) {
+    emit('update:modelValue', localPath.value)
+  }
+}
 
 const currentPath = ref<string | null>(null)
 const parentPath = ref<string | null>(null)
@@ -447,7 +459,11 @@ onMounted(() => {
 watch(
   () => props.modelValue,
   (v) => {
-    localPath.value = v ?? ''
+    const next = v ?? ''
+    // Ignore echoes of values we just emitted from the inline input — otherwise
+    // every keystroke would re-trigger a path validation request.
+    if (next === localPath.value) return
+    localPath.value = next
     // Validate the incoming path so the parent sees validation feedback immediately
     if (localPath.value) validatePath()
   },


### PR DESCRIPTION
## Summary
Fixes #523 — manually typed local path values in the remote path mapping form were not being sent to the backend.

## Changes

### Fixed
- `FolderBrowser.vue`: inline text input now emits `update:modelValue` on typing, not just `path-draft`
- Added echo guard on `modelValue` watcher to prevent feedback loop

### Added
- `FolderBrowser.inlineInput.spec.ts`: two unit tests covering the fix

## Testing
- Unit tests added and passing (2/2)
- Lint and type-check clean

## Notes
Root cause: the inline input was draft-only and never committed its value to v-model. Fix is scoped to `props.inline && props.autoSelect` so the browse-modal flow is untouched.