### PR TITLE
fix(toasts): keep warning/error toasts until dismissed

### DIFF
--- a/fe/src/services/toastService.ts
+++ b/fe/src/services/toastService.ts
@@ -80,9 +80,13 @@ export function useToast() {
       push('info', title, message, timeoutMs),
     success: (title: string, message: string, timeoutMs?: number) =>
       push('success', title, message, timeoutMs),
-    warning: (title: string, message: string, timeoutMs?: number) =>
+    // Warnings and errors are sticky by default (timeoutMs = 0): they carry
+    // information the user needs to act on — a 5s auto-dismiss too often vanishes
+    // before it can be read. They're dismissed via the toast's close button.
+    // Callers can still pass an explicit timeout to opt back into auto-dismiss.
+    warning: (title: string, message: string, timeoutMs = 0) =>
       push('warning', title, message, timeoutMs),
-    error: (title: string, message: string, timeoutMs?: number) =>
+    error: (title: string, message: string, timeoutMs = 0) =>
       push('error', title, message, timeoutMs),
   }
 }


### PR DESCRIPTION
## Problem

Warning and error toasts auto-dismiss after 5s, the same as info/success. But they carry information the user needs to read and act on — e.g. *why* a file operation failed — and frequently vanish before they can be read, especially when several stack up.

## Change

Default `warning` / `error` toasts to `timeoutMs = 0` (sticky). They're dismissed via the close button (`×`) already present on every toast. `info` / `success` keep the 5s auto-dismiss, and callers can still pass an explicit timeout to opt warning/error back into auto-dismiss.

```ts
warning: (title, message, timeoutMs = 0) => push('warning', title, message, timeoutMs),
error:   (title, message, timeoutMs = 0) => push('error',   title, message, timeoutMs),
```

`push()` already treats a `0`/falsy timeout as "no auto-dismiss", so no other change is needed. `vue-tsc` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)