### PR TITLE
feat(search): configurable automatic-search interval, per-book delay, title-only fallback

### DIFF
--- a/listenarr.domain/Configuration/ApplicationSettings.cs
+++ b/listenarr.domain/Configuration/ApplicationSettings.cs
@@ -245,5 +245,26 @@ namespace Listenarr.Domain.Configuration
         /// Preferred default language filter for Add New searches.
         /// </summary>
         public string DefaultSearchLanguage { get; set; } = "english";
+
+        /// <summary>
+        /// How often the automatic-search sweep runs, in hours. A daily (24h) cadence is
+        /// plenty for a large wanted list and spares the indexers (and shared Prowlarr).
+        /// Read each sweep so a change takes effect without a restart. Clamped to [1, 168].
+        /// </summary>
+        public int AutomaticSearchIntervalHours { get; set; } = 24;
+
+        /// <summary>
+        /// Delay between per-book searches during the automatic sweep, in seconds, to avoid
+        /// hammering indexers when the wanted list is large. Manual "Search now" is untouched.
+        /// 0 disables the throttle. Clamped to [0, 300].
+        /// </summary>
+        public int AutomaticSearchBookDelaySeconds { get; set; } = 5;
+
+        /// <summary>
+        /// When an automatic search finds nothing, optionally retry with a title-only query.
+        /// This doubles indexer queries for every unfound book, so the background sweep can
+        /// disable it; manual "Search now" always uses the fallback regardless.
+        /// </summary>
+        public bool AutomaticSearchTitleOnlyFallback { get; set; } = true;
     }
 }

--- a/listenarr.infrastructure/HostedServices/Search/AutomaticSearchResultClassifier.cs
+++ b/listenarr.infrastructure/HostedServices/Search/AutomaticSearchResultClassifier.cs
@@ -37,6 +37,13 @@ namespace Listenarr.Infrastructure.HostedServices.Search
             return string.Join(" ", parts);
         }
 
+        /// <summary>
+        /// A looser query using only the title, for the automatic-search title-only fallback
+        /// when the full "Title Author Series" query returns nothing.
+        /// </summary>
+        public string BuildTitleOnlySearchQuery(Audiobook audiobook)
+            => audiobook.Title ?? string.Empty;
+
         public bool IsTorrentResult(SearchResult result)
         {
             if (!string.IsNullOrEmpty(result.DownloadType))

--- a/listenarr.infrastructure/HostedServices/Search/AutomaticSearchService.cs
+++ b/listenarr.infrastructure/HostedServices/Search/AutomaticSearchService.cs
@@ -24,22 +24,39 @@ namespace Listenarr.Infrastructure.HostedServices.Search
     public class AutomaticSearchService(
         ILogger<AutomaticSearchService> logger,
         IAutomaticSearchProcessor processor,
-        IWorkerCycleRunner cycleRunner) : BackgroundService
+        IWorkerCycleRunner cycleRunner,
+        IServiceScopeFactory scopeFactory) : BackgroundService
     {
-        private static readonly TimeSpan SearchInterval = TimeSpan.FromHours(6);
-
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            logger.LogInformation("AutomaticSearchService started. Will search monitored audiobooks every {Hours} hours", SearchInterval.TotalHours);
+            logger.LogInformation("AutomaticSearchService started. Sweep interval is configurable (AutomaticSearchIntervalHours), read each cycle");
 
             await cycleRunner.RunPeriodicAsync(
                 nameof(AutomaticSearchService),
                 initialDelay: TimeSpan.FromMinutes(5),
-                intervalProvider: () => SearchInterval,
+                // Read the interval from settings each cycle so a change takes effect
+                // without a restart. Clamped to [1, 168] hours; falls back to 24h on error.
+                intervalProvider: GetSearchInterval,
                 runCycle: processor.RunCycleAsync,
                 stoppingToken);
 
             logger.LogInformation("AutomaticSearchService stopped");
+        }
+
+        private TimeSpan GetSearchInterval()
+        {
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var config = scope.ServiceProvider.GetRequiredService<Listenarr.Application.Configuration.Contracts.IConfigurationService>();
+                var settings = config.GetApplicationSettingsAsync().GetAwaiter().GetResult();
+                return TimeSpan.FromHours(Math.Clamp(settings.AutomaticSearchIntervalHours, 1, 168));
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                logger.LogWarning(ex, "Failed to read AutomaticSearchIntervalHours; defaulting to 24h");
+                return TimeSpan.FromHours(24);
+            }
         }
     }
 
@@ -75,9 +92,17 @@ namespace Listenarr.Infrastructure.HostedServices.Search
             var searchService = scope.ServiceProvider.GetRequiredService<ISearchService>();
             var qualityProfileService = scope.ServiceProvider.GetRequiredService<IQualityProfileService>();
             var downloadService = scope.ServiceProvider.GetRequiredService<IDownloadService>();
+            var configService = scope.ServiceProvider.GetRequiredService<Listenarr.Application.Configuration.Contracts.IConfigurationService>();
 
-            // Get all monitored audiobooks that haven't been searched in the last 6 hours
-            var cutoffTime = DateTime.UtcNow.AddHours(-6);
+            var appSettings = await configService.GetApplicationSettingsAsync();
+            var intervalHours = Math.Clamp(appSettings.AutomaticSearchIntervalHours, 1, 168);
+            // Per-book throttle: with a large wanted list, searching every book back-to-back
+            // hammers the indexers. 0 disables it. Manual "Search now" is unaffected.
+            var bookDelay = TimeSpan.FromSeconds(Math.Clamp(appSettings.AutomaticSearchBookDelaySeconds, 0, 300));
+            var enableTitleOnlyFallback = appSettings.AutomaticSearchTitleOnlyFallback;
+
+            // Don't re-search a book more often than the configured sweep interval.
+            var cutoffTime = DateTime.UtcNow.AddHours(-intervalHours);
             var monitoredAudiobooks = await audiobookRepository.GetMonitoredAudiobooksForSearchAsync(cutoffTime, stoppingToken);
 
             _logger.LogInformation("Found {Count} monitored audiobooks eligible for automatic search", monitoredAudiobooks.Count);
@@ -99,7 +124,7 @@ namespace Listenarr.Infrastructure.HostedServices.Search
                 try
                 {
                     var downloadsQueuedForBook = await ProcessAudiobookAsync(
-                        audiobook, searchService, qualityProfileService, downloadService, audiobookRepository, downloadRepository, fileRepository, stoppingToken);
+                        audiobook, searchService, qualityProfileService, downloadService, audiobookRepository, downloadRepository, fileRepository, enableTitleOnlyFallback, stoppingToken);
 
                     downloadsQueued += downloadsQueuedForBook;
                     processedCount++;
@@ -110,6 +135,10 @@ namespace Listenarr.Infrastructure.HostedServices.Search
 
                     _logger.LogInformation("Processed audiobook '{Title}' - queued {QueuedCount} downloads",
                         audiobook.Title, downloadsQueuedForBook);
+
+                    // Throttle between books so a large wanted list doesn't hammer the indexers.
+                    if (bookDelay > TimeSpan.Zero)
+                        await Task.Delay(bookDelay, stoppingToken);
                 }
                 catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
                 {
@@ -137,6 +166,7 @@ namespace Listenarr.Infrastructure.HostedServices.Search
             IAudiobookRepository audiobookRepository,
             IDownloadRepository downloadRepository,
             IAudiobookFileRepository fileRepository,
+            bool enableTitleOnlyFallback,
             CancellationToken stoppingToken)
         {
             if (audiobook.QualityProfile == null)
@@ -181,6 +211,21 @@ namespace Listenarr.Infrastructure.HostedServices.Search
             // Search for results
             var searchResults = await searchService.SearchAsync(searchQuery, isAutomaticSearch: true);
             _logger.LogInformation("Found {Count} raw search results for audiobook '{Title}'", searchResults.Count, audiobook.Title);
+
+            // Optional title-only fallback: when the full "Title Author Series" query finds nothing,
+            // retry with just the title to catch releases named loosely. Doubles indexer queries for
+            // unfound books, so it's opt-out on the background sweep (AutomaticSearchTitleOnlyFallback).
+            if (searchResults.Count == 0 && enableTitleOnlyFallback)
+            {
+                var fallbackQuery = _resultClassifier.BuildTitleOnlySearchQuery(audiobook);
+                if (!string.IsNullOrWhiteSpace(fallbackQuery)
+                    && !string.Equals(fallbackQuery, searchQuery, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogInformation("No results for '{Title}', retrying with title-only query: {Query}", audiobook.Title, fallbackQuery);
+                    searchResults = await searchService.SearchAsync(fallbackQuery, isAutomaticSearch: true);
+                    _logger.LogInformation("Title-only fallback found {Count} results for '{Title}'", searchResults.Count, audiobook.Title);
+                }
+            }
 
             // Broadcast detailed debug info about the raw search results to help diagnose automatic search failures
             try

--- a/listenarr.infrastructure/Persistence/Migrations/20260701163938_AddAutomaticSearchTuning.Designer.cs
+++ b/listenarr.infrastructure/Persistence/Migrations/20260701163938_AddAutomaticSearchTuning.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Listenarr.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Listenarr.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ListenArrDbContext))]
-    partial class ListenArrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701163938_AddAutomaticSearchTuning")]
+    partial class AddAutomaticSearchTuning
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/listenarr.infrastructure/Persistence/Migrations/20260701163938_AddAutomaticSearchTuning.cs
+++ b/listenarr.infrastructure/Persistence/Migrations/20260701163938_AddAutomaticSearchTuning.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Listenarr.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAutomaticSearchTuning : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "AutomaticSearchBookDelaySeconds",
+                table: "ApplicationSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 5);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AutomaticSearchIntervalHours",
+                table: "ApplicationSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 24);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "AutomaticSearchTitleOnlyFallback",
+                table: "ApplicationSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AutomaticSearchBookDelaySeconds",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "AutomaticSearchIntervalHours",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "AutomaticSearchTitleOnlyFallback",
+                table: "ApplicationSettings");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The automatic-search background sweep ran on a hardcoded 6-hour cadence and searched every wanted book back-to-back with no throttle. On a large wanted list that hammers the indexers (and a shared Prowlarr). This adds three `ApplicationSettings`, read fresh each sweep so changes take effect without a restart:

- **`AutomaticSearchIntervalHours`** (default 24, clamped `[1,168]`) — sweep cadence, via the service's `intervalProvider`. Also drives the "not searched since" cutoff so a book isn't re-searched more often than the configured interval.
- **`AutomaticSearchBookDelaySeconds`** (default 5, clamped `[0,300]`) — delay between per-book searches during the sweep. `0` disables it. Manual "Search now" is unaffected.
- **`AutomaticSearchTitleOnlyFallback`** (default true) — when the full `Title Author Series` query returns nothing, retry once with a title-only query to catch loosely-named releases. Doubles indexer queries for unfound books, so it's opt-out on the background sweep.

## Changes

- `ApplicationSettings`: 3 new properties + migration `AddAutomaticSearchTuning` (column defaults 24/5/true so the existing singleton row is correct) + snapshot.
- `AutomaticSearchService`: interval now read from settings each cycle (`GetSearchInterval`, clamped, 24h fallback on error).
- `AutomaticSearchProcessor`: reads the settings, applies the per-book delay in the sweep loop, and the interval-aware cutoff.
- `ProcessAudiobookAsync` + `AutomaticSearchResultClassifier.BuildTitleOnlySearchQuery`: the title-only fallback retry.

## Testing

`dotnet build` clean (0 warnings/0 errors); full suite green (**1015 passed**), including the migration/model-snapshot integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)