### PR TITLE
fix(edit-modal): Listening Length throws "trim is not a function" on every keystroke

### DIFF
--- a/fe/src/components/domain/audiobook/EditAudiobookModal.vue
+++ b/fe/src/components/domain/audiobook/EditAudiobookModal.vue
@@ -1133,11 +1133,16 @@ async function syncFormFromAudiobook(audiobook: Audiobook, loadSupportingData: b
   }
 }
 
-function normalizeNumericInput(value: string | null | undefined): string {
-  return (value || '').trim()
+// NOTE: `<input type="number" v-model="formData.runtime">` makes Vue coerce the bound
+// value to a JS *number* (vModelText casts when el.type === 'number'), even though
+// formData.runtime is typed as string. So this must accept number too — calling .trim()
+// on a number throws "trim is not a function", which fired on every keystroke in the
+// Listening Length field and tore the edit modal down.
+function normalizeNumericInput(value: string | number | null | undefined): string {
+  return (value == null ? '' : String(value)).trim()
 }
 
-function parseRuntimeInput(value: string | null | undefined): number | undefined {
+function parseRuntimeInput(value: string | number | null | undefined): number | undefined {
   const normalized = normalizeNumericInput(value)
   if (!normalized) return undefined
   const parsed = Number.parseInt(normalized, 10)


### PR DESCRIPTION
## Problem

Editing **Listening Length (minutes)** in the audiobook edit modal throws on every keystroke. Each digit produces an "Unexpected Error — Something went wrong. Please refresh the page." toast, and after a few keystrokes the modal tears down.

## Root cause

The field is `<input type="number" v-model="formData.runtime">`. Vue's `v-model` coerces a `type="number"` input to a **JS number** — `vModelText` casts whenever `el.type === 'number'`, even without the `.number` modifier. So `formData.runtime` holds a *number* at runtime, despite being typed `string`.

`normalizeNumericInput` then runs:

```ts
return (value || '').trim()
```

`Number.prototype` has no `.trim()`, so this throws `TypeError: (value || "").trim is not a function`. It's invoked from the dirty-check (`hasChanges`) which re-evaluates on every keystroke. Vue's global `errorHandler` catches it (hence the toast rather than a console error), and the repeated failure unmounts the modal.

An empty field is `''` (a genuine string), which is why it only surfaces once a digit is typed.

## Fix

Harden `normalizeNumericInput` / `parseRuntimeInput` to accept `string | number` and `String()`-coerce before trimming:

```ts
function normalizeNumericInput(value: string | number | null | undefined): string {
  return (value == null ? '' : String(value)).trim()
}
```

## Verification

Reproduced in a real browser by hooking the running app's `errorHandler` to capture the swallowed stack (`TypeError: (e || "").trim is not a function`), confirmed every keystroke threw and the 3rd closed the modal. After the fix: typing `452` leaves the modal open with zero error toasts and the field value intact. `vue-tsc` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)