### PR TITLE
Fix Transmission completed seeding status

### DIFF
--- a/listenarr.infrastructure/DownloadClients/Transmission/TransmissionDownloadPollingWorkflow.cs
+++ b/listenarr.infrastructure/DownloadClients/Transmission/TransmissionDownloadPollingWorkflow.cs
@@ -209,6 +209,7 @@ namespace Listenarr.Infrastructure.DownloadClients.Transmission
                             var percent = matching.TryGetProperty("percentDone", out var p) ? p.GetDouble() : 0.0;
                             var left = matching.TryGetProperty("leftUntilDone", out var l) ? l.GetInt64() : 0L;
                             var statusCode = matching.TryGetProperty("status", out var statusProp) ? statusProp.GetInt32() : 0;
+                            var isFinished = matching.TryGetProperty("isFinished", out var finishedProp) && finishedProp.GetBoolean();
 
                             var status = statusCode switch
                             {
@@ -262,8 +263,18 @@ namespace Listenarr.Infrastructure.DownloadClients.Transmission
                                 continue;
                             }
 
-                            var isComplete = percent >= 1.0 && (status == "seeding" || status == "queued" || status == "paused");
-                            _logger.LogInformation("PollTransmission download {DownloadId}: percent={Percent}, status={Status}, isComplete={IsComplete}", dl.Id, percent, status, isComplete);
+                            // Transmission can report fully downloaded torrents as still seeding.
+                            // Mark completed-side payloads importable while preserving the existing
+                            // seed-limit/removal metadata flow above.
+                            var payloadComplete = percent >= 1.0 || left <= 0 || isFinished;
+                            var isCompleteSideState = statusCode is 0 or 5 or 6 || isFinished;
+                            var isComplete = payloadComplete && isCompleteSideState;
+                            if (isComplete)
+                            {
+                                dl.Completed();
+                            }
+
+                            _logger.LogInformation("PollTransmission download {DownloadId}: percent={Percent}, left={Left}, status={Status}, isFinished={IsFinished}, isComplete={IsComplete}", dl.Id, percent, left, status, isFinished, isComplete);
                         }
                         catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
                         {

--- a/tests/Features/Infrastructure/DownloadClients/Transmission/TransmissionAdapterTests.cs
+++ b/tests/Features/Infrastructure/DownloadClients/Transmission/TransmissionAdapterTests.cs
@@ -15,12 +15,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+using System.Net;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
 using Listenarr.Tests.Builders;
 using Listenarr.Tests.Common;
 using Listenarr.Tests.Mocks.Api;
 
 using Listenarr.Infrastructure.Torrents;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Listenarr.Tests.Features.Infrastructure.DownloadClients.Transmission
 {
@@ -285,6 +289,102 @@ namespace Listenarr.Tests.Features.Infrastructure.DownloadClients.Transmission
             Assert.Equal(42, arguments.GetProperty("ids")[0].GetInt32());
         }
 
+        [Fact]
+        [Trait("Method", "FetchDownloadsAsync")]
+        public async Task FetchDownloadsAsync_WhenTransmissionTorrentIsSeedingAndComplete_MarksDownloadCompleted()
+        {
+            var adapter = CreateFetchDownloadsAdapter("""
+            {
+              "result":"success",
+              "arguments":{
+                "torrents":[
+                  {
+                    "id":1,
+                    "hashString":"ABCDEF1234567890",
+                    "name":"Book.m4b",
+                    "percentDone":1.0,
+                    "leftUntilDone":0,
+                    "isFinished":false,
+                    "status":6,
+                    "downloadDir":"/downloads",
+                    "uploadRatio":1.0,
+                    "seedRatioMode":0,
+                    "seedRatioLimit":0,
+                    "seedIdleMode":0,
+                    "seedIdleLimit":0,
+                    "secondsSeeding":60
+                  }
+                ]
+              }
+            }
+            """);
+            var download = new Download
+            {
+                Id = "download-1",
+                Title = "Book.m4b",
+                Status = DownloadStatus.Downloading,
+                TotalSize = 100,
+                Metadata = new Dictionary<string, object>
+                {
+                    ["TorrentHash"] = "ABCDEF1234567890"
+                }
+            };
+
+            var results = await adapter.FetchDownloadsAsync(_client!, [download], CancellationToken.None);
+
+            Assert.Single(results);
+            Assert.Equal(DownloadStatus.Completed, results[0].Status);
+            Assert.Equal(100.0M, results[0].Progress);
+        }
+
+        [Fact]
+        [Trait("Method", "FetchDownloadsAsync")]
+        public async Task FetchDownloadsAsync_WhenTransmissionTorrentIsStillDownloading_DoesNotMarkCompleted()
+        {
+            var adapter = CreateFetchDownloadsAdapter("""
+            {
+              "result":"success",
+              "arguments":{
+                "torrents":[
+                  {
+                    "id":1,
+                    "hashString":"ABCDEF1234567890",
+                    "name":"Book.m4b",
+                    "percentDone":0.5,
+                    "leftUntilDone":50,
+                    "isFinished":false,
+                    "status":4,
+                    "downloadDir":"/downloads",
+                    "uploadRatio":0.0,
+                    "seedRatioMode":0,
+                    "seedRatioLimit":0,
+                    "seedIdleMode":0,
+                    "seedIdleLimit":0,
+                    "secondsSeeding":0
+                  }
+                ]
+              }
+            }
+            """);
+            var download = new Download
+            {
+                Id = "download-1",
+                Title = "Book.m4b",
+                Status = DownloadStatus.Downloading,
+                TotalSize = 100,
+                Metadata = new Dictionary<string, object>
+                {
+                    ["TorrentHash"] = "ABCDEF1234567890"
+                }
+            };
+
+            var results = await adapter.FetchDownloadsAsync(_client!, [download], CancellationToken.None);
+
+            Assert.Single(results);
+            Assert.Equal(DownloadStatus.Downloading, results[0].Status);
+            Assert.Equal(50.0M, results[0].Progress);
+        }
+
         [Theory]
         [InlineData(0)]
         [InlineData(3)]
@@ -294,6 +394,33 @@ namespace Listenarr.Tests.Features.Infrastructure.DownloadClients.Transmission
         {
             Assert.Equal(DownloadItemStatus.Completed, TransmissionResponseMapper.MapDownloadItemStatus(status, 100));
             Assert.Equal("completed", TransmissionResponseMapper.MapQueueStatus(status, 100));
+        }
+
+        private static TransmissionAdapter CreateFetchDownloadsAdapter(string torrentGetResponse)
+        {
+            var handler = new DelegatingHandlerMock(async (request, ct) =>
+            {
+                var body = await request.Content!.ReadAsStringAsync(ct);
+                using var document = JsonDocument.Parse(body);
+                var method = document.RootElement.GetProperty("method").GetString();
+                var responseBody = string.Equals(method, "session-get", StringComparison.OrdinalIgnoreCase)
+                    ? """
+                    {
+                      "result":"success",
+                      "arguments":{}
+                    }
+                    """
+                    : torrentGetResponse;
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+                };
+            });
+            var httpFactory = new Mock<IHttpClientFactory>();
+            httpFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(new HttpClient(handler));
+
+            return new TransmissionAdapter(httpFactory.Object, Mock.Of<ITorrentFileDownloader>(), NullLogger<TransmissionAdapter>.Instance);
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes Transmission downloads that are fully downloaded but continue seeding not transitioning to completed/importable in Listenarr.

When Transmission reports a torrent as fully downloaded while it is still seeding or otherwise in a completed-side state, Listenarr could leave the corresponding download in `Downloading` instead of marking it completed for the normal import flow. In practice, completed downloads that continued seeding in Transmission were not reliably becoming completed/importable in Listenarr.

## Changes

### Fixed
- Treat Transmission torrents as completed/importable when the payload indicates the torrent is fully downloaded:
  - `percentDone >= 1.0`
  - or `leftUntilDone <= 0`
  - or Transmission reports `isFinished`
- Limit that transition to completed-side Transmission states so active incomplete downloads remain `Downloading`.
- Preserve seed-limit/removal behavior by only marking the Listenarr download completed/importable; this does not force-remove the torrent or bypass existing removal/seed handling flow.

### Added
- Adapter tests covering:
  - fully downloaded seeding torrents becoming `Completed`
  - incomplete/downloading torrents staying `Downloading`

## Testing

- `dotnet test tests/Listenarr.Tests.csproj --filter FullyQualifiedName~TransmissionAdapterTests`
  - Passed: 7/7
- Push hook also ran:
  - backend format check
  - frontend type check
  - frontend tests: 74 passed, 1 skipped test file; 378 tests passed

## Notes

- Branch is based on latest `canary`.
- This PR is intentionally limited to the Transmission completed/seeding status fix and directly related tests.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] Comments added for complex logic
- [x] Tests added/updated
- [x] Relevant tests pass
- [x] No documentation changes needed
- [x] Rebased on latest `canary`
