### PR TITLE
fix(quality): ignore disabled quality rungs

### DIFF
--- a/listenarr.domain/Common/QualityMatcher.cs
+++ b/listenarr.domain/Common/QualityMatcher.cs
@@ -92,10 +92,14 @@ namespace Listenarr.Domain.Common
             var fileIsLossless = IsLosslessFile(file);
             var fileKbps = NormalizeKbps(file.BitrateBitsPerSecond);
 
-            var effective = profile.Qualities
-                .Where(q => q != null && !string.IsNullOrWhiteSpace(q.Quality))
+            var effective = AllowedQualities(profile)
                 .Select(EffectiveRung)
                 .ToList();
+
+            if (effective.Count == 0)
+            {
+                return new QualityMatchResult(QualityMatchKind.Unknown, null);
+            }
 
             // Codec-specific rungs take precedence; wildcard (codec-less) rungs are the fallback
             // and exist mainly for legacy/bare profiles such as "320kbps" / "lossless".
@@ -201,7 +205,7 @@ namespace Listenarr.Domain.Common
                 return false;
             }
 
-            var rung = FindRung(profile!, qualityLabel);
+            var rung = FindAllowedRung(profile!, qualityLabel);
             return rung != null && rung.Priority <= cutoff.Priority;
         }
 
@@ -216,23 +220,24 @@ namespace Listenarr.Domain.Common
                 return false;
             }
 
-            if (string.IsNullOrWhiteSpace(existing))
-            {
-                return true;
-            }
-
             if (profile == null)
             {
                 return false;
             }
 
-            var cand = FindRung(profile, candidate);
-            var exist = FindRung(profile, existing);
+            var cand = FindAllowedRung(profile, candidate);
 
             if (cand == null)
             {
                 return false;
             }
+
+            if (string.IsNullOrWhiteSpace(existing))
+            {
+                return true;
+            }
+
+            var exist = FindAllowedRung(profile, existing);
 
             if (exist == null)
             {
@@ -240,17 +245,6 @@ namespace Listenarr.Domain.Common
             }
 
             return cand.Priority < exist.Priority;
-        }
-
-        /// <summary>Whether the profile declares a rung whose label equals <paramref name="hint"/> (case-insensitive).</summary>
-        public static bool ProfileContainsHint(QualityProfile? profile, string? hint)
-        {
-            if (profile?.Qualities == null || string.IsNullOrWhiteSpace(hint))
-            {
-                return false;
-            }
-
-            return profile.Qualities.Any(q => string.Equals(q.Quality, hint, StringComparison.OrdinalIgnoreCase));
         }
 
         // ---- internals --------------------------------------------------------------------
@@ -276,11 +270,16 @@ namespace Listenarr.Domain.Common
                 return null;
             }
 
-            return FindRung(profile, profile.CutoffQuality);
+            return FindAllowedRung(profile, profile.CutoffQuality);
         }
 
-        private static QualityDefinition? FindRung(QualityProfile profile, string label)
-            => profile.Qualities.FirstOrDefault(q => string.Equals(q.Quality, label, StringComparison.OrdinalIgnoreCase));
+        private static IEnumerable<QualityDefinition> AllowedQualities(QualityProfile profile)
+            => profile.Qualities
+                .Where(q => q.Allowed && !string.IsNullOrWhiteSpace(q.Quality));
+
+        private static QualityDefinition? FindAllowedRung(QualityProfile profile, string label)
+            => AllowedQualities(profile)
+                .FirstOrDefault(q => string.Equals(q.Quality, label, StringComparison.OrdinalIgnoreCase));
 
         /// <summary>
         /// Resolve a rung's effective (codec group, bitrate-kbps, lossless) using the structured

--- a/listenarr.domain/Common/QualityMatcher.cs
+++ b/listenarr.domain/Common/QualityMatcher.cs
@@ -92,7 +92,13 @@ namespace Listenarr.Domain.Common
             var fileIsLossless = IsLosslessFile(file);
             var fileKbps = NormalizeKbps(file.BitrateBitsPerSecond);
 
-            var effective = AllowedQualities(profile)
+            var allowed = AllowedQualities(profile).ToList();
+            if (allowed.Count == 0)
+            {
+                return new QualityMatchResult(QualityMatchKind.Unknown, null);
+            }
+
+            var effective = MatchableQualities(profile)
                 .Select(EffectiveRung)
                 .ToList();
 
@@ -121,7 +127,7 @@ namespace Listenarr.Domain.Common
             // Lossless files ignore bitrate: take the best (lowest-priority) lossless rung.
             if (fileIsLossless)
             {
-                return new QualityMatchResult(QualityMatchKind.Matched, Best(pool).Source);
+                return ToAllowedMatch(Best(pool).Source);
             }
 
             var withBitrate = pool.Where(r => r.BitrateKbps is not null).ToList();
@@ -132,18 +138,18 @@ namespace Listenarr.Domain.Common
                 var eligible = withBitrate.Where(r => r.BitrateKbps <= kbps).ToList();
                 if (eligible.Count > 0)
                 {
-                    return new QualityMatchResult(QualityMatchKind.Matched, Best(eligible).Source);
+                    return ToAllowedMatch(Best(eligible).Source);
                 }
 
                 // File is below the lowest configured rung: fall to the worst rung (never over-claim).
                 if (withBitrate.Count > 0)
                 {
-                    return new QualityMatchResult(QualityMatchKind.Matched, Worst(withBitrate).Source);
+                    return ToAllowedMatch(Worst(withBitrate).Source);
                 }
 
                 if (vbr.Count > 0)
                 {
-                    return new QualityMatchResult(QualityMatchKind.Matched, Best(vbr).Source);
+                    return ToAllowedMatch(Best(vbr).Source);
                 }
 
                 return new QualityMatchResult(QualityMatchKind.NoBitrateRung, null);
@@ -152,15 +158,20 @@ namespace Listenarr.Domain.Common
             // Unknown bitrate: prefer a VBR rung, else conservatively the worst bitrate rung.
             if (vbr.Count > 0)
             {
-                return new QualityMatchResult(QualityMatchKind.Matched, Best(vbr).Source);
+                return ToAllowedMatch(Best(vbr).Source);
             }
 
             if (withBitrate.Count > 0)
             {
-                return new QualityMatchResult(QualityMatchKind.Matched, Worst(withBitrate).Source);
+                return ToAllowedMatch(Worst(withBitrate).Source);
             }
 
             return new QualityMatchResult(QualityMatchKind.NoBitrateRung, null);
+
+            static QualityMatchResult ToAllowedMatch(QualityDefinition rung)
+                => rung.Allowed
+                    ? new QualityMatchResult(QualityMatchKind.Matched, rung)
+                    : new QualityMatchResult(QualityMatchKind.NoBitrateRung, null);
         }
 
         /// <summary>The profile rung label a file maps to, or null if it does not match.</summary>
@@ -276,6 +287,10 @@ namespace Listenarr.Domain.Common
         private static IEnumerable<QualityDefinition> AllowedQualities(QualityProfile profile)
             => profile.Qualities
                 .Where(q => q.Allowed && !string.IsNullOrWhiteSpace(q.Quality));
+
+        private static IEnumerable<QualityDefinition> MatchableQualities(QualityProfile profile)
+            => profile.Qualities
+                .Where(q => !string.IsNullOrWhiteSpace(q.Quality));
 
         private static QualityDefinition? FindAllowedRung(QualityProfile profile, string label)
             => AllowedQualities(profile)

--- a/tests/Builders/QualityProfileBuilder.cs
+++ b/tests/Builders/QualityProfileBuilder.cs
@@ -29,7 +29,13 @@ namespace Listenarr.Tests.Builders
             return this;
         }
 
-        public QualityProfileBuilder WithQuality(string quality, int priority, string? codec = null, int? bitrate = null, bool lossless = false)
+        public QualityProfileBuilder WithQuality(
+            string quality,
+            int priority,
+            string? codec = null,
+            int? bitrate = null,
+            bool lossless = false,
+            bool allowed = true)
         {
             _qualityProfile.Qualities.Add(new QualityDefinition
             {
@@ -37,7 +43,8 @@ namespace Listenarr.Tests.Builders
                 Priority = priority,
                 Codec = codec,
                 Bitrate = bitrate,
-                IsLossless = lossless
+                IsLossless = lossless,
+                Allowed = allowed
             });
             return this;
         }

--- a/tests/Features/Api/Features/Library/LibraryController_QualityCutoffTests.cs
+++ b/tests/Features/Api/Features/Library/LibraryController_QualityCutoffTests.cs
@@ -59,5 +59,52 @@ namespace Listenarr.Tests.Features.Api.Features.Library
             // Then
             Assert.True(result);
         }
+
+        [Fact]
+        [Trait("Method", "IsQualityCutoffMetAsync")]
+        [Trait("Scenario", "DisabledQualityRung_ReturnsFalse")]
+        public async Task IsQualityCutoffMetAsync_DisabledMatchingQualityRung_ReturnsFalse()
+        {
+            // Given
+            var profile = new QualityProfile
+            {
+                Name = "Disabled AAC cutoff",
+                CutoffQuality = "AAC 256kbps",
+                Qualities = new List<QualityDefinition>
+                {
+                    new()
+                    {
+                        Quality = "AAC 256kbps",
+                        Codec = "AAC",
+                        Bitrate = 256,
+                        Priority = 0,
+                        Allowed = false
+                    }
+                }
+            };
+
+            var audiobook = await _audiobookRepository.AddAsync(new AudiobookBuilder()
+                .WithTitle("Disabled AAC")
+                .WithQualityProfile(profile)
+                .Build());
+
+            await _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(audiobook)
+                .WithPath(@"C:\books\disabled-aac\book.m4b")
+                .WithFormat("m4b")
+                .WithCoded("aac")
+                .WithBitrate(256_000)
+                .WithSize(123_456)
+                .Build());
+
+            // When
+            var result = await AudiobookQualityCutoffEvaluator.IsQualityCutoffMetAsync(
+                audiobook,
+                _downloadRepository,
+                _audiobookFileRepository);
+
+            // Then
+            Assert.False(result);
+        }
     }
 }

--- a/tests/Features/Domain/Utils/QualityMatcherTests.cs
+++ b/tests/Features/Domain/Utils/QualityMatcherTests.cs
@@ -111,6 +111,21 @@ namespace Listenarr.Tests.Features.Domain.Utils
             Assert.Equal(QualityMatchKind.CodecMismatch, result.Kind);
         }
 
+        [Fact]
+        public void Match_DisabledMatchingRung_IsNotReturnedAsMatch()
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("DisabledAac")
+                .WithQuality("AAC 256kbps", 0, codec: "AAC", bitrate: 256, allowed: false)
+                .Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 256_000 };
+
+            var result = QualityMatcher.Match(file, profile);
+
+            Assert.False(result.IsMatch);
+            Assert.Equal(QualityMatchKind.Unknown, result.Kind);
+        }
+
         // ---- lossless ---------------------------------------------------------------------
 
         [Fact]
@@ -304,7 +319,20 @@ namespace Listenarr.Tests.Features.Domain.Utils
             Assert.False(QualityMatcher.MeetsCutoff(file, profile));
         }
 
-        // ---- LabelMeetsCutoff & IsLabelBetter & ProfileContainsHint -----------------------
+        [Fact]
+        public void MeetsCutoff_DisabledCutoffRung_IsFalse()
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("DisabledCutoff")
+                .WithCutoff("AAC 256kbps")
+                .WithQuality("AAC 256kbps", 0, codec: "AAC", bitrate: 256, allowed: false)
+                .Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 256_000 };
+
+            Assert.False(QualityMatcher.MeetsCutoff(file, profile));
+        }
+
+        // ---- LabelMeetsCutoff & IsLabelBetter ---------------------------------------------
 
         [Fact]
         public void LabelMeetsCutoff_HonoursPriorityDirection()
@@ -314,6 +342,18 @@ namespace Listenarr.Tests.Features.Domain.Utils
             Assert.True(QualityMatcher.LabelMeetsCutoff("AAC 320kbps", profile));
             Assert.True(QualityMatcher.LabelMeetsCutoff("AAC 256kbps", profile));
             Assert.False(QualityMatcher.LabelMeetsCutoff("AAC 192kbps", profile));
+        }
+
+        [Fact]
+        public void LabelMeetsCutoff_DisabledDownloadQuality_IsFalse()
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("DisabledDownloadQuality")
+                .WithCutoff("AAC 256kbps")
+                .WithQuality("AAC 256kbps", 0, codec: "AAC", bitrate: 256, allowed: false)
+                .Build();
+
+            Assert.False(QualityMatcher.LabelMeetsCutoff("AAC 256kbps", profile));
         }
 
         [Fact]
@@ -338,15 +378,15 @@ namespace Listenarr.Tests.Features.Domain.Utils
         }
 
         [Fact]
-        public void ProfileContainsHint_IsCaseInsensitive()
+        public void IsLabelBetter_AllowedCandidateBeatsDisabledExistingQuality()
         {
             var profile = new QualityProfileBuilder()
-                .WithName("Custom")
-                .WithQuality("Audible AAX", 0)
+                .WithName("DisabledExisting")
+                .WithQuality("AAC 320kbps", 0, codec: "AAC", bitrate: 320)
+                .WithQuality("AAC 256kbps", 1, codec: "AAC", bitrate: 256, allowed: false)
                 .Build();
 
-            Assert.True(QualityMatcher.ProfileContainsHint(profile, "audible aax"));
-            Assert.False(QualityMatcher.ProfileContainsHint(profile, "FLAC"));
+            Assert.True(QualityMatcher.IsLabelBetter("AAC 320kbps", "AAC 256kbps", profile));
         }
     }
 }

--- a/tests/Features/Domain/Utils/QualityMatcherTests.cs
+++ b/tests/Features/Domain/Utils/QualityMatcherTests.cs
@@ -332,6 +332,20 @@ namespace Listenarr.Tests.Features.Domain.Utils
             Assert.False(QualityMatcher.MeetsCutoff(file, profile));
         }
 
+        [Fact]
+        public void MeetsCutoff_DisabledLowerRung_DoesNotPromoteFileToHigherAllowedRung()
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("DisabledLowerRung")
+                .WithCutoff("AAC 320kbps")
+                .WithQuality("AAC 320kbps", 0, codec: "AAC", bitrate: 320)
+                .WithQuality("AAC 256kbps", 1, codec: "AAC", bitrate: 256, allowed: false)
+                .Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 256_000 };
+
+            Assert.False(QualityMatcher.MeetsCutoff(file, profile));
+        }
+
         // ---- LabelMeetsCutoff & IsLabelBetter ---------------------------------------------
 
         [Fact]


### PR DESCRIPTION
## Summary

This PR builds on #648 and makes quality matching treat disabled profile rungs as unavailable for production decisions. Quality detection can still understand a quality label conceptually, but disabled qualities no longer satisfy cutoff, stop searches, or trigger upgrades.

## Changes

### Added
- Added domain regressions for disabled cutoff rungs, disabled matched rungs, disabled stored labels, and allowed candidates beating disabled existing labels.
- Added an evaluator-level regression for `AudiobookQualityCutoffEvaluator` when the only matching `AAC 256kbps` rung is disabled.

### Changed
- Updated `QualityMatcher` to match, compare, and resolve cutoffs using allowed quality rungs only.
- Updated `QualityProfileBuilder.WithQuality` to support test setup for disabled qualities.

### Removed
- Removed the public `ProfileContainsHint` helper because it was test-only surface with no production caller.

## Testing

- `dotnet test tests/Listenarr.Tests.csproj -c Release --filter "FullyQualifiedName~QualityMatcher|FullyQualifiedName~AudiobookStatusEvaluator|FullyQualifiedName~AudiobookQualityCutoffEvaluator"`
- `npm run test:unit -- --run src/__tests__/audiobookStatus.spec.ts` from `fe/`
- Push hook: frontend unit suite, 74 passed / 1 skipped, 380 tests passed
- `git diff --check origin/canary...HEAD`

## Notes

#648 has been merged into `canary`; this branch has been rebased on top of the current `canary` tip so the PR diff now contains only the disabled-rung follow-up.