### PR TITLE
fix(downloads): fall back to default quality profile in auto-search

### DIFF
--- a/listenarr.application/Downloads/Submission/DownloadService.cs
+++ b/listenarr.application/Downloads/Submission/DownloadService.cs
@@ -131,8 +131,12 @@ namespace Listenarr.Application.Downloads.Submission
             }
 
             // Fall back to the default profile when an audiobook has none, so auto-search
-            // doesn't silently bail. Only give up if no profile exists at all.
-            var qualityProfile = audiobook.QualityProfile ?? await qualityProfileService.GetDefaultAsync();
+            // doesn't silently bail. GetDefaultAsync only returns a profile flagged
+            // IsDefault, which may be unset, so fall back to any profile too. Only give
+            // up if no profile exists at all.
+            var qualityProfile = audiobook.QualityProfile
+                ?? await qualityProfileService.GetDefaultAsync()
+                ?? (await qualityProfileService.GetAllAsync()).FirstOrDefault();
             if (qualityProfile == null)
             {
                 logger.LogWarning("Audiobook '{Title}' has no quality profile and no default profile exists", audiobook.Title);

--- a/listenarr.application/Downloads/Submission/DownloadService.cs
+++ b/listenarr.application/Downloads/Submission/DownloadService.cs
@@ -130,14 +130,22 @@ namespace Listenarr.Application.Downloads.Submission
                 };
             }
 
-            if (audiobook.QualityProfile == null)
+            // Fall back to the default profile when an audiobook has none, so auto-search
+            // doesn't silently bail. Only give up if no profile exists at all.
+            var qualityProfile = audiobook.QualityProfile ?? await qualityProfileService.GetDefaultAsync();
+            if (qualityProfile == null)
             {
-                logger.LogWarning("Audiobook '{Title}' has no quality profile assigned", audiobook.Title);
+                logger.LogWarning("Audiobook '{Title}' has no quality profile and no default profile exists", audiobook.Title);
                 return new SearchAndDownloadResult
                 {
                     Success = false,
-                    Message = "Audiobook has no quality profile assigned"
+                    Message = "No quality profile is configured"
                 };
+            }
+            if (audiobook.QualityProfile == null)
+            {
+                logger.LogInformation("Audiobook '{Title}' has no quality profile assigned; using default profile '{Profile}'",
+                    LogRedaction.SanitizeText(audiobook.Title), qualityProfile.Name);
             }
 
             // Build search query from audiobook metadata
@@ -159,7 +167,7 @@ namespace Listenarr.Application.Downloads.Submission
             }
 
             // Score results against quality profile
-            var scoredResults = await qualityProfileService.ScoreSearchResults(searchResults, audiobook.QualityProfile);
+            var scoredResults = await qualityProfileService.ScoreSearchResults(searchResults, qualityProfile);
 
             // Log all scored results for debugging
             logger.LogInformation("Scored {Count} search results for audiobook '{Title}':", scoredResults.Count, LogRedaction.SanitizeText(audiobook.Title));


### PR DESCRIPTION
## Problem
On the **Wanted** tab, clicking **auto search** returned nothing for any audiobook that had no quality profile assigned, while **manual search** worked. `DownloadService.SearchAndDownloadAsync` bails out *before searching any indexer* when `audiobook.QualityProfile == null`:

```
Audiobook '<title>' has no quality profile assigned
```

Manual search (the `ManualSearchModal`) has no such requirement, so it worked — making the failure look inconsistent and silent (the Wanted view only flashes the message for ~5s).

## Fix
Fall back to the **default** quality profile when an audiobook has none, instead of bailing. Only fail when *no* profile exists at all. Quality scoring then proceeds against the resolved profile.

## Behavior
- Audiobook with a profile → unchanged.
- Audiobook with **no** profile → uses the default profile (logged at info level) and searches/grabs normally.
- No profiles configured at all → clear failure (`No quality profile is configured`).

Small, self-contained change in `SearchAndDownloadAsync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)