### PR TITLE
feat: show narrator in Library Import match result cards (#552)   

### DIFF
--- a/fe/src/__tests__/LibraryImportSearchModal.spec.ts
+++ b/fe/src/__tests__/LibraryImportSearchModal.spec.ts
@@ -46,6 +46,44 @@ describe('LibraryImportSearchModal', () => {
     vi.restoreAllMocks()
   })
 
+  it('displays narrator when result includes narrator data', async () => {
+    vi.spyOn(apiService, 'advancedSearch').mockResolvedValue([
+      {
+        asin: 'B000APXZHK',
+        title: 'Alchemised',
+        imageUrl: '/api/v1/images/B000APXZHK',
+        authors: [{ name: 'SenLinYu' }],
+        narrator: 'John Smith',
+      } as unknown as SearchResult,
+    ])
+
+    const wrapper = mount(LibraryImportSearchModal, {
+      props: {
+        item: {
+          id: 'C:\\incoming\\Alchemised.m4b',
+          fullPath: 'C:\\incoming\\Alchemised.m4b',
+          sourceFiles: ['C:\\incoming\\Alchemised.m4b'],
+          folderPath: 'C:\\incoming',
+          relativePath: 'Alchemised',
+          folderName: 'Alchemised',
+          detectedTitle: 'Alchemised',
+          detectedAuthor: 'SenLinYu',
+          format: 'M4B',
+          fileCount: 1,
+          selectedMatch: null,
+          hasSearched: false,
+          isSearching: false,
+          selected: false,
+        },
+      },
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.result-narrator').text()).toContain('John Smith')
+  })
+
   it('routes result thumbnails through the protected image helper', async () => {
     const wrapper = mount(LibraryImportSearchModal, {
       props: {

--- a/fe/src/components/domain/audiobook/LibraryImportSearchModal.vue
+++ b/fe/src/components/domain/audiobook/LibraryImportSearchModal.vue
@@ -72,6 +72,9 @@
                 >
                 <span v-if="result.asin" class="result-asin"> · {{ result.asin }}</span>
               </span>
+              <span v-if="extractNarrators(result)" class="result-narrator">
+                Narrated by {{ extractNarrators(result) }}
+              </span>
             </div>
           </div>
         </div>
@@ -101,6 +104,7 @@ import {
 } from '@/utils/libraryImportSearch'
 import { getPlaceholderUrl } from '@/utils/placeholder'
 import type { SearchResult } from '@/types'
+import { extractNarrators } from '@/utils/searchResultHelpers'
 
 const props = defineProps<{ item: LibraryImportItem }>()
 const emit = defineEmits<{
@@ -246,6 +250,15 @@ function select(result: SearchResult) {
 .result-asin {
   font-family: monospace;
   font-size: 0.7rem;
+}
+
+.result-narrator {
+  display: block;
+  font-size: 0.75rem;
+  color: #888;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .no-results,


### PR DESCRIPTION
## Summary

Fixes #552. The Library Import match modal showed result cards with title, author, and ASIN but never displayed the narrator, making it impossible to distinguish between multiple recordings of the same title read by different narrators. 

## Changes

### Added
- Narrator line (`Narrated by …`) on each result card in `LibraryImportSearchModal.vue`, rendered via the existing `extractNarrators()` helper
- Unit tests for narrator display and protected image routing in `LibraryImportSearchModal.spec.ts`   

<!-- Remove any empty sections above -->

## Testing

  - `cd fe && npm run type-check` — no errors                                                                                                                                                    
  - `cd fe && npm run test:unit` — all relevant tests pass
  - Manual: searched in the Library Import match modal; result cards now show "Narrated by [name]" beneath the author line  

## Notes

No backend changes required — narrator data is already returned by the /search endpoint. Pattern mirrors the existing narrator rendering in `AddNewView.vue`.         