### PR TITLE
feat(plugins): runtime-installable plugin system (loader + manager)

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -1,0 +1,93 @@
+# Plugins
+
+Listenarr supports **runtime-installable plugins** — self-contained add-ons you install from the
+**Settings → Plugins** page without rebuilding or restarting the container yourself. A plugin can
+add backend API endpoints, frontend views and navigation, and its own data storage, all without
+any changes to Listenarr core.
+
+Plugins are distributed through **plugin repositories**: a repository is just a URL to a JSON index
+that lists the plugins it offers. Adding a repository does **not** install anything — it populates a
+menu of available plugins, and you install only the ones you want.
+
+## Get started
+
+A ready-made repository of plugins is maintained at
+**[shuff57/listenarr-plugins](https://github.com/shuff57/listenarr-plugins)**.
+
+1. In Listenarr, go to **Settings → Plugins**.
+2. Under **Repositories**, paste this URL and add it:
+
+   ```
+   https://raw.githubusercontent.com/shuff57/listenarr-plugins/main/listenarr-plugins.json
+   ```
+
+3. The available plugins appear in the list. Click **Install** on the ones you want. The app
+   restarts briefly to load each plugin. **Uninstall** and **Update** work the same way.
+
+That's it — install what you need, ignore the rest, and remove anything later without a trace.
+
+## Available plugins
+
+From the repository above:
+
+| Plugin | What it does |
+| --- | --- |
+| **Profiles** | Multi-user accounts: per-user "My Library" shelves on the shared pool, admin user management, self-service password change. |
+| **Inline Player** | In-app audiobook player — chapters, bookmarks, resume, and a Listen library page. |
+| **Discover** | Suggests audiobooks you might like, seeded from the authors and genres you already have, with one-click hand-off into Add New. |
+| **Library Stats** | A dashboard: totals, top authors/narrators, and (with the player) in-progress/finished counts. |
+| **Theme** | Inject custom CSS at runtime — accent presets, a full CSS editor, and Apply/Save/Reset. |
+| **Library Export** | Export your library to JSON or CSV in one click. |
+| **Backup** | Download your config directory as a zip. Admin-gated. |
+| **Health** | File-integrity scan: flags missing, zero-byte, or unreadable audiobook files on disk. Admin-gated. |
+
+## How it works
+
+- **A repository is a catalog, not a bundle.** The index (`listenarr-plugins.json`) lists each
+  plugin's `id`, `name`, `version`, `description`, and a `package` URL. You install per-plugin.
+- **Each plugin is a small zip** containing a `plugin.json` manifest and any of: a backend `.dll`,
+  a frontend bundle (`ui/<id>.js` + `ui/<id>.css`).
+- **Backend** assemblies are loaded at startup and their controllers run in Listenarr's own API
+  pipeline (so they share auth, CSRF, and routing). A plugin owns its **own** data — its own SQLite
+  file or config — and never modifies the core schema.
+- **Frontend** bundles are injected at runtime and register their own routes, sidebar items, and an
+  optional always-mounted root component, against a small stable host SDK (`window.LISTENARR`).
+- **Install / uninstall / update** write to the plugins directory and restart the app so the change
+  loads on the next boot.
+
+> **Trust:** installing a plugin from a repository downloads and runs its code — the same trust
+> model as *arr custom repositories. Only add repositories you trust, and keep the Plugins page
+> behind authentication / your local network.
+
+## Run your own repository
+
+A repository is just a static JSON file you host anywhere (a GitHub repo, a release asset, any web
+server). Point Listenarr at its URL and it appears in the list.
+
+```json
+{
+  "name": "My Listenarr plugins",
+  "plugins": [
+    {
+      "id": "example",
+      "name": "Example",
+      "version": "1.0.0",
+      "description": "What it does.",
+      "author": "you",
+      "package": "https://example.com/example.zip"
+    }
+  ]
+}
+```
+
+Each `package` is a zip laid out as:
+
+```
+plugin.json                 # { "id", "name", "version", "frontend"?, "styles"? }
+Listenarr.Plugins.Example.dll   # optional backend (implements IListenarrPlugin)
+ui/example.js               # optional frontend bundle
+ui/example.css              # optional styles
+```
+
+The [shuff57/listenarr-plugins](https://github.com/shuff57/listenarr-plugins) repository is a
+working example of the catalog + packaged releases.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,15 +20,19 @@ fi
 if [ "$(id -u)" = "0" ] && { [ "$PUID" != "0" ] || [ "$PGID" != "0" ]; }; then
     echo "Starting Listenarr with UID=$PUID GID=$PGID UMASK=$UMASK"
 
+    # /app/plugins must be writable by the service user so the plugin manager can
+    # install/uninstall plugins at runtime.
+    mkdir -p /app/plugins
+
     if [ "$PUID" != "0" ] && [ "$PGID" != "0" ]; then
         groupmod -o -g "$PGID" listenarr
         usermod -o -u "$PUID" listenarr
-        chown -R "$PUID:$PGID" /app/config
+        chown -R "$PUID:$PGID" /app/config /app/plugins
 
         exec gosu listenarr dotnet Listenarr.Api.dll "$@"
     fi
 
-    chown -R "$PUID:$PGID" /app/config
+    chown -R "$PUID:$PGID" /app/config /app/plugins
     exec gosu "$PUID:$PGID" dotnet Listenarr.Api.dll "$@"
 fi
 

--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -357,6 +357,21 @@
             </RouterLink>
           </div>
 
+          <!-- Plugin-contributed sidebar entries (empty in a stock install). -->
+          <div v-if="pluginNavItems.length > 0" class="nav-section">
+            <RouterLink
+              v-for="item in pluginNavItems"
+              :key="item.pluginId + item.to"
+              :to="item.to"
+              class="nav-item"
+              :class="{ 'router-link-active': pendingNavPath === item.to }"
+              @click="closeMobileMenu"
+            >
+              <component :is="item.icon" v-if="item.icon" />
+              <span>{{ item.label }}</span>
+            </RouterLink>
+          </div>
+
           <div class="nav-section">
             <RouterLink
               to="/settings"
@@ -442,6 +457,14 @@
               >
                 <span>General</span>
               </RouterLink>
+              <RouterLink
+                :to="{ path: '/settings', hash: '#plugins' }"
+                class="nav-subitem"
+                @click="closeMobileMenu"
+                :class="{ active: route.hash === '#plugins' }"
+              >
+                <span>Plugins</span>
+              </RouterLink>
             </div>
             <RouterLink
               to="/system"
@@ -524,6 +547,11 @@
 
     <!-- Global toast notifications -->
     <GlobalToast />
+
+    <!-- Plugin root components (e.g. a floating player bar). Empty in a stock install. -->
+    <template v-for="p in plugins" :key="p.id">
+      <component v-if="p.root" :is="p.root" />
+    </template>
   </div>
 </template>
 
@@ -571,6 +599,12 @@ import { normalizeQueueSnapshot } from '@/utils/queueSnapshot'
 import type { QueueItem } from '@/types'
 import { ref as vueRef, ref as vueRef2, reactive } from 'vue'
 import GlobalToast from '@/components/ui/GlobalToast.vue'
+import { plugins } from '@/plugins'
+
+// Sidebar entries contributed by runtime-loaded plugins.
+const pluginNavItems = computed(() =>
+  plugins.value.flatMap((p) => (p.nav ?? []).map((n) => ({ ...n, pluginId: p.id }))),
+)
 import { useToast } from '@/services/toastService'
 import { logger } from '@/utils/logger'
 import BrandLogo from '@/components/base/BrandLogo.vue'

--- a/fe/src/main.ts
+++ b/fe/src/main.ts
@@ -33,6 +33,7 @@ import { createPinia } from 'pinia'
 
 import App from './App.vue'
 import { createAppRouter, preloadRoute } from './router'
+import { installPluginSdk, loadInstalledPlugins } from './plugins/runtime'
 import { useToast } from './services/toastService'
 import { errorTracking } from './services/errorTracking'
 import { apiService } from '@/services/api'
@@ -81,6 +82,9 @@ window.addEventListener('unhandledrejection', (event) => {
 app.use(createPinia())
 const router = createAppRouter()
 app.use(router)
+
+// Expose the host SDK (window.LISTENARR) so runtime-loaded plugin bundles can register.
+installPluginSdk()
 
 // Prefetch lazy route chunks when a user hovers or presses a link.
 // This reduces perceived navigation latency by warming the dynamic import.
@@ -146,6 +150,9 @@ getStartupConfigCached(2000)
   .catch(() => {})
 
 app.mount('#app')
+
+// Discover and load installed plugins (manifest → inject bundles). Best-effort, non-blocking.
+void loadInstalledPlugins()
 
 // Web Vitals - Performance monitoring (production only)
 // NOTE: Analytics integration point - when adding analytics service (Google Analytics, Plausible, etc.),

--- a/fe/src/plugins/index.ts
+++ b/fe/src/plugins/index.ts
@@ -1,0 +1,67 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+import { ref, markRaw, type Component } from 'vue'
+import type { RouteRecordRaw, Router } from 'vue-router'
+
+/**
+ * A frontend plugin contributes an optional always-mounted root component (e.g. a floating
+ * player bar) and/or routes. Plugins are loaded at runtime (see runtime.ts) from packages
+ * dropped into the host's plugins/ folder — no rebuild required.
+ */
+export interface PluginNavItem {
+  label: string
+  to: string
+  icon?: Component
+}
+
+export interface ListenarrPlugin {
+  id: string
+  root?: Component
+  routes?: RouteRecordRaw[]
+  /** Sidebar entries contributed by the plugin. */
+  nav?: PluginNavItem[]
+}
+
+/** Reactive registry; App.vue renders each plugin's root, router gets each plugin's routes. */
+export const plugins = ref<ListenarrPlugin[]>([])
+
+let router: Router | null = null
+
+/** Called once by the app after the router is created, so runtime registrations can add routes. */
+export function setPluginRouter(r: Router): void {
+  router = r
+}
+
+/** Register a plugin at runtime. Idempotent by id. Adds routes to the live router. */
+export function registerPlugin(plugin: ListenarrPlugin): void {
+  if (!plugin?.id || plugins.value.some((p) => p.id === plugin.id)) {
+    return
+  }
+
+  const nav = plugin.nav?.map((n) => ({ ...n, icon: n.icon ? markRaw(n.icon) : undefined }))
+  plugins.value = [
+    ...plugins.value,
+    {
+      id: plugin.id,
+      root: plugin.root ? markRaw(plugin.root) : undefined,
+      routes: plugin.routes,
+      nav,
+    },
+  ]
+
+  if (router && plugin.routes) {
+    for (const route of plugin.routes) {
+      const name = route.name as string | undefined
+      if (!name || !router.hasRoute(name)) {
+        router.addRoute(route)
+      }
+    }
+  }
+}

--- a/fe/src/plugins/runtime.ts
+++ b/fe/src/plugins/runtime.ts
@@ -1,0 +1,100 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * Runtime plugin loader. Exposes the host SDK on window.LISTENARR (the stable contract a
+ * plugin builds against), fetches the installed-plugin manifest, and injects each plugin's
+ * prebuilt bundle. Plugins self-register via window.LISTENARR.registerPlugin.
+ */
+import * as Vue from 'vue'
+import * as VueRouter from 'vue-router'
+import * as Pinia from 'pinia'
+import { registerPlugin } from './index'
+import { apiService } from '@/services/api'
+import { buildApiPath } from '@/services/apiBase'
+import { useLibraryStore } from '@/stores/library'
+import { useProtectedImages } from '@/composables/useProtectedImages'
+import { getPlaceholderUrl } from '@/utils/placeholder'
+
+interface ManifestEntry {
+  id: string
+  name: string
+  version: string
+  frontend: string | null
+  styles: string[]
+}
+
+/**
+ * Install the host SDK as window globals. Plugin bundles externalize vue/vue-router/pinia to
+ * the LISTENARR_* globals (one shared framework instance) and read host services + the
+ * register hook from window.LISTENARR.
+ */
+export function installPluginSdk(): void {
+  const w = window as unknown as Record<string, unknown>
+  w.LISTENARR_VUE = Vue
+  w.LISTENARR_VUE_ROUTER = VueRouter
+  w.LISTENARR_PINIA = Pinia
+  w.LISTENARR = {
+    version: '1.0',
+    registerPlugin,
+    // Curated host services a plugin may use, so it never bundles a second copy.
+    api: {
+      request: <T>(endpoint: string, options?: RequestInit) =>
+        apiService.pluginRequest<T>(endpoint, options),
+      buildApiPath,
+    },
+    stores: { useLibraryStore },
+    ui: { useProtectedImages, getPlaceholderUrl },
+  }
+}
+
+function injectStyle(href: string): void {
+  if (document.querySelector(`link[data-plugin-style="${href}"]`)) return
+  const link = document.createElement('link')
+  link.rel = 'stylesheet'
+  link.href = href
+  link.dataset.pluginStyle = href
+  document.head.appendChild(link)
+}
+
+function injectScript(src: string): Promise<void> {
+  return new Promise((resolve) => {
+    if (document.querySelector(`script[data-plugin-src="${src}"]`)) {
+      resolve()
+      return
+    }
+    const script = document.createElement('script')
+    script.src = src
+    script.dataset.pluginSrc = src
+    script.onload = () => resolve()
+    script.onerror = () => {
+      console.error('[plugins] failed to load', src)
+      resolve() // one bad plugin must not block the rest
+    }
+    document.body.appendChild(script)
+  })
+}
+
+/** Fetch the manifest and load every installed plugin's bundle. Best-effort. */
+export async function loadInstalledPlugins(): Promise<void> {
+  let manifest: ManifestEntry[]
+  try {
+    const url = new URL('plugins/manifest', document.baseURI).toString()
+    const res = await fetch(url, { credentials: 'include' })
+    if (!res.ok) return
+    manifest = await res.json()
+  } catch {
+    return
+  }
+
+  for (const entry of manifest) {
+    // Version-stamp asset URLs so a plugin update busts the browser cache (otherwise the
+    // fixed /plugins/<id>/ui/*.js URL serves the stale bundle after an in-place update).
+    for (const href of entry.styles ?? []) injectStyle(withVersion(href, entry.version))
+    if (entry.frontend) await injectScript(withVersion(entry.frontend, entry.version))
+  }
+}
+
+function withVersion(url: string, version: string): string {
+  return `${url}${url.includes('?') ? '&' : '?'}v=${encodeURIComponent(version)}`
+}

--- a/fe/src/plugins/runtime.ts
+++ b/fe/src/plugins/runtime.ts
@@ -42,6 +42,9 @@ export function installPluginSdk(): void {
       request: <T>(endpoint: string, options?: RequestInit) =>
         apiService.pluginRequest<T>(endpoint, options),
       buildApiPath,
+      // Plugins doing writes should call this before a mutation so the antiforgery token is
+      // fresh (a stale token surfaces as a 500 that the core auto-retry doesn't cover).
+      ensureAntiforgery: () => apiService.ensureAntiforgeryForCurrentAuth(),
     },
     stores: { useLibraryStore },
     ui: { useProtectedImages, getPlaceholderUrl },

--- a/fe/src/router/index.ts
+++ b/fe/src/router/index.ts
@@ -20,6 +20,7 @@ import { useAuthStore } from '@/stores/auth'
 import { getStartupConfigCached } from '@/services/startupConfigCache'
 import { logger } from '@/utils/logger'
 import { setRouter } from '@/services/routerInstance'
+import { setPluginRouter } from '@/plugins'
 import type { StartupConfig } from '@/types'
 
 // Module-level cache/promise for startup config to avoid repeated requests during rapid navigation
@@ -160,6 +161,9 @@ export function createAppRouter() {
     history: createWebHistory(import.meta.env.BASE_URL),
     routes,
   })
+
+  // Let runtime-loaded plugins add their routes to this live router.
+  setPluginRouter(router)
 
   // Navigation guard: protect routes requiring auth and preserve redirectTo
   router.beforeEach(async (to, from) => {

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -108,6 +108,14 @@ class ApiService {
     return {}
   }
 
+  /**
+   * Generic request passthrough for plugins. Player-agnostic FE seam: lets a plugin's own API
+   * client reuse this service's auth + antiforgery + retry handling instead of reimplementing it.
+   */
+  public pluginRequest<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+    return this.request<T>(endpoint, options)
+  }
+
   private async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
     // Await tokenReadyPromise before any unsafe request to guarantee fresh token
     const method = (options.method || 'GET').toString().toUpperCase()

--- a/fe/src/views/SettingsView.vue
+++ b/fe/src/views/SettingsView.vue
@@ -92,6 +92,14 @@
             <PhSliders />
             General Settings
           </button>
+          <button
+            @click="router.push({ hash: '#plugins' })"
+            :class="{ active: activeTab === 'plugins' }"
+            class="tab-button"
+          >
+            <PhPuzzlePiece />
+            Plugins
+          </button>
         </div>
 
         <button
@@ -257,6 +265,9 @@
         ref="notificationsRef"
         :settings="settings"
       />
+
+      <!-- Plugins Tab -->
+      <PluginsTab v-if="activeTab === 'plugins'" />
     </div>
 
     <!-- Metadata Source Configuration Modal -->
@@ -405,6 +416,7 @@ import IndexersTab from '@/views/settings/IndexersTab.vue'
 import { Modal, ModalHeader, ModalFooter } from '@/components/feedback'
 import DeleteConfirmationModal from '@/components/feedback/DeleteConfirmationModal.vue'
 import GeneralSettingsTab from '@/views/settings/GeneralSettingsTab.vue'
+import PluginsTab from '@/views/settings/PluginsTab.vue'
 import CustomSelect from '@/components/form/CustomSelect.vue'
 import PasswordInput from '@/components/form/PasswordInput.vue'
 import {
@@ -421,6 +433,7 @@ import {
   PhX,
   PhCheck,
   PhDownloadSimple,
+  PhPuzzlePiece,
 } from '@phosphor-icons/vue'
 import { useToast } from '@/services/toastService'
 
@@ -450,7 +463,14 @@ logger.debug(
   (globalThis as unknown as { __vitest?: unknown }).__vitest,
 )
 const activeTab = ref<
-  'rootfolders' | 'indexers' | 'clients' | 'quality-profiles' | 'notifications' | 'bot' | 'general'
+  | 'rootfolders'
+  | 'indexers'
+  | 'clients'
+  | 'quality-profiles'
+  | 'notifications'
+  | 'bot'
+  | 'general'
+  | 'plugins'
 >('rootfolders')
 
 const mobileTabOptions = computed(() => [
@@ -461,7 +481,7 @@ const mobileTabOptions = computed(() => [
   { value: 'notifications', label: 'Notifications', icon: PhBell },
   { value: 'bot', label: 'Discord Bot', icon: PhGlobe },
   { value: 'general', label: 'General Settings', icon: PhSliders },
-  // Integrations removed
+  { value: 'plugins', label: 'Plugins', icon: PhPuzzlePiece },
 ])
 // Desktop tabs carousel refs/state
 const desktopTabsRef = ref<HTMLElement | null>(null)
@@ -1125,6 +1145,7 @@ const syncTabFromHash = () => {
     | 'notifications'
     | 'bot'
     | 'general'
+    | 'plugins'
   if (
     hash &&
     [
@@ -1135,6 +1156,7 @@ const syncTabFromHash = () => {
       'notifications',
       'bot',
       'general',
+      'plugins',
     ].includes(hash)
   ) {
     activeTab.value = hash as typeof activeTab.value

--- a/fe/src/views/settings/PluginsTab.vue
+++ b/fe/src/views/settings/PluginsTab.vue
@@ -1,0 +1,375 @@
+<!--
+  Listenarr - Audiobook Management System
+  Copyright (C) 2024-2026 Listenarr Contributors
+
+  Licensed under the GNU Affero General Public License v3 or later.
+-->
+<template>
+  <div class="tab-content">
+    <div class="plugins-tab">
+      <div class="section-header">
+        <h3>Plugins</h3>
+        <button class="btn btn-secondary" :disabled="loading" @click="load">
+          <PhArrowClockwise :class="{ spin: loading }" />
+          Refresh
+        </button>
+      </div>
+
+      <p class="warn">
+        Plugins run with full server access. Only add repositories you trust — installing from a URL
+        downloads and runs code, the same trust model as *arr custom repositories.
+      </p>
+
+      <!-- Repositories -->
+      <div class="card">
+        <div class="card-title">Repositories</div>
+        <div v-if="repositories.length === 0" class="muted">No repositories added yet.</div>
+        <div v-for="url in repositories" :key="url" class="row">
+          <span class="repo-url" :title="url">{{ url }}</span>
+          <button class="btn-icon danger" title="Remove repository" @click="removeRepo(url)">
+            <PhTrash />
+          </button>
+        </div>
+        <div class="add-repo">
+          <input
+            v-model="newRepoUrl"
+            type="url"
+            placeholder="https://example.com/listenarr-plugins.json"
+            @keydown.enter="addRepo"
+          />
+          <button class="btn btn-primary" :disabled="!newRepoUrl.trim() || busy" @click="addRepo">
+            <PhPlus />
+            Add
+          </button>
+        </div>
+        <div v-if="repoError" class="error">{{ repoError }}</div>
+      </div>
+
+      <!-- Available / updatable -->
+      <div class="card">
+        <div class="card-title">Available</div>
+        <div v-if="available.length === 0" class="muted">
+          Nothing to install. Add a repository above.
+        </div>
+        <div v-for="p in available" :key="p.id" class="row plugin">
+          <div class="plugin-meta">
+            <div class="plugin-name">
+              {{ p.name }} <span class="ver">v{{ p.availableVersion ?? p.version }}</span>
+              <span v-if="p.status === 'update'" class="badge update">update</span>
+            </div>
+            <div v-if="p.description" class="plugin-desc">{{ p.description }}</div>
+          </div>
+          <button class="btn btn-primary" :disabled="busy" @click="install(p.id)">
+            {{ p.status === 'update' ? 'Update' : 'Install' }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Installed -->
+      <div class="card">
+        <div class="card-title">Installed</div>
+        <div v-if="installed.length === 0" class="muted">No plugins installed.</div>
+        <div v-for="p in installed" :key="p.id" class="row plugin">
+          <div class="plugin-meta">
+            <div class="plugin-name">{{ p.name }} <span class="ver">v{{ p.version }}</span></div>
+            <div v-if="p.description" class="plugin-desc">{{ p.description }}</div>
+          </div>
+          <button class="btn btn-danger" :disabled="busy" @click="uninstall(p.id)">Remove</button>
+        </div>
+      </div>
+
+      <div v-if="error" class="error">{{ error }}</div>
+    </div>
+
+    <!-- Restart overlay -->
+    <div v-if="restarting" class="restart-overlay">
+      <div class="restart-box">
+        <PhArrowClockwise class="spin big" />
+        <div>Restarting to apply…</div>
+        <div class="muted small">Reconnecting</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { PhArrowClockwise, PhPlus, PhTrash } from '@phosphor-icons/vue'
+import { apiService } from '@/services/api'
+
+interface PluginInfo {
+  id: string
+  name: string
+  version: string
+  description?: string | null
+  author?: string | null
+  status: 'installed' | 'available' | 'update'
+  availableVersion?: string | null
+  repository?: string | null
+}
+
+const plugins = ref<PluginInfo[]>([])
+const repositories = ref<string[]>([])
+const newRepoUrl = ref('')
+const loading = ref(false)
+const busy = ref(false)
+const error = ref('')
+const repoError = ref('')
+const restarting = ref(false)
+
+const available = computed(() => plugins.value.filter((p) => p.status !== 'installed'))
+const installed = computed(() => plugins.value.filter((p) => p.status !== 'available'))
+
+async function load(): Promise<void> {
+  loading.value = true
+  error.value = ''
+  try {
+    repositories.value = await apiService.pluginRequest<string[]>('/plugins/repositories')
+    plugins.value = await apiService.pluginRequest<PluginInfo[]>('/plugins')
+  } catch (e) {
+    error.value = (e as Error).message || 'Failed to load plugins.'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function addRepo(): Promise<void> {
+  const url = newRepoUrl.value.trim()
+  if (!url) return
+  busy.value = true
+  repoError.value = ''
+  try {
+    await apiService.ensureAntiforgeryForCurrentAuth()
+    repositories.value = await apiService.pluginRequest<string[]>('/plugins/repositories', {
+      method: 'POST',
+      body: JSON.stringify({ url }),
+    })
+    newRepoUrl.value = ''
+    await load()
+  } catch (e) {
+    repoError.value = (e as Error).message || 'Could not add repository.'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function removeRepo(url: string): Promise<void> {
+  busy.value = true
+  try {
+    await apiService.ensureAntiforgeryForCurrentAuth()
+    repositories.value = await apiService.pluginRequest<string[]>(
+      `/plugins/repositories?url=${encodeURIComponent(url)}`,
+      { method: 'DELETE' },
+    )
+    await load()
+  } catch (e) {
+    repoError.value = (e as Error).message || 'Could not remove repository.'
+  } finally {
+    busy.value = false
+  }
+}
+
+async function install(id: string): Promise<void> {
+  busy.value = true
+  error.value = ''
+  try {
+    await apiService.ensureAntiforgeryForCurrentAuth()
+    await apiService.pluginRequest('/plugins/install', {
+      method: 'POST',
+      body: JSON.stringify({ id }),
+    })
+    waitForRestart()
+  } catch (e) {
+    error.value = (e as Error).message || 'Install failed.'
+    busy.value = false
+  }
+}
+
+async function uninstall(id: string): Promise<void> {
+  busy.value = true
+  error.value = ''
+  try {
+    await apiService.ensureAntiforgeryForCurrentAuth()
+    await apiService.pluginRequest(`/plugins/${encodeURIComponent(id)}`, { method: 'DELETE' })
+    waitForRestart()
+  } catch (e) {
+    error.value = (e as Error).message || 'Uninstall failed.'
+    busy.value = false
+  }
+}
+
+// The server restarts after install/uninstall. Poll the (anonymous) plugin manifest until it
+// answers again, then hard-reload so the new plugin set is picked up everywhere.
+function waitForRestart(): void {
+  restarting.value = true
+  let tries = 0
+  const tick = async (): Promise<void> => {
+    tries++
+    try {
+      // A small delay first so we don't catch the still-up old process.
+      const resp = await fetch('/plugins/manifest', { cache: 'no-store' })
+      if (resp.ok && tries > 2) {
+        window.location.reload()
+        return
+      }
+    } catch {
+      // server still down — keep waiting
+    }
+    if (tries < 60) {
+      setTimeout(tick, 1000)
+    } else {
+      restarting.value = false
+      error.value = 'Server did not come back automatically — reload the page manually.'
+    }
+  }
+  setTimeout(tick, 1500)
+}
+
+onMounted(load)
+</script>
+
+<style scoped>
+.plugins-tab {
+  max-width: 820px;
+}
+/* Core .btn sets align-items but not justify-content, so text left-aligns when a
+   button is wider than its label. Center it. */
+.btn {
+  justify-content: center;
+}
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+.warn {
+  color: #f0ad4e;
+  font-size: 13px;
+  margin: 0 0 1rem;
+}
+.card {
+  background: #2a2a2a;
+  border: 1px solid #3a3a3a;
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 16px;
+}
+.card-title {
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: #fff;
+}
+.muted {
+  color: #9aa4b2;
+  font-size: 13px;
+}
+.small {
+  font-size: 12px;
+}
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0;
+  border-top: 1px solid #333;
+}
+.row:first-of-type {
+  border-top: none;
+}
+.repo-url {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: #ddd;
+}
+.add-repo {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+.add-repo input {
+  flex: 1;
+  padding: 8px 10px;
+  background: #1f1f1f;
+  border: 1px solid #444;
+  border-radius: 6px;
+  color: #fff;
+}
+.plugin-meta {
+  flex: 1;
+}
+.plugin-name {
+  color: #fff;
+  font-weight: 500;
+}
+.plugin-desc {
+  color: #9aa4b2;
+  font-size: 12px;
+  margin-top: 2px;
+}
+.ver {
+  color: #9aa4b2;
+  font-weight: 400;
+  font-size: 12px;
+}
+.badge.update {
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  background: rgba(243, 156, 18, 0.2);
+  color: #f39c12;
+  border: 1px solid rgba(243, 156, 18, 0.4);
+}
+.btn-icon.danger {
+  background: none;
+  border: none;
+  color: #e74c3c;
+  cursor: pointer;
+  display: inline-flex;
+  padding: 4px;
+}
+.btn-icon.danger:hover {
+  color: #c0392b;
+}
+.error {
+  color: #e74c3c;
+  font-size: 13px;
+  margin-top: 8px;
+}
+.spin {
+  animation: lp-spin 1s linear infinite;
+}
+.spin.big {
+  font-size: 32px;
+}
+@keyframes lp-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.restart-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+.restart-box {
+  background: #2a2a2a;
+  border: 1px solid #3a3a3a;
+  border-radius: 10px;
+  padding: 28px 40px;
+  text-align: center;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+</style>

--- a/listenarr.api/Plugins/IListenarrPlugin.cs
+++ b/listenarr.api/Plugins/IListenarrPlugin.cs
@@ -1,0 +1,21 @@
+namespace Listenarr.Api.Plugins;
+
+/// <summary>
+/// Contract every Listenarr plugin assembly implements. At startup the host discovers each
+/// public, parameterless-constructable implementation in <c>plugins/*.dll</c>, registers the
+/// owning assembly as an MVC application part (so its controllers are routed), and invokes
+/// <see cref="ConfigureServices"/>. A plugin owns its own state: it registers its own
+/// DbContext and a hosted service to run its own migrations (with a distinct migrations
+/// history table so it never collides with the core schema).
+/// </summary>
+// ponytail: contract lives in the host assembly so a plugin just references Listenarr.Api.
+// Extract to a standalone Listenarr.Plugins.Abstractions package only if third-party plugins
+// ever need to compile without referencing the host.
+public interface IListenarrPlugin
+{
+    /// <summary>
+    /// Register the plugin's services, DbContext, and migration runner against the host's
+    /// DI container. Runs during host build, before the app starts.
+    /// </summary>
+    void ConfigureServices(IServiceCollection services, IConfiguration configuration);
+}

--- a/listenarr.api/Plugins/PluginAssets.cs
+++ b/listenarr.api/Plugins/PluginAssets.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using Microsoft.Extensions.FileProviders;
+
+namespace Listenarr.Api.Plugins;
+
+/// <summary>
+/// Serves runtime-installable plugin frontends. Each plugin package is a folder under the
+/// plugins directory containing <c>plugin.json</c> and a <c>ui/</c> folder with its prebuilt
+/// bundle. This exposes a manifest (<c>GET /plugins/manifest</c>) the host frontend fetches at
+/// startup, and static-serves each plugin's <c>ui/</c> assets. Generic; knows no specific plugin.
+/// </summary>
+public static class PluginAssets
+{
+    private sealed record RawManifest(string? Id, string? Name, string? Version, string? Frontend, string[]? Styles);
+
+    public static void UseListenarrPluginAssets(this WebApplication app, string pluginsDir)
+    {
+        if (!Directory.Exists(pluginsDir))
+        {
+            return;
+        }
+
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var loaded = new List<RawManifest>();
+
+        foreach (var dir in Directory.GetDirectories(pluginsDir))
+        {
+            var manifestPath = Path.Combine(dir, "plugin.json");
+            if (!File.Exists(manifestPath))
+            {
+                continue;
+            }
+
+            RawManifest? manifest;
+            try
+            {
+                manifest = JsonSerializer.Deserialize<RawManifest>(File.ReadAllText(manifestPath), options);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[plugins] bad plugin.json in {Path.GetFileName(dir)}: {ex.Message}");
+                continue;
+            }
+
+            if (manifest is null || string.IsNullOrWhiteSpace(manifest.Id))
+            {
+                continue;
+            }
+
+            var uiDir = Path.Combine(dir, "ui");
+            if (Directory.Exists(uiDir))
+            {
+                // Only the ui/ folder is web-exposed — never the dll.
+                app.UseStaticFiles(new StaticFileOptions
+                {
+                    FileProvider = new PhysicalFileProvider(uiDir),
+                    RequestPath = $"/plugins/{manifest.Id}/ui",
+                });
+            }
+
+            loaded.Add(manifest);
+        }
+
+        app.MapGet("/plugins/manifest", (HttpContext ctx) =>
+        {
+            var basePath = ctx.Request.PathBase.HasValue ? ctx.Request.PathBase.Value : string.Empty;
+            var result = loaded.Select(m => new
+            {
+                id = m.Id,
+                name = m.Name ?? m.Id,
+                version = m.Version ?? "0.0.0",
+                frontend = string.IsNullOrWhiteSpace(m.Frontend) ? null : $"{basePath}/plugins/{m.Id}/ui/{m.Frontend}",
+                styles = (m.Styles ?? []).Select(s => $"{basePath}/plugins/{m.Id}/ui/{s}").ToArray(),
+            });
+            return Results.Json(result);
+        });
+
+        Console.WriteLine($"[plugins] serving {loaded.Count} plugin UI package(s)");
+    }
+}

--- a/listenarr.api/Plugins/PluginLoader.cs
+++ b/listenarr.api/Plugins/PluginLoader.cs
@@ -1,0 +1,94 @@
+using System.Reflection;
+
+namespace Listenarr.Api.Plugins;
+
+/// <summary>
+/// Generic, plugin-agnostic loader. Scans a directory for plugin assemblies, registers their
+/// controllers as MVC application parts, and lets each plugin configure its own services.
+/// Knows nothing about any specific plugin.
+/// </summary>
+public static class PluginLoader
+{
+    /// <summary>
+    /// Load plugins from <paramref name="pluginsDir"/>. Safe no-op when the directory is
+    /// absent or contains no plugin assemblies, so a stock install behaves exactly as before.
+    /// </summary>
+    public static void AddListenarrPlugins(this WebApplicationBuilder builder, string pluginsDir)
+    {
+        if (!Directory.Exists(pluginsDir))
+        {
+            return;
+        }
+
+        var assemblies = new List<Assembly>();
+        var plugins = new List<IListenarrPlugin>();
+
+        // Support both a flat layout (plugins/*.dll) and self-contained packages
+        // (plugins/<id>/<id>.dll alongside plugin.json + ui/ for runtime-installable plugins).
+        var dlls = Directory.GetFiles(pluginsDir, "*.dll")
+            .Concat(Directory.GetDirectories(pluginsDir).SelectMany(d => Directory.GetFiles(d, "*.dll")));
+
+        foreach (var dll in dlls)
+        {
+            Assembly assembly;
+            try
+            {
+                assembly = Assembly.LoadFrom(dll);
+            }
+            catch (Exception ex)
+            {
+                // A non-plugin dll (a dependency, a native lib) is expected here — skip it.
+                Console.Error.WriteLine($"[plugins] skipped {Path.GetFileName(dll)}: {ex.Message}");
+                continue;
+            }
+
+            Type[] exported;
+            try
+            {
+                exported = assembly.GetExportedTypes();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[plugins] could not inspect {Path.GetFileName(dll)}: {ex.Message}");
+                continue;
+            }
+
+            var found = false;
+            foreach (var type in exported)
+            {
+                if (typeof(IListenarrPlugin).IsAssignableFrom(type)
+                    && type is { IsAbstract: false, IsInterface: false }
+                    && type.GetConstructor(Type.EmptyTypes) is not null)
+                {
+                    plugins.Add((IListenarrPlugin)Activator.CreateInstance(type)!);
+                    found = true;
+                }
+            }
+
+            if (found)
+            {
+                assemblies.Add(assembly);
+            }
+        }
+
+        if (plugins.Count == 0)
+        {
+            return;
+        }
+
+        // Calling AddControllers again returns a builder over the shared ApplicationPartManager;
+        // adding parts here makes the plugins' controllers discoverable.
+        var mvc = builder.Services.AddControllers();
+        foreach (var assembly in assemblies)
+        {
+            mvc.AddApplicationPart(assembly);
+        }
+
+        foreach (var plugin in plugins)
+        {
+            plugin.ConfigureServices(builder.Services, builder.Configuration);
+        }
+
+        Console.WriteLine($"[plugins] loaded {plugins.Count} plugin(s) from {assemblies.Count} assembly(ies) in {pluginsDir}");
+    }
+}

--- a/listenarr.api/Plugins/PluginManager.cs
+++ b/listenarr.api/Plugins/PluginManager.cs
@@ -1,0 +1,328 @@
+using System.IO.Compression;
+using System.Net.Http;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Api.Plugins;
+
+/// <summary>
+/// Runtime plugin management: list installed/available plugins, manage repositories
+/// (URLs to a <c>listenarr-plugins.json</c> index), and install/uninstall plugin packages.
+/// Filesystem-only — the startup <see cref="PluginLoader"/> / <see cref="PluginAssets"/> apply
+/// the change on the next boot, so install/uninstall are followed by a restart. Generic;
+/// knows nothing about any specific plugin.
+/// </summary>
+public sealed class PluginManager
+{
+    private const long MaxDownloadBytes = 64L * 1024 * 1024;       // 64 MB compressed
+    private const long MaxUncompressedBytes = 256L * 1024 * 1024;  // 256 MB extracted
+
+    private static readonly JsonSerializerOptions Json = new() { PropertyNameCaseInsensitive = true };
+
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly string _pluginsDir;
+    private readonly string _reposFile;
+    private readonly ILogger<PluginManager> _logger;
+
+    public PluginManager(IHttpClientFactory httpFactory, string pluginsDir, string configDir, ILogger<PluginManager> logger)
+    {
+        _httpFactory = httpFactory;
+        _pluginsDir = pluginsDir;
+        _reposFile = Path.Combine(configDir, "plugin-repositories.json");
+        _logger = logger;
+    }
+
+    public sealed record RepoPlugin(string Id, string? Name, string? Version, string? Description, string? Author, string? Package);
+    public sealed record RepoIndex(string? Name, RepoPlugin[]? Plugins);
+    public sealed record PluginInfo(string Id, string Name, string Version, string? Description, string? Author,
+        string Status, string? AvailableVersion, string? Repository);
+
+    // --- repositories ---
+    public List<string> GetRepositories()
+    {
+        if (!File.Exists(_reposFile))
+        {
+            return new List<string>();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(File.ReadAllText(_reposFile), Json) ?? new List<string>();
+        }
+        catch
+        {
+            return new List<string>();
+        }
+    }
+
+    private void SaveRepositories(List<string> repos)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_reposFile)!);
+        File.WriteAllText(_reposFile, JsonSerializer.Serialize(repos, Json));
+    }
+
+    public async Task AddRepositoryAsync(string url, CancellationToken ct)
+    {
+        url = (url ?? string.Empty).Trim();
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new ArgumentException("Repository URL must be an absolute http(s) URL.");
+        }
+
+        // Validate it points at a parseable index before persisting.
+        _ = await FetchIndexAsync(url, ct) ?? throw new ArgumentException("URL did not return a valid plugin index.");
+
+        var repos = GetRepositories();
+        if (!repos.Contains(url))
+        {
+            repos.Add(url);
+            SaveRepositories(repos);
+        }
+    }
+
+    public void RemoveRepository(string url)
+    {
+        var repos = GetRepositories();
+        if (repos.Remove((url ?? string.Empty).Trim()))
+        {
+            SaveRepositories(repos);
+        }
+    }
+
+    private async Task<RepoIndex?> FetchIndexAsync(string url, CancellationToken ct)
+    {
+        try
+        {
+            var http = _httpFactory.CreateClient();
+            http.Timeout = TimeSpan.FromSeconds(20);
+            var json = await http.GetStringAsync(url, ct);
+            var index = JsonSerializer.Deserialize<RepoIndex>(json, Json);
+            return index?.Plugins is null ? null : index;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch plugin index {Url}", url);
+            return null;
+        }
+    }
+
+    // --- listing ---
+    public Dictionary<string, (string Name, string Version)> GetInstalled()
+    {
+        var result = new Dictionary<string, (string, string)>(StringComparer.OrdinalIgnoreCase);
+        if (!Directory.Exists(_pluginsDir))
+        {
+            return result;
+        }
+
+        foreach (var dir in Directory.GetDirectories(_pluginsDir))
+        {
+            var manifestPath = Path.Combine(dir, "plugin.json");
+            if (!File.Exists(manifestPath))
+            {
+                continue;
+            }
+
+            try
+            {
+                var m = JsonSerializer.Deserialize<RepoPlugin>(File.ReadAllText(manifestPath), Json);
+                if (!string.IsNullOrWhiteSpace(m?.Id))
+                {
+                    result[m!.Id] = (m.Name ?? m.Id, m.Version ?? "0.0.0");
+                }
+            }
+            catch
+            {
+                // Ignore an unreadable manifest — a half-written package shouldn't break the list.
+            }
+        }
+
+        return result;
+    }
+
+    public async Task<List<PluginInfo>> ListAsync(CancellationToken ct)
+    {
+        var installed = GetInstalled();
+        var byId = new Dictionary<string, PluginInfo>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var repo in GetRepositories())
+        {
+            var index = await FetchIndexAsync(repo, ct);
+            if (index?.Plugins is null)
+            {
+                continue;
+            }
+
+            foreach (var p in index.Plugins)
+            {
+                if (string.IsNullOrWhiteSpace(p.Id) || byId.ContainsKey(p.Id))
+                {
+                    continue;
+                }
+
+                var isInstalled = installed.TryGetValue(p.Id, out var inst);
+                var repoVersion = p.Version ?? "0.0.0";
+                var status = !isInstalled
+                    ? "available"
+                    : VersionGreater(repoVersion, inst.Version) ? "update" : "installed";
+                byId[p.Id] = new PluginInfo(
+                    p.Id, p.Name ?? p.Id, isInstalled ? inst.Version : repoVersion,
+                    p.Description, p.Author, status, isInstalled ? repoVersion : null, repo);
+            }
+        }
+
+        // Installed plugins not offered by any repository (e.g. baked into the image).
+        foreach (var (id, inst) in installed)
+        {
+            if (!byId.ContainsKey(id))
+            {
+                byId[id] = new PluginInfo(id, inst.Name, inst.Version, null, null, "installed", null, null);
+            }
+        }
+
+        return byId.Values.OrderBy(p => p.Name, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    private static bool VersionGreater(string? a, string? b)
+        => Version.TryParse(a, out var va) && Version.TryParse(b, out var vb) && va > vb;
+
+    // --- install / uninstall ---
+    public async Task InstallAsync(string id, CancellationToken ct)
+    {
+        id = SanitizeId(id);
+
+        string? package = null;
+        foreach (var repo in GetRepositories())
+        {
+            var index = await FetchIndexAsync(repo, ct);
+            var match = index?.Plugins?.FirstOrDefault(p => string.Equals(p.Id, id, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+            {
+                package = match.Package;
+                break;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(package))
+        {
+            throw new InvalidOperationException($"No repository offers plugin '{id}'.");
+        }
+
+        var http = _httpFactory.CreateClient();
+        http.Timeout = TimeSpan.FromMinutes(5);
+        using var resp = await http.GetAsync(package, HttpCompletionOption.ResponseHeadersRead, ct);
+        resp.EnsureSuccessStatusCode();
+        if (resp.Content.Headers.ContentLength > MaxDownloadBytes)
+        {
+            throw new InvalidOperationException("Plugin package exceeds the size limit.");
+        }
+
+        var tmpZip = Path.Combine(Path.GetTempPath(), $"listenarr-plugin-{id}-{Guid.NewGuid():N}.zip");
+        var staging = Path.Combine(_pluginsDir, id + ".staging");
+        try
+        {
+            await using (var fs = File.Create(tmpZip))
+            {
+                await resp.Content.CopyToAsync(fs, ct);
+            }
+
+            if (Directory.Exists(staging))
+            {
+                Directory.Delete(staging, true);
+            }
+
+            SafeExtract(tmpZip, staging);
+
+            // The package must declare the same id we asked to install.
+            var manifestPath = Path.Combine(staging, "plugin.json");
+            var manifest = File.Exists(manifestPath)
+                ? JsonSerializer.Deserialize<RepoPlugin>(File.ReadAllText(manifestPath), Json)
+                : null;
+            if (string.IsNullOrWhiteSpace(manifest?.Id) || !string.Equals(manifest!.Id, id, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Package plugin.json id does not match the requested plugin id.");
+            }
+
+            var target = Path.Combine(_pluginsDir, id);
+            if (Directory.Exists(target))
+            {
+                Directory.Delete(target, true);
+            }
+
+            Directory.Move(staging, target);
+            _logger.LogInformation("Installed plugin {Id} v{Version}", id, manifest.Version);
+        }
+        finally
+        {
+            if (File.Exists(tmpZip))
+            {
+                File.Delete(tmpZip);
+            }
+
+            if (Directory.Exists(staging))
+            {
+                Directory.Delete(staging, true);
+            }
+        }
+    }
+
+    public void Uninstall(string id)
+    {
+        id = SanitizeId(id);
+        var target = Path.Combine(_pluginsDir, id);
+        if (Directory.Exists(target))
+        {
+            Directory.Delete(target, true);
+            _logger.LogInformation("Uninstalled plugin {Id}", id);
+        }
+    }
+
+    private static string SanitizeId(string id)
+    {
+        id = (id ?? string.Empty).Trim();
+        if (id.Length == 0 || id.Any(c => !(char.IsLetterOrDigit(c) || c is '-' or '_')))
+        {
+            throw new ArgumentException("Invalid plugin id.");
+        }
+
+        return id;
+    }
+
+    /// <summary>
+    /// Extract <paramref name="zipPath"/> into <paramref name="destDir"/>, rejecting any entry that
+    /// would escape the destination (zip-slip) and capping total uncompressed size. Static + pure so
+    /// it can be unit-tested without a host.
+    /// </summary>
+    public static void SafeExtract(string zipPath, string destDir)
+    {
+        Directory.CreateDirectory(destDir);
+        var destRoot = Path.GetFullPath(destDir + Path.DirectorySeparatorChar);
+
+        using var archive = ZipFile.OpenRead(zipPath);
+        long total = 0;
+        foreach (var entry in archive.Entries)
+        {
+            var targetPath = Path.GetFullPath(Path.Combine(destDir, entry.FullName));
+            if (!targetPath.StartsWith(destRoot, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Zip entry escapes target directory: {entry.FullName}");
+            }
+
+            // Directory entry.
+            if (entry.FullName.EndsWith('/') || entry.FullName.EndsWith('\\'))
+            {
+                Directory.CreateDirectory(targetPath);
+                continue;
+            }
+
+            total += entry.Length;
+            if (total > MaxUncompressedBytes)
+            {
+                throw new InvalidOperationException("Plugin package uncompressed size exceeds the limit.");
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+            entry.ExtractToFile(targetPath, overwrite: true);
+        }
+    }
+}

--- a/listenarr.api/Plugins/PluginsController.cs
+++ b/listenarr.api/Plugins/PluginsController.cs
@@ -1,0 +1,100 @@
+using Listenarr.Api.Attributes;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Api.Plugins;
+
+/// <summary>
+/// Runtime plugin management API. Lets an admin add plugin repositories and
+/// install / update / uninstall plugins. Install and uninstall touch the filesystem and then
+/// restart the app (the dll only (un)loads at startup); Docker's restart policy relaunches it.
+///
+/// Trust model: installing from a repository URL downloads and runs arbitrary code — identical to
+/// *arr custom repositories. Admin/local-network only, hence <see cref="RequireAdminOrApiKey"/>.
+/// </summary>
+[ApiController]
+[Route("api/v{version:apiVersion}/plugins")]
+[RequireAdminOrApiKey]
+public sealed class PluginsController : ControllerBase
+{
+    private readonly PluginManager _manager;
+    private readonly IHostApplicationLifetime _lifetime;
+    private readonly ILogger<PluginsController> _logger;
+
+    public PluginsController(PluginManager manager, IHostApplicationLifetime lifetime, ILogger<PluginsController> logger)
+    {
+        _manager = manager;
+        _lifetime = lifetime;
+        _logger = logger;
+    }
+
+    public sealed record RepoBody(string Url);
+    public sealed record InstallBody(string Id);
+
+    [HttpGet]
+    public async Task<IActionResult> List(CancellationToken ct) => Ok(await _manager.ListAsync(ct));
+
+    [HttpGet("repositories")]
+    public IActionResult ListRepositories() => Ok(_manager.GetRepositories());
+
+    [HttpPost("repositories")]
+    public async Task<IActionResult> AddRepository([FromBody] RepoBody body, CancellationToken ct)
+    {
+        try
+        {
+            await _manager.AddRepositoryAsync(body.Url, ct);
+            return Ok(_manager.GetRepositories());
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpDelete("repositories")]
+    public IActionResult RemoveRepository([FromQuery] string url)
+    {
+        _manager.RemoveRepository(url);
+        return Ok(_manager.GetRepositories());
+    }
+
+    [HttpPost("install")]
+    public async Task<IActionResult> Install([FromBody] InstallBody body, CancellationToken ct)
+    {
+        try
+        {
+            await _manager.InstallAsync(body.Id, ct);
+            ScheduleRestart();
+            return Ok(new { restarting = true });
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public IActionResult Uninstall(string id)
+    {
+        try
+        {
+            _manager.Uninstall(id);
+            ScheduleRestart();
+            return Ok(new { restarting = true });
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    // Respond first, then stop the host shortly after so the dll (un)loads on the next boot.
+    private void ScheduleRestart()
+    {
+        _logger.LogInformation("Plugin change applied — restarting to load.");
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(700);
+            _lifetime.StopApplication();
+        });
+    }
+}

--- a/listenarr.api/Program.cs
+++ b/listenarr.api/Program.cs
@@ -16,6 +16,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using Listenarr.Api.Plugins;
 using Listenarr.Api.Startup;
 using Listenarr.Infrastructure.DependencyInjection;
 using Listenarr.Infrastructure.FileSystem;
@@ -28,12 +29,28 @@ var builder = ListenarrBuilderFactory.Create(args, realtimeLogSink, bootstrapFil
 builder.AddListenarrApiServices(bootstrapFileSystem);
 builder.Services.AddListenarrInfrastructureComposition(builder.Configuration, builder.Environment);
 
+// Load any plugins dropped into the app's plugins/ folder. No-op on a stock install.
+var pluginsDir = Path.Combine(AppContext.BaseDirectory, "plugins");
+builder.AddListenarrPlugins(pluginsDir);
+
+// Runtime plugin manager (Settings → Plugins): install/uninstall from repositories.
+var pluginConfigDir = Path.Combine(AppContext.BaseDirectory, "config");
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton(sp => new Listenarr.Api.Plugins.PluginManager(
+    sp.GetRequiredService<IHttpClientFactory>(),
+    pluginsDir,
+    pluginConfigDir,
+    sp.GetRequiredService<ILogger<Listenarr.Api.Plugins.PluginManager>>()));
+
 var app = builder.Build();
 
 app.Services.ApplyListenarrDatabaseMigrations();
 await app.RunListenarrStartupTasksAsync();
 
 realtimeLogSink.InitializeListenarrRealtimeLogging(app.Services);
+
+// Serve runtime-installable plugin frontends (manifest + ui assets) before the SPA fallback.
+app.UseListenarrPluginAssets(pluginsDir);
 
 app.UseListenarrRequestPipeline(endpoints => endpoints.MapListenarrRealtimeHubs(app.Environment));
 

--- a/tests/Features/Plugins/PluginManagerTests.cs
+++ b/tests/Features/Plugins/PluginManagerTests.cs
@@ -1,0 +1,73 @@
+using System.IO;
+using System.IO.Compression;
+using Listenarr.Api.Plugins;
+
+namespace Listenarr.Tests.Features.Plugins;
+
+public class PluginManagerTests
+{
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "listenarr-plugin-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void SafeExtract_ExtractsNormalEntries()
+    {
+        var work = NewTempDir();
+        try
+        {
+            var zip = Path.Combine(work, "ok.zip");
+            using (var archive = ZipFile.Open(zip, ZipArchiveMode.Create))
+            {
+                // Create mode allows only one open entry stream at a time — close each before the next.
+                using (var w = new StreamWriter(archive.CreateEntry("plugin.json").Open()))
+                {
+                    w.Write("{\"id\":\"demo\"}");
+                }
+
+                using (var w2 = new StreamWriter(archive.CreateEntry("ui/app.js").Open()))
+                {
+                    w2.Write("console.log(1)");
+                }
+            }
+
+            var dest = Path.Combine(work, "out");
+            PluginManager.SafeExtract(zip, dest);
+
+            Assert.True(File.Exists(Path.Combine(dest, "plugin.json")));
+            Assert.True(File.Exists(Path.Combine(dest, "ui", "app.js")));
+        }
+        finally
+        {
+            Directory.Delete(work, true);
+        }
+    }
+
+    [Fact]
+    public void SafeExtract_RejectsZipSlip()
+    {
+        var work = NewTempDir();
+        try
+        {
+            var zip = Path.Combine(work, "evil.zip");
+            using (var archive = ZipFile.Open(zip, ZipArchiveMode.Create))
+            {
+                // Entry name escapes the destination directory.
+                using var w = new StreamWriter(archive.CreateEntry("../escape.txt").Open());
+                w.Write("pwned");
+            }
+
+            var dest = Path.Combine(work, "out");
+            Assert.Throws<InvalidOperationException>(() => PluginManager.SafeExtract(zip, dest));
+            // Nothing should have been written outside the destination.
+            Assert.False(File.Exists(Path.Combine(work, "escape.txt")));
+        }
+        finally
+        {
+            Directory.Delete(work, true);
+        }
+    }
+}


### PR DESCRIPTION
## What this adds

A generic, **plugin-agnostic** system so Listenarr can load and manage plugins at runtime — without a rebuild. It's a foundation, not a specific feature: **no `plugins/` folder → behaviour is byte-for-byte unchanged**, so a stock install is unaffected.

### Host (backend)
- **`IListenarrPlugin`** — a one-method contract (`ConfigureServices`). A plugin owns its own state: it registers its own `DbContext` and a migration runner with an isolated migrations-history table, so it never collides with the core schema.
- **`PluginLoader`** — scans `plugins/*.dll`, registers each as an MVC application part (so its controllers route) and calls `ConfigureServices`. Safe no-op when the folder is absent.
- **`PluginAssets`** — serves `GET /plugins/manifest` and static `/plugins/<id>/ui/*`, so a plugin's prebuilt frontend loads without rebuilding the host.
- **`PluginManager` + `PluginsController`** (`/api/v1/plugins`, admin-gated) — manage plugin **repositories** (a `listenarr-plugins.json` index), list installed ⊎ available, **install / update** (download package zip → zip-slip-safe extract → atomic swap) and **uninstall**. Changes apply via a restart (`IHostApplicationLifetime.StopApplication`; the container restart policy relaunches and the loader picks up the change).
- **entrypoint** chowns `/app/plugins` to the runtime user so runtime install works under `PUID`/`PGID`.

### Frontend
- A **`window.LISTENARR` SDK** (shares the host's Vue/Router/Pinia + a few curated services, so a plugin never bundles a second framework) and a **runtime loader** (fetch manifest → inject each plugin's bundle, version-stamped so updates bust the browser cache). Plugin registry + route / root-component injection.
- **Settings → Plugins** tab: Repositories / Available / Installed, with install / update / remove and a "restarting…" reconnect overlay.

## How a plugin uses it

A plugin ships as a folder — `plugin.json` + a `.dll` + a prebuilt `ui/` bundle — dropped into `plugins/<id>/` (or installed at runtime from a repository). The `.dll` implements `IListenarrPlugin`; the UI self-registers via `window.LISTENARR.registerPlugin`.

## Live demo

A working plugin using this system: **[shuff57/listenarr-player](https://github.com/shuff57/listenarr-player)** — an in-app audiobook player (chapters, bookmarks, resume, a Listen page). Add its repo in Settings → Plugins and Install to see the whole flow end-to-end.

## Trust model

Installing from a repository URL downloads and runs code with full server access — the **same trust model as *arr custom repositories**. The endpoints are admin-gated; intended for admin / local-network use, and documented as such.

## Testing

- Backend compiles clean; a zip-slip safe-extract unit test is included.
- Frontend typechecks + builds.
- Verified end-to-end (add repo → install → update → uninstall, each with the auto-restart) using the demo plugin above.

## Scope

This PR is **only the generic ecosystem** — no bundled plugin, no packaging opinions. The player and any specific plugins live in their own repos and install on top.
