### PR TITLE
Add Deluge download client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Listenarr is a fast, feature-rich, cross-platform audiobook management server. B
 - [x] **First-class responsive web interface** that works great on any device (phone, tablet, desktop)
 - [x] **Rich metadata support** with automatic enrichment from Audible and Amazon
 - [x] **External API integration** for searching across multiple torrent and NZB indexers simultaneously
-- [x] **Download management** with support for popular clients (qBittorrent, Transmission, SABnzbd, NZBGet)
+- [x] **Download management** with support for popular clients (qBittorrent, Transmission, Deluge, SABnzbd, NZBGet)
 - [x] **Real-time monitoring** of download progress and status
 - [x] **Intelligent file organization** with customizable naming patterns
 - [ ] **Full localization support** Soon™️
@@ -386,6 +386,7 @@ Supported download clients:
 
 - **qBittorrent** - Popular torrent client with web UI
 - **Transmission** - Cross-platform torrent client
+- **Deluge** - Torrent client via Deluge Web JSON-RPC
 - **SABnzbd** - Usenet downloader
 - **NZBGet** - Efficient usenet client
 

--- a/fe/src/components/domain/download/DownloadClientFormModal.vue
+++ b/fe/src/components/domain/download/DownloadClientFormModal.vue
@@ -65,6 +65,7 @@
               <select id="type" v-model="formData.type" required @change="onTypeChange">
                 <option value="qbittorrent">qBittorrent</option>
                 <option value="transmission">Transmission</option>
+                <option value="deluge">Deluge</option>
                 <option value="sabnzbd">SABnzbd</option>
                 <option value="nzbget">NZBGet</option>
               </select>
@@ -116,18 +117,22 @@
               </Checkbox>
             </div>
 
-            <div class="form-group" v-if="formData.type === 'transmission'">
+            <div
+              class="form-group"
+              v-if="formData.type === 'transmission' || formData.type === 'deluge'"
+            >
               <label for="urlBase">URL Base</label>
               <input
                 id="urlBase"
                 v-model="formData.urlBase"
                 type="text"
-                placeholder="/transmission/rpc"
+                :placeholder="formData.type === 'deluge' ? '/deluge' : '/transmission/rpc'"
               />
-              <small
-                >RPC path for the Transmission endpoint. Default is <code>/transmission/rpc</code>.
-                Some seedbox providers use a custom path (e.g. <code>/rpc</code>).</small
-              >
+              <small>{{
+                formData.type === 'deluge'
+                  ? 'Optional reverse proxy prefix for Deluge Web. The JSON-RPC endpoint will be /json under this path.'
+                  : 'RPC path for the Transmission endpoint. Default is /transmission/rpc. Some seedbox providers use a custom path (e.g. /rpc).'
+              }}</small>
             </div>
           </FormSection>
 
@@ -404,7 +409,7 @@ const testing = ref(false)
 
 const defaultFormData = {
   name: '',
-  type: 'qbittorrent' as 'qbittorrent' | 'transmission' | 'sabnzbd' | 'nzbget',
+  type: 'qbittorrent' as 'qbittorrent' | 'transmission' | 'deluge' | 'sabnzbd' | 'nzbget',
   host: '',
   port: 8080,
   username: '',
@@ -469,6 +474,7 @@ const getHostPlaceholder = () => {
   const placeholders: Record<string, string> = {
     qbittorrent: 'qbittorrent.tld.com',
     transmission: 'transmission.tld.com',
+    deluge: 'deluge.tld.com',
     sabnzbd: 'sabnzbd.tld.com',
     nzbget: 'nzbget.tld.com',
   }
@@ -479,6 +485,7 @@ const getPortPlaceholder = () => {
   const ports: Record<string, number> = {
     qbittorrent: 8080,
     transmission: 9091,
+    deluge: 8112,
     sabnzbd: 8080,
     nzbget: 6789,
   }
@@ -489,6 +496,7 @@ const getPortHelpText = () => {
   const hints: Record<string, string> = {
     transmission:
       'RPC port (default: 9091). This is not the web UI port if you changed it separately.',
+    deluge: 'Deluge Web UI port (default: 8112). The adapter uses Deluge Web JSON-RPC at /json.',
     qbittorrent: 'Web UI port (default: 8080). Found in qBittorrent → Options → Web UI.',
     sabnzbd: 'Web interface port (default: 8080). Found in SABnzbd → Config → General.',
     nzbget: 'Web interface port (default: 6789). Found in NZBGet → Settings → Connection.',
@@ -500,6 +508,9 @@ const getCategoryHelp = () => {
   if (isUsenet.value) {
     return 'Adding a category specific to Listenarr avoids conflicts with unrelated non-Listenarr downloads. Using a category is optional, but strongly recommended.'
   }
+  if (formData.value.type === 'deluge') {
+    return 'Adding a category specific to Listenarr avoids conflicts with unrelated downloads. Deluge category support requires the Label plugin to be enabled.'
+  }
   return 'Adding a category specific to Listenarr avoids conflicts with unrelated downloads.'
 }
 
@@ -508,6 +519,7 @@ const onTypeChange = () => {
   const defaultPorts: Record<string, number> = {
     qbittorrent: 8080,
     transmission: 9091,
+    deluge: 8112,
     sabnzbd: 8080,
     nzbget: 6789,
   }
@@ -518,6 +530,8 @@ const onTypeChange = () => {
     formData.value.password = ''
   } else {
     formData.value.apiKey = ''
+    if (formData.value.type === 'deluge' && !formData.value.category)
+      formData.value.category = 'listenarr'
   }
 }
 
@@ -593,7 +607,8 @@ const testConnection = async () => {
         ...(formData.value.type === 'sabnzbd' && formData.value.apiKey
           ? { apiKey: formData.value.apiKey }
           : {}),
-        ...(formData.value.type === 'transmission' && formData.value.urlBase
+        ...((formData.value.type === 'transmission' || formData.value.type === 'deluge') &&
+        formData.value.urlBase
           ? { urlBase: formData.value.urlBase }
           : {}),
         ...(formData.value.category && { category: formData.value.category }),
@@ -653,7 +668,8 @@ const handleSubmit = async () => {
         ...(formData.value.type === 'sabnzbd' && formData.value.apiKey
           ? { apiKey: formData.value.apiKey }
           : {}),
-        ...(formData.value.type === 'transmission' && formData.value.urlBase
+        ...((formData.value.type === 'transmission' || formData.value.type === 'deluge') &&
+        formData.value.urlBase
           ? { urlBase: formData.value.urlBase }
           : {}),
         ...(formData.value.category && { category: formData.value.category }),

--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -241,7 +241,7 @@ export interface ApiConfiguration {
 export interface DownloadClientConfiguration {
   id: string
   name: string
-  type: 'qbittorrent' | 'transmission' | 'sabnzbd' | 'nzbget'
+  type: 'qbittorrent' | 'transmission' | 'deluge' | 'sabnzbd' | 'nzbget'
   host: string
   port: number
   username: string

--- a/fe/src/views/settings/DownloadClientsTab.vue
+++ b/fe/src/views/settings/DownloadClientsTab.vue
@@ -33,8 +33,8 @@
       <div v-else-if="configStore.downloadClientConfigurations.length === 0" class="empty-state">
         <PhDownloadSimple />
         <p>
-          No download clients configured. Add qBittorrent, Transmission, SABnzbd, or NZBGet to
-          download audiobooks.
+          No download clients configured. Add qBittorrent, Transmission, Deluge, SABnzbd, or NZBGet
+          to download audiobooks.
         </p>
       </div>
 

--- a/listenarr.domain/Downloads/DownloadClientConfiguration.cs
+++ b/listenarr.domain/Downloads/DownloadClientConfiguration.cs
@@ -6,7 +6,7 @@ namespace Listenarr.Domain.Downloads
     {
         public string Id { get; set; } = Guid.NewGuid().ToString();
         public string Name { get; set; } = string.Empty;
-        public string Type { get; set; } = string.Empty; // "qbittorrent", "transmission", "sabnzbd", "nzbget"
+        public string Type { get; set; } = string.Empty; // "qbittorrent", "transmission", "deluge", "sabnzbd", "nzbget"
         public string Host { get; set; } = string.Empty;
         public int Port { get; set; }
         public string Username { get; set; } = string.Empty;

--- a/listenarr.infrastructure/DependencyInjection/DownloadClients/DownloadClientRegistrationExtensions.cs
+++ b/listenarr.infrastructure/DependencyInjection/DownloadClients/DownloadClientRegistrationExtensions.cs
@@ -35,6 +35,7 @@ internal static class DownloadClientRegistrationExtensions
 
         AddAdapterClient(services, "qbittorrent", useCookies: true, retryPolicy, circuitBreakerPolicy);
         AddAdapterClient(services, "transmission", useCookies: false, retryPolicy, circuitBreakerPolicy);
+        AddAdapterClient(services, "deluge", useCookies: true, retryPolicy, circuitBreakerPolicy);
         AddAdapterClient(services, "sabnzbd", useCookies: false, retryPolicy, circuitBreakerPolicy);
         AddAdapterClient(services, "nzbget", useCookies: false, retryPolicy, circuitBreakerPolicy);
         return services;
@@ -52,6 +53,7 @@ internal static class DownloadClientRegistrationExtensions
         services.AddScoped<ITorrentFileDownloader, TorrentFileDownloader>();
         services.AddScoped<IDownloadClientAdapter, QbittorrentAdapter>();
         services.AddScoped<IDownloadClientAdapter, TransmissionAdapter>();
+        services.AddScoped<IDownloadClientAdapter, DelugeAdapter>();
         services.AddScoped<IDownloadClientAdapter, SabnzbdAdapter>();
         services.AddScoped<IDownloadClientAdapter, NzbgetAdapter>();
         services.AddScoped<IDownloadClientAdapterFactory, DownloadClientAdapterFactory>();

--- a/listenarr.infrastructure/DownloadClients/Deluge/DelugeAdapter.cs
+++ b/listenarr.infrastructure/DownloadClients/Deluge/DelugeAdapter.cs
@@ -1,0 +1,370 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Listenarr.Infrastructure.Torrents;
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Infrastructure.DownloadClients.Deluge
+{
+    /// <summary>
+    /// Deluge Web JSON-RPC adapter, modelled after the Servarr Deluge integration.
+    /// </summary>
+    public class DelugeAdapter : IDownloadClientAdapter
+    {
+        public string ClientId => "deluge";
+        public string ClientType => "deluge";
+        public DownloadProtocol Protocol => DownloadProtocol.Torrent;
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<DelugeAdapter> _logger;
+
+        private static readonly string[] StatusKeys =
+        [
+            "name", "total_size", "total_done", "progress", "download_payload_rate", "eta", "state",
+            "save_path", "label", "ratio", "num_seeds", "num_peers", "time_added", "files", "message"
+        ];
+
+        public DelugeAdapter(IHttpClientFactory httpClientFactory, ITorrentFileDownloader torrentFileDownloader, ILogger<DelugeAdapter> logger)
+        {
+            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            _ = torrentFileDownloader ?? throw new ArgumentNullException(nameof(torrentFileDownloader));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<(bool Success, string Message)> TestConnectionAsync(DownloadClientConfiguration client, CancellationToken ct = default)
+        {
+            try
+            {
+                using var http = _httpClientFactory.CreateClient(ClientType);
+                await AuthenticateAsync(http, client, ct);
+                await EnsureDaemonConnectedAsync(http, client, ct);
+                var connected = await RpcAsync(http, client, "web.connected", [], ct);
+                if (connected.ValueKind == JsonValueKind.True)
+                    return (true, "Deluge: connected to Web UI and daemon");
+                return (false, "Deluge: unexpected JSON-RPC response");
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogDebug(ex, "Deluge authentication failed for client {ClientId}", LogRedaction.SanitizeText(client?.Id ?? client?.Name ?? client?.Type));
+                return (false, "Deluge: authentication failed (check Web UI password)");
+            }
+            catch (TaskCanceledException)
+            {
+                return (false, "Deluge: connection timed out");
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogDebug(ex, "Deluge test failed for client {ClientId}", LogRedaction.SanitizeText(client?.Id ?? client?.Name ?? client?.Type));
+                return (false, $"Deluge: connection failed ({ex.Message})");
+            }
+        }
+
+        public async Task<DownloadClientSubmissionResult> AddAsync(
+            DownloadClientConfiguration client,
+            PreparedDownloadSubmission submission,
+            CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(client);
+            if (submission is not PreparedTorrentSubmission torrent)
+            {
+                throw new DownloadClientSubmissionException("Deluge requires a prepared torrent submission.");
+            }
+
+            using var http = _httpClientFactory.CreateClient(ClientType);
+            await AuthenticateAsync(http, client, ct);
+            await EnsureDaemonConnectedAsync(http, client, ct);
+
+            var options = BuildTorrentOptions(client);
+            string? id = null;
+
+            if (torrent.TorrentBytes != null && torrent.TorrentBytes.Length > 0)
+            {
+                var filename = SanitizeTorrentFileName(torrent.FileName ?? torrent.Title) + ".torrent";
+                var res = await RpcAsync(http, client, "core.add_torrent_file", [filename, Convert.ToBase64String(torrent.TorrentBytes), options], ct);
+                id = res.ValueKind == JsonValueKind.String ? res.GetString() : null;
+            }
+            else
+            {
+                var uri = !string.IsNullOrWhiteSpace(torrent.MagnetUri)
+                    ? DownloadClientUriBuilder.NormalizeMagnetLink(torrent.MagnetUri)
+                    : NormalizeTorrentUrl(torrent.OriginalLocator);
+                if (string.IsNullOrWhiteSpace(uri))
+                {
+                    throw new DownloadClientSubmissionException("No magnet link, torrent URL, or cached torrent file provided.");
+                }
+
+                if (uri.StartsWith("magnet:", StringComparison.OrdinalIgnoreCase))
+                {
+                    var res = await RpcAsync(http, client, "core.add_torrent_magnet", [uri, options], ct);
+                    id = res.ValueKind == JsonValueKind.String ? res.GetString() : TryExtractHashFromMagnet(uri);
+                }
+                else
+                {
+                    var tempPath = await RpcAsync(http, client, "web.download_torrent_from_url", [uri], ct);
+                    var path = tempPath.GetString();
+                    if (!string.IsNullOrWhiteSpace(path))
+                    {
+                        var res = await RpcAsync(http, client, "web.add_torrents", [new[] { new { path, options } }], ct);
+                        id = TryExtractAddedId(res);
+                    }
+                }
+            }
+
+            var category = GetSetting(client, "category");
+            if (!string.IsNullOrWhiteSpace(id) && !string.IsNullOrWhiteSpace(category))
+                await TrySetLabelAsync(http, client, id, category, ct);
+
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new DownloadClientSubmissionException("Deluge did not return a verified torrent identifier.");
+            }
+
+            return new DownloadClientSubmissionResult(id, torrent.InfoHash);
+        }
+
+        public async Task<bool> RemoveAsync(DownloadClientConfiguration client, string id, bool deleteFiles = false, CancellationToken ct = default)
+        {
+            using var http = _httpClientFactory.CreateClient(ClientType);
+            await AuthenticateAsync(http, client, ct);
+            await EnsureDaemonConnectedAsync(http, client, ct);
+            var res = await RpcAsync(http, client, "core.remove_torrent", [id, deleteFiles], ct);
+            return res.ValueKind == JsonValueKind.True || res.ValueKind == JsonValueKind.Null || res.ValueKind == JsonValueKind.Undefined;
+        }
+
+        public async Task<List<QueueItem>> GetQueueAsync(DownloadClientConfiguration client, CancellationToken ct = default)
+            => (await GetItemsAsync(client, ct)).Select(ToQueueItem).ToList();
+
+        public async Task<List<DownloadClientItem>> GetItemsAsync(DownloadClientConfiguration client, CancellationToken ct = default)
+        {
+            using var http = _httpClientFactory.CreateClient(ClientType);
+            await AuthenticateAsync(http, client, ct);
+            await EnsureDaemonConnectedAsync(http, client, ct);
+            var res = await RpcAsync(http, client, "web.update_ui", [StatusKeys, new Dictionary<string, object>()], ct);
+            var list = new List<DownloadClientItem>();
+            var configuredCategory = DownloadClientCategoryFilter.GetConfiguredCategory(client);
+            if (!res.TryGetProperty("torrents", out var torrents) || torrents.ValueKind != JsonValueKind.Object) return list;
+
+            foreach (var torrent in torrents.EnumerateObject())
+            {
+                var t = torrent.Value;
+                var label = GetString(t, "label");
+                if (!DownloadClientCategoryFilter.Matches(configuredCategory, label)) continue;
+                var total = GetLong(t, "total_size");
+                var done = GetLong(t, "total_done");
+                list.Add(new DownloadClientItem
+                {
+                    DownloadId = torrent.Name,
+                    Title = GetString(t, "name"),
+                    Category = label,
+                    TotalSize = total,
+                    RemainingSize = Math.Max(0, total - done),
+                    OutputPath = BuildOutputPath(t),
+                    Status = MapStatus(GetString(t, "state"), GetDouble(t, "progress")),
+                    Message = GetString(t, "message"),
+                    Progress = GetDouble(t, "progress"),
+                    DownloadSpeed = GetDouble(t, "download_payload_rate"),
+                    SeedRatio = GetDouble(t, "ratio"),
+                    Seeders = (int)GetLong(t, "num_seeds"),
+                    Leechers = (int)GetLong(t, "num_peers"),
+                    AddedAt = FromUnix(GetDouble(t, "time_added")),
+                    CanBeRemoved = true,
+                    CanMoveFiles = false,
+                    DownloadClientInfo = DownloadClientItemClientInfo.FromClient(client.Id, client.Name, client.Type, Protocol, client.RemoveCompletedDownloads != "none", false)
+                });
+            }
+            return list;
+        }
+
+        public async Task<List<(string Id, string Name)>> GetRecentHistoryAsync(DownloadClientConfiguration client, int limit = 100, CancellationToken ct = default)
+            => (await GetItemsAsync(client, ct)).Where(i => i.Status == DownloadItemStatus.Completed).Take(limit).Select(i => (i.DownloadId, i.Title)).ToList();
+
+        public async Task<DownloadClientItem> GetImportItemAsync(DownloadClientConfiguration client, DownloadClientItem item, DownloadClientItem? previousAttempt = null, CancellationToken ct = default)
+        {
+            var current = (await GetItemsAsync(client, ct)).FirstOrDefault(i => string.Equals(i.DownloadId, item.DownloadId, StringComparison.OrdinalIgnoreCase));
+            return current ?? item;
+        }
+
+        public async Task<QueueItem> GetImportItemAsync(DownloadClientConfiguration client, Download download, QueueItem queueItem, QueueItem? previousAttempt = null, CancellationToken ct = default)
+        {
+            var externalId = download.GetExternalId();
+            var current = !string.IsNullOrWhiteSpace(externalId)
+                ? (await GetQueueAsync(client, ct)).FirstOrDefault(i => string.Equals(i.Id, externalId, StringComparison.OrdinalIgnoreCase))
+                : null;
+            return current ?? queueItem;
+        }
+
+        public async Task<List<Download>> FetchDownloadsAsync(DownloadClientConfiguration client, List<Download> downloads, CancellationToken cancellationToken = default)
+        {
+            var items = await GetItemsAsync(client, cancellationToken);
+            var byId = items.ToDictionary(i => i.DownloadId, StringComparer.OrdinalIgnoreCase);
+            foreach (var d in downloads)
+            {
+                var externalId = d.GetExternalId();
+                if (!string.IsNullOrWhiteSpace(externalId) && byId.TryGetValue(externalId, out var item))
+                {
+                    d.Progress = (decimal)item.Progress;
+                    d.TotalSize = item.TotalSize;
+                    d.DownloadedSize = Math.Max(0, item.TotalSize - item.RemainingSize);
+                    d.DownloadPath = item.OutputPath;
+                    if (d.Status is DownloadStatus.Moved or DownloadStatus.Processing or DownloadStatus.ImportPending)
+                        continue;
+                    if (item.Status == DownloadItemStatus.Completed) d.Status = DownloadStatus.Completed;
+                    else if (item.Status == DownloadItemStatus.Failed) d.Status = DownloadStatus.Failed;
+                    else if (item.Status == DownloadItemStatus.Paused) d.Status = DownloadStatus.Paused;
+                    else d.Status = DownloadStatus.Downloading;
+                }
+            }
+            return downloads;
+        }
+
+        private static string BuildBaseUrl(DownloadClientConfiguration client)
+        {
+            var scheme = client.UseSSL ? "https" : "http";
+            var host = client.Host.Trim().TrimEnd('/');
+            if (host.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || host.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                host = new Uri(host).Authority;
+            var urlBase = GetSetting(client, "urlBase") ?? GetSetting(client, "UrlBase") ?? string.Empty;
+            urlBase = urlBase.Trim('/');
+            return string.IsNullOrWhiteSpace(urlBase) ? $"{scheme}://{host}:{client.Port}/json" : $"{scheme}://{host}:{client.Port}/{urlBase}/json";
+        }
+
+        private async Task AuthenticateAsync(HttpClient http, DownloadClientConfiguration client, CancellationToken ct)
+        {
+            var res = await RpcAsync(http, client, "auth.login", [client.Password ?? string.Empty], ct);
+            if (res.ValueKind != JsonValueKind.True) throw new UnauthorizedAccessException("Failed to authenticate with Deluge Web UI");
+        }
+
+        private async Task EnsureDaemonConnectedAsync(HttpClient http, DownloadClientConfiguration client, CancellationToken ct)
+        {
+            var connected = await RpcAsync(http, client, "web.connected", [], ct);
+            if (connected.ValueKind == JsonValueKind.True) return;
+
+            var hosts = await RpcAsync(http, client, "web.get_hosts", [], ct);
+            if (hosts.ValueKind != JsonValueKind.Array || hosts.GetArrayLength() == 0)
+                throw new InvalidOperationException("Deluge Web is not connected to a daemon and no daemon hosts are configured");
+
+            string? hostId = null;
+            foreach (var host in hosts.EnumerateArray())
+            {
+                if (host.ValueKind == JsonValueKind.Array && host.GetArrayLength() > 0)
+                {
+                    hostId = host[0].GetString();
+                    if (!string.IsNullOrWhiteSpace(hostId)) break;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(hostId))
+                throw new InvalidOperationException("Deluge Web returned no daemon host id");
+
+            await RpcAsync(http, client, "web.connect", [hostId], ct);
+        }
+
+        private async Task<JsonElement> RpcAsync(HttpClient http, DownloadClientConfiguration client, string method, object[] parameters, CancellationToken ct)
+        {
+            var payload = JsonSerializer.Serialize(new { method, @params = parameters, id = 1 });
+            using var content = new ByteArrayContent(Encoding.UTF8.GetBytes(payload));
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            using var response = await http.PostAsync(BuildBaseUrl(client), content, ct);
+            if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden) throw new UnauthorizedAccessException("Deluge rejected the request");
+            response.EnsureSuccessStatusCode();
+            using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync(ct));
+            if (doc.RootElement.TryGetProperty("error", out var error) && error.ValueKind != JsonValueKind.Null)
+                throw new InvalidOperationException($"Deluge JSON-RPC error calling {method}: {error}");
+            if (doc.RootElement.TryGetProperty("result", out var result)) return result.Clone();
+            return default;
+        }
+
+        private static Dictionary<string, object> BuildTorrentOptions(DownloadClientConfiguration client)
+        {
+            var options = new Dictionary<string, object>();
+            if (!string.IsNullOrWhiteSpace(client.DownloadPath)) options["download_location"] = client.DownloadPath;
+            var addPaused = GetSetting(client, "addPaused") ?? GetSetting(client, "AddPaused");
+            if (bool.TryParse(addPaused, out var paused)) options["add_paused"] = paused;
+            return options;
+        }
+
+        private async Task TrySetLabelAsync(HttpClient http, DownloadClientConfiguration client, string id, string label, CancellationToken ct)
+        {
+            try { await RpcAsync(http, client, "label.set_torrent", [id, label], ct); }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            { _logger.LogDebug(ex, "Unable to set Deluge label/category. Is the Label plugin enabled?"); }
+        }
+
+        private static QueueItem ToQueueItem(DownloadClientItem item) => new()
+        {
+            Id = item.DownloadId,
+            Title = item.Title,
+            Status = item.Status.ToString().ToLowerInvariant(),
+            Progress = item.Progress,
+            Size = item.TotalSize,
+            Downloaded = Math.Max(0, item.TotalSize - item.RemainingSize),
+            DownloadSpeed = item.DownloadSpeed,
+            Eta = item.RemainingTime.HasValue ? (int)item.RemainingTime.Value.TotalSeconds : null,
+            DownloadClient = item.DownloadClientInfo.Name,
+            DownloadClientId = item.DownloadClientInfo.Id,
+            DownloadClientType = item.DownloadClientInfo.Type,
+            AddedAt = item.AddedAt,
+            ErrorMessage = item.Message,
+            Seeders = item.Seeders,
+            Leechers = item.Leechers,
+            Ratio = item.SeedRatio,
+            RemotePath = item.OutputPath,
+            ContentPath = item.OutputPath,
+            CanRemove = item.CanBeRemoved
+        };
+
+        private static DownloadItemStatus MapStatus(string state, double progress)
+        {
+            var normalizedState = (state ?? string.Empty).Trim().ToLowerInvariant();
+            var payloadComplete = progress >= 100.0;
+
+            return normalizedState switch
+            {
+                "seeding" or "finished" => DownloadItemStatus.Completed,
+                "paused" when payloadComplete => DownloadItemStatus.Completed,
+                "paused" => DownloadItemStatus.Paused,
+                "queued" when payloadComplete => DownloadItemStatus.Completed,
+                "queued" => DownloadItemStatus.Queued,
+                "downloading" or "downloading metadata" => DownloadItemStatus.Downloading,
+                "error" => DownloadItemStatus.Failed,
+                "checking" => DownloadItemStatus.Checking,
+                _ => payloadComplete ? DownloadItemStatus.Completed : DownloadItemStatus.Unknown
+            };
+        }
+
+        private static string BuildOutputPath(JsonElement t)
+        {
+            var savePath = GetString(t, "save_path").TrimEnd('/', '\\');
+            var name = GetString(t, "name");
+            if (string.IsNullOrWhiteSpace(savePath)) return string.Empty;
+            return string.IsNullOrWhiteSpace(name) ? savePath : Path.Combine(savePath, name);
+        }
+        private static string? GetSetting(DownloadClientConfiguration c, string key) => c.Settings != null && c.Settings.TryGetValue(key, out var v) ? v?.ToString() : null;
+        private static string GetString(JsonElement e, string key) => e.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() ?? string.Empty : string.Empty;
+        private static long GetLong(JsonElement e, string key) => e.TryGetProperty(key, out var v) && v.TryGetInt64(out var l) ? l : 0;
+        private static double GetDouble(JsonElement e, string key) => e.TryGetProperty(key, out var v) && v.TryGetDouble(out var d) ? d : 0;
+        private static DateTime FromUnix(double seconds) => seconds > 0 ? DateTimeOffset.FromUnixTimeSeconds((long)seconds).UtcDateTime : DateTime.UtcNow;
+        private static string? NormalizeTorrentUrl(string? url) => string.IsNullOrWhiteSpace(url) ? null : url.Trim();
+        private static string SanitizeTorrentFileName(string? title) => string.Join("_", (title ?? "listenarr").Split(Path.GetInvalidFileNameChars(), StringSplitOptions.RemoveEmptyEntries)).Trim();
+        private static string? TryExtractHashFromMagnet(string magnet) { var m = System.Text.RegularExpressions.Regex.Match(magnet, @"btih:([A-Fa-f0-9]{40})"); return m.Success ? m.Groups[1].Value.ToLowerInvariant() : null; }
+        private static string? TryExtractAddedId(JsonElement res) => res.ValueKind == JsonValueKind.Array && res.GetArrayLength() > 0 ? res[0].GetString() : null;
+    }
+}

--- a/listenarr.infrastructure/GlobalUsings.cs
+++ b/listenarr.infrastructure/GlobalUsings.cs
@@ -97,6 +97,7 @@ global using Listenarr.Infrastructure.Metadata.Providers.Audnexus;
 global using Listenarr.Infrastructure.Metadata.Providers.OpenLibrary;
 global using Listenarr.Infrastructure.HostedServices.Search;
 global using Listenarr.Infrastructure.DownloadClients.Common;
+global using Listenarr.Infrastructure.DownloadClients.Deluge;
 global using Listenarr.Infrastructure.DownloadClients.Nzbget;
 global using Listenarr.Infrastructure.DownloadClients.Qbittorrent;
 global using Listenarr.Infrastructure.DownloadClients.Sabnzbd;

--- a/tests/Features/Infrastructure/DownloadClients/Deluge/DelugeAdapterTests.cs
+++ b/tests/Features/Infrastructure/DownloadClients/Deluge/DelugeAdapterTests.cs
@@ -1,0 +1,283 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Listenarr.Infrastructure.DownloadClients.Deluge;
+using Listenarr.Infrastructure.Torrents;
+using Listenarr.Tests.Common;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Listenarr.Tests.Features.Infrastructure.DownloadClients.Deluge
+{
+    [Trait("Name", "DelugeAdapterTests")]
+    [Trait("Category", "DownloadClientAdapter")]
+    [Trait("Third-Party", "Deluge")]
+    public class DelugeAdapterTests
+    {
+        [Theory]
+        [InlineData("Seeding", 100.0, DownloadItemStatus.Completed)]
+        [InlineData("Paused", 100.0, DownloadItemStatus.Completed)]
+        [InlineData("Queued", 100.0, DownloadItemStatus.Completed)]
+        [InlineData("Downloading", 42.5, DownloadItemStatus.Downloading)]
+        [InlineData("Downloading Metadata", 0.0, DownloadItemStatus.Downloading)]
+        [InlineData("Checking", 100.0, DownloadItemStatus.Checking)]
+        [InlineData("Error", 0.0, DownloadItemStatus.Failed)]
+        public async Task GetItemsAsync_MapsDelugeStatesToNormalizedStatuses(string state, double progress, DownloadItemStatus expectedStatus)
+        {
+            var adapter = CreateAdapter(BuildUpdateUiResponse(state, progress, "listenarr"));
+            var client = CreateClient(category: "listenarr");
+
+            var items = await adapter.GetItemsAsync(client, CancellationToken.None);
+
+            Assert.Single(items);
+            Assert.Equal(expectedStatus, items[0].Status);
+            Assert.Equal("ABCDEF1234567890", items[0].DownloadId);
+            Assert.Equal("Book.m4b", items[0].Title);
+            Assert.Equal("/downloads/Book.m4b", items[0].OutputPath);
+        }
+
+        [Fact]
+        public async Task GetItemsAsync_FiltersByConfiguredCategory()
+        {
+            var adapter = CreateAdapter("""
+            {
+              "id":1,
+              "result":{
+                "torrents":{
+                  "HASH1":{
+                    "name":"Book One",
+                    "total_size":100,
+                    "total_done":100,
+                    "progress":100.0,
+                    "download_payload_rate":0,
+                    "eta":0,
+                    "state":"Seeding",
+                    "save_path":"/downloads",
+                    "label":"listenarr",
+                    "ratio":1.0,
+                    "num_seeds":1,
+                    "num_peers":0,
+                    "time_added":1700000000,
+                    "message":""
+                  },
+                  "HASH2":{
+                    "name":"Movie One",
+                    "total_size":100,
+                    "total_done":100,
+                    "progress":100.0,
+                    "download_payload_rate":0,
+                    "eta":0,
+                    "state":"Seeding",
+                    "save_path":"/downloads",
+                    "label":"movies",
+                    "ratio":1.0,
+                    "num_seeds":1,
+                    "num_peers":0,
+                    "time_added":1700000000,
+                    "message":""
+                  }
+                }
+              },
+              "error":null
+            }
+            """);
+            var client = CreateClient(category: "listenarr");
+
+            var items = await adapter.GetItemsAsync(client, CancellationToken.None);
+
+            Assert.Single(items);
+            Assert.Equal("HASH1", items[0].DownloadId);
+            Assert.Equal("listenarr", items[0].Category);
+        }
+
+        [Fact]
+        public async Task TestConnectionAsync_AuthenticatesAndRequiresDaemonConnection()
+        {
+            var adapter = CreateAdapter(BuildUpdateUiResponse("Seeding", 100.0, "listenarr"));
+            var client = CreateClient(category: null);
+
+            var (success, message) = await adapter.TestConnectionAsync(client, CancellationToken.None);
+
+            Assert.True(success);
+            Assert.Contains("daemon", message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task FetchDownloadsAsync_MatchesDownloadsByExternalClientId()
+        {
+            var adapter = CreateAdapter(BuildUpdateUiResponse("Seeding", 100.0, "listenarr"));
+            var client = CreateClient(category: "listenarr");
+            var download = new Download
+            {
+                Id = "listenarr-download-1",
+                DownloadClientId = client.Id,
+                Status = DownloadStatus.Queued
+            };
+            download.SetExternalId("ABCDEF1234567890");
+
+            var updated = await adapter.FetchDownloadsAsync(client, [download], CancellationToken.None);
+
+            Assert.Single(updated);
+            Assert.Equal(DownloadStatus.Completed, updated[0].Status);
+            Assert.Equal(100m, updated[0].Progress);
+            Assert.Equal(100, updated[0].DownloadedSize);
+            Assert.Equal("/downloads/Book.m4b", updated[0].DownloadPath);
+        }
+
+        [Fact]
+        public async Task GetImportItemAsync_MatchesQueueItemByExternalClientId()
+        {
+            var adapter = CreateAdapter(BuildUpdateUiResponse("Seeding", 100.0, "listenarr"));
+            var client = CreateClient(category: "listenarr");
+            var download = new Download
+            {
+                Id = "listenarr-download-1",
+                DownloadClientId = client.Id
+            };
+            download.SetExternalId("ABCDEF1234567890");
+            var fallback = new QueueItem
+            {
+                Id = "listenarr-download-1",
+                Title = "Fallback"
+            };
+
+            var item = await adapter.GetImportItemAsync(client, download, fallback, null, CancellationToken.None);
+
+            Assert.Equal("ABCDEF1234567890", item.Id);
+            Assert.Equal("Book.m4b", item.Title);
+            Assert.Equal("completed", item.Status);
+        }
+
+        [Fact]
+        public async Task FetchDownloadsAsync_PreservesImportedStatusWhenClientStillReportsCompletedTorrent()
+        {
+            var adapter = CreateAdapter(BuildUpdateUiResponse("Seeding", 100.0, "listenarr"));
+            var client = CreateClient(category: "listenarr");
+            var download = new Download
+            {
+                Id = "listenarr-download-1",
+                DownloadClientId = client.Id,
+                Status = DownloadStatus.Moved
+            };
+            download.SetExternalId("ABCDEF1234567890");
+
+            var updated = await adapter.FetchDownloadsAsync(client, [download], CancellationToken.None);
+
+            Assert.Single(updated);
+            Assert.Equal(DownloadStatus.Moved, updated[0].Status);
+            Assert.Equal(100m, updated[0].Progress);
+            Assert.Equal("/downloads/Book.m4b", updated[0].DownloadPath);
+        }
+
+        private static DelugeAdapter CreateAdapter(string updateUiResponse)
+        {
+            var handler = new DelegatingHandlerMock(async (request, ct) =>
+            {
+                var body = await request.Content!.ReadAsStringAsync(ct);
+                using var document = JsonDocument.Parse(body);
+                var method = document.RootElement.GetProperty("method").GetString();
+                var responseBody = method switch
+                {
+                    "auth.login" => """
+                    {
+                      "id":1,
+                      "result":true,
+                      "error":null
+                    }
+                    """,
+                    "web.connected" => """
+                    {
+                      "id":1,
+                      "result":true,
+                      "error":null
+                    }
+                    """,
+                    "web.update_ui" => updateUiResponse,
+                    _ => """
+                    {
+                      "id":1,
+                      "result":null,
+                      "error":null
+                    }
+                    """
+                };
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+                };
+            });
+            var httpFactory = new Mock<IHttpClientFactory>();
+            httpFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(new HttpClient(handler));
+
+            return new DelugeAdapter(httpFactory.Object, Mock.Of<ITorrentFileDownloader>(), NullLogger<DelugeAdapter>.Instance);
+        }
+
+        private static DownloadClientConfiguration CreateClient(string? category)
+        {
+            var client = new DownloadClientConfiguration
+            {
+                Id = "deluge-1",
+                Name = "Deluge",
+                Type = "deluge",
+                Host = "localhost",
+                Port = 8112,
+                Password = "deluge"
+            };
+
+            if (!string.IsNullOrWhiteSpace(category))
+            {
+                client.Settings = new Dictionary<string, object>
+                {
+                    ["category"] = category
+                };
+            }
+
+            return client;
+        }
+
+        private static string BuildUpdateUiResponse(string state, double progress, string label)
+            => $$"""
+            {
+              "id":1,
+              "result":{
+                "torrents":{
+                  "ABCDEF1234567890":{
+                    "name":"Book.m4b",
+                    "total_size":100,
+                    "total_done":{{(long)Math.Round(progress)}},
+                    "progress":{{progress.ToString(System.Globalization.CultureInfo.InvariantCulture)}},
+                    "download_payload_rate":25,
+                    "eta":60,
+                    "state":"{{state}}",
+                    "save_path":"/downloads",
+                    "label":"{{label}}",
+                    "ratio":1.0,
+                    "num_seeds":1,
+                    "num_peers":0,
+                    "time_added":1700000000,
+                    "message":""
+                  }
+                }
+              },
+              "error":null
+            }
+            """;
+    }
+}


### PR DESCRIPTION
## Summary

Adds Deluge Web JSON-RPC as a supported download client.

Fixes #240.

## Changes

### Added
- `DelugeAdapter` implementing Listenarr download-client operations via Deluge Web JSON-RPC:
  - connection/authentication check
  - add torrent
  - remove torrent
  - queue/item monitoring
  - import item lookup
  - download status polling
- Named Deluge `HttpClient` registration with cookie support for Deluge Web sessions.
- Deluge adapter registration with `IDownloadClientAdapterFactory`.
- Deluge frontend configuration support:
  - client type option
  - default port `8112`
  - optional URL base/reverse-proxy prefix
  - category/label guidance
- README supported-client documentation for Deluge.
- Backend adapter tests covering lifecycle status mapping, category filtering, daemon connection, external torrent id matching, and completed/imported status preservation.

### Changed
- Download client type definitions/configuration now include `deluge`.
- Download client settings UI now lists Deluge alongside qBittorrent, Transmission, SABnzbd, and NZBGet.

### Fixed
- Deluge monitor/import matching uses the external torrent id/hash instead of the Listenarr client/config id.

## Testing

- `dotnet test tests/Listenarr.Tests.csproj --filter FullyQualifiedName~DelugeAdapterTests`
  - Passed: 12/12
- `cd fe && npm run type-check && npm run lint:check`
  - Passed
- Push hook also ran:
  - backend format check
  - frontend type check
  - frontend tests: 74 passed, 1 skipped test file; 378 tests passed

## Notes

- Branch is based on latest `canary`.
- Deluge label/category support requires the Deluge Label plugin to be enabled.
- UI change is limited to download-client configuration fields; screenshots can be added if maintainers want visual confirmation.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] Comments added for complex logic where useful
- [x] Tests added/updated
- [x] Relevant backend tests pass
- [x] Frontend type check and lint pass
- [x] Documentation updated in README supported clients
- [x] Rebased on latest `canary`
