### PR TITLE
fix(scan): clear stale legacy file columns when a book's folder is gone

### DIFF
--- a/listenarr.infrastructure/Library/Scanning/ScanJobProcessor.cs
+++ b/listenarr.infrastructure/Library/Scanning/ScanJobProcessor.cs
@@ -147,6 +147,12 @@ namespace Listenarr.Infrastructure.Library.Scanning
                         }
 
                         audiobook.BasePath = null;
+                        // The whole folder is gone, so the legacy single-file columns are stale too.
+                        // Leaving them set makes hasAnyFile/Wanted treat the book as "Downloaded"
+                        // with zero files forever (it never re-searches). Clear them alongside
+                        // BasePath so the book correctly reverts to "no file" / wanted.
+                        audiobook.FilePath = null;
+                        audiobook.FileSize = null;
                         await audiobookRepository.UpdateAsync(audiobook);
 
                         if (removedFilesDto.Count > 0)

--- a/tests/Features/Infrastructure/Library/Scanning/ScanJobProcessorTests.cs
+++ b/tests/Features/Infrastructure/Library/Scanning/ScanJobProcessorTests.cs
@@ -124,6 +124,44 @@ namespace Listenarr.Tests.Features.Infrastructure.Library.Scanning
             Assert.Single(files);
         }
 
+        [Fact]
+        public async Task ProcessJobAsync_BasePathMissing_ClearsLegacyFileColumns()
+        {
+            // A book whose entire folder vanished: BasePath points at a non-existent directory and
+            // the legacy single-file columns (FilePath/FileSize) are still populated. The scan must
+            // clear those columns alongside BasePath — otherwise hasAnyFile/Wanted keep treating the
+            // book as "Downloaded" with zero files forever and it never re-searches.
+            var missingPath = Path.Combine(FileService.GetTempDirectory("scan-processor-basepath-gone"), "vanished");
+            Assert.False(Directory.Exists(missingPath));
+
+            var audiobook = await _audiobookRepository.AddAsync(new AudiobookBuilder()
+                .WithTitle("Vanished Folder")
+                .WithBasePath(missingPath)
+                .WithFilePath(Path.Combine(missingPath, "Vanished.m4b"))
+                .WithFileSize(123456)
+                .WithMonitored(true)
+                .Build());
+            var (queue, job) = await CreateQueuedScanJobAsync(audiobook);
+
+            var processor = _provider.GetRequiredService<IScanJobProcessor>();
+            await processor.ProcessJobAsync(job, CancellationToken.None);
+
+            Assert.True(queue.TryGetJob(job.Id, out var updatedJob));
+            Assert.Equal("Completed", updatedJob!.Status);
+
+            // Read through a fresh scope so we bypass the test context's identity map (it tracked
+            // this audiobook at AddAsync; the scan updated it through its own DbContext scope).
+            using var readScope = _provider.CreateScope();
+            var reloaded = await readScope.ServiceProvider
+                .GetRequiredService<IAudiobookRepository>()
+                .GetByIdAsync(audiobook.Id);
+            Assert.NotNull(reloaded);
+            // The legacy single-file columns must be cleared so the book no longer reads as
+            // "Downloaded" with zero files (these drive hasAnyFile / Wanted).
+            Assert.Null(reloaded!.FilePath);
+            Assert.Null(reloaded.FileSize);
+        }
+
         private async Task<(ScanQueueService Queue, ScanJob Job)> CreateQueuedScanJobAsync(Audiobook audiobook)
         {
             var queue = Assert.IsType<ScanQueueService>(_provider.GetRequiredService<IScanQueueService>());


### PR DESCRIPTION
## Problem

Audiobooks can show **"Downloaded" status with zero files** and silently stop being re-searched.

`LibraryListService` derives file presence from a backward-compat fallback:

```csharp
var hasTrackedFiles      = files != null && files.Count > 0;          // real AudiobookFiles rows
var hasLegacyFileSummary = !string.IsNullOrWhiteSpace(a.FilePath);   // legacy single-file column
var hasAnyFile = hasTrackedFiles || hasLegacyFileSummary;
```

So a book with a stale legacy `FilePath` (and no tracked files) reads as `hasAnyFile == true` → "Downloaded", while the UI's FileCount (from the real `AudiobookFiles` rows) is 0. It's also treated as complete by `AudiobookWantedEvaluator`, so it never re-searches.

## Root cause

`ScanJobProcessor.ProcessJobAsync` has a dedicated branch for when a book's `BasePath` directory has vanished: it deletes the tracked `AudiobookFile` rows and sets `audiobook.BasePath = null`, then returns — but it **never clears the legacy `FilePath`/`FileSize` columns**. The later "legacy filePath migration" block that *would* clear them is downstream of this early `return`, so it's skipped.

Result: a book whose whole folder disappeared keeps its legacy columns set → permanent phantom "Downloaded".

## Fix

Clear `FilePath`/`FileSize` alongside `BasePath` in the missing-folder branch:

```csharp
audiobook.BasePath = null;
audiobook.FilePath = null;
audiobook.FileSize = null;
await audiobookRepository.UpdateAsync(audiobook);
```

The synchronous/manual scan path (`LibraryManualScanWorkflow.MigrateLegacyFilePathAsync`) already clears these for a missing file; this brings the background worker in line.

## Test

Added `ProcessJobAsync_BasePathMissing_ClearsLegacyFileColumns`: a book with a non-existent `BasePath` and populated legacy columns is scanned, and `FilePath`/`FileSize` are asserted null afterward (read through a fresh DI scope to bypass the test context's identity map). Full suite green (1016 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)