### PR TITLE
feat(monitoring): author-monitoring exclusion list — never re-add deleted books

### DIFF
--- a/fe/src/components/settings/AuthorMonitoringExclusionsSection.vue
+++ b/fe/src/components/settings/AuthorMonitoringExclusionsSection.vue
@@ -1,0 +1,302 @@
+<!--
+  Listenarr - Audiobook Management System
+  Copyright (C) 2024-2026 Listenarr Contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<template>
+  <div class="author-monitoring-exclusions">
+    <div class="section-header">
+      <h3>Author Monitoring Exclusions</h3>
+      <p class="description">
+        Books you deleted and chose not to re-add from a monitored author's catalog sync. Remove an
+        entry here to let author monitoring add the book again.
+      </p>
+    </div>
+
+    <!-- Error State -->
+    <div v-if="error" class="error-banner">
+      <PhWarningCircle />
+      <span>{{ error }}</span>
+      <button class="close-btn" @click="error = null">
+        <PhX />
+      </button>
+    </div>
+
+    <!-- Success Message -->
+    <div v-if="successMessage" class="success-banner">
+      <PhCheckCircle />
+      <span>{{ successMessage }}</span>
+      <button class="close-btn" @click="successMessage = null">
+        <PhX />
+      </button>
+    </div>
+
+    <!-- Loading State -->
+    <div v-if="loading" class="loading-state">
+      <PhSpinner class="ph-spin" />
+      <p>Loading exclusions...</p>
+    </div>
+
+    <!-- Exclusions List -->
+    <div v-if="!loading && exclusions.length > 0" class="exclusions-list">
+      <div v-for="exclusion in exclusions" :key="exclusion.id" class="exclusion-card">
+        <div class="exclusion-info">
+          <h4>{{ exclusion.title || 'Untitled' }}</h4>
+          <span class="exclusion-meta">
+            <template v-if="exclusion.authorName">{{ exclusion.authorName }} • </template>
+            <template v-if="exclusion.asin">ASIN {{ exclusion.asin }} • </template>
+            Excluded {{ formatDate(exclusion.createdAt) }}
+          </span>
+        </div>
+        <div class="exclusion-actions">
+          <button
+            class="btn btn-icon btn-danger action-delete"
+            title="Remove exclusion"
+            @click="handleRemove(exclusion)"
+          >
+            <PhTrash />
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Empty State -->
+    <div v-if="!loading && exclusions.length === 0" class="empty-state">
+      <PhProhibit class="empty-icon" />
+      <h4>No Exclusions</h4>
+      <p>
+        When you delete a book by a monitored author you can choose to keep it from being re-added.
+        Those choices show up here.
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import {
+  PhWarningCircle,
+  PhX,
+  PhCheckCircle,
+  PhSpinner,
+  PhTrash,
+  PhProhibit,
+} from '@phosphor-icons/vue'
+import { showConfirm } from '@/composables/useConfirm'
+import type { AuthorMonitoringExclusion } from '@/types'
+import { getAuthorMonitoringExclusions, removeAuthorMonitoringExclusion } from '@/services/api'
+
+const exclusions = ref<AuthorMonitoringExclusion[]>([])
+const loading = ref(false)
+const error = ref<string | null>(null)
+const successMessage = ref<string | null>(null)
+
+const loadExclusions = async () => {
+  loading.value = true
+  error.value = null
+  try {
+    exclusions.value = await getAuthorMonitoringExclusions()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load exclusions'
+  } finally {
+    loading.value = false
+  }
+}
+
+const handleRemove = async (exclusion: AuthorMonitoringExclusion) => {
+  const ok = await showConfirm(
+    `Remove the exclusion for "${exclusion.title || 'this book'}"?\n\n` +
+      `If the author is monitored, the catalog sync may re-add this book.`,
+    'Remove Exclusion',
+  )
+  if (!ok) return
+
+  error.value = null
+  try {
+    await removeAuthorMonitoringExclusion(exclusion.id)
+    successMessage.value = 'Exclusion removed.'
+    await loadExclusions()
+    setTimeout(() => {
+      successMessage.value = null
+    }, 3000)
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to remove exclusion'
+  }
+}
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString)
+  return date.toLocaleString()
+}
+
+onMounted(() => {
+  loadExclusions()
+})
+</script>
+
+<style scoped>
+.author-monitoring-exclusions {
+  margin-top: 1.5rem;
+}
+
+.section-header h3 {
+  color: #fff;
+  font-size: 1.1rem;
+  margin: 0 0 1rem 0;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #444;
+}
+
+.description {
+  color: #999;
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+  font-size: 0.9rem;
+}
+
+.loading-state {
+  text-align: center;
+  padding: 2rem;
+  color: #999;
+}
+
+.ph-spin {
+  animation: spin 1s linear infinite;
+}
+
+.error-banner,
+.success-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  position: relative;
+}
+
+.error-banner {
+  background-color: rgba(220, 53, 69, 0.1);
+  border: 1px solid rgba(220, 53, 69, 0.3);
+  color: #ff6b7a;
+}
+
+.success-banner {
+  background-color: rgba(40, 167, 69, 0.1);
+  border: 1px solid rgba(40, 167, 69, 0.3);
+  color: #6fbf73;
+}
+
+.error-banner .close-btn,
+.success-banner .close-btn {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.25rem;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+
+.error-banner .close-btn:hover,
+.success-banner .close-btn:hover {
+  opacity: 1;
+}
+
+.exclusions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.exclusion-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  background-color: #1a1a1a;
+  border: 1px solid #444;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  transition: all 0.2s;
+}
+
+.exclusion-card:hover {
+  border-color: #666;
+}
+
+.exclusion-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.exclusion-info h4 {
+  margin: 0 0 0.25rem 0;
+  color: #fff;
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.exclusion-meta {
+  color: #999;
+  font-size: 0.8rem;
+}
+
+.exclusion-actions {
+  flex-shrink: 0;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 2.5rem 2rem;
+  color: #999;
+}
+
+.empty-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+  color: #666;
+  display: block;
+}
+
+.empty-state h4 {
+  color: #fff;
+  margin: 0 0 0.5rem 0;
+  font-size: 1.1rem;
+}
+
+.empty-state p {
+  max-width: 500px;
+  margin: 0 auto;
+  line-height: 1.6;
+  font-size: 0.9rem;
+}
+
+.btn-icon {
+  padding: 0.5rem;
+  background-color: #2a2a2a;
+  border: 1px solid #444;
+  color: #fff;
+  min-width: auto;
+}
+
+.btn-icon.btn-danger:hover {
+  background-color: #333;
+  border-color: #dc3545;
+  color: #dc3545;
+}
+</style>

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -44,6 +44,7 @@ import type {
   AuthorLookupResponse,
   AuthorMonitoringStatusResponse,
   MonitorAuthorResponse,
+  AuthorMonitoringExclusion,
   MonitorSeriesResponse,
   SeriesMonitoringStatusResponse,
   SeriesCatalogResponse,
@@ -511,6 +512,16 @@ class ApiService {
 
   async unmonitorAuthor(id: number): Promise<{ message: string }> {
     return this.request<{ message: string }>(`/authors/monitoring/${id}`, {
+      method: 'DELETE',
+    })
+  }
+
+  async getAuthorMonitoringExclusions(): Promise<AuthorMonitoringExclusion[]> {
+    return this.request<AuthorMonitoringExclusion[]>('/authors/monitoring/exclusions')
+  }
+
+  async removeAuthorMonitoringExclusion(id: number): Promise<{ message: string }> {
+    return this.request<{ message: string }>(`/authors/monitoring/exclusions/${id}`, {
       method: 'DELETE',
     })
   }
@@ -1240,12 +1251,14 @@ class ApiService {
 
   async removeFromLibrary(
     id: number,
-    options?: { deleteFiles?: boolean; deleteFolder?: boolean },
+    options?: { deleteFiles?: boolean; deleteFolder?: boolean; excludeFromAuthorMonitoring?: boolean },
   ): Promise<{ message: string; id: number }> {
     const params = new URLSearchParams()
     if (options?.deleteFiles !== undefined) params.set('deleteFiles', String(options.deleteFiles))
     if (options?.deleteFolder !== undefined)
       params.set('deleteFolder', String(options.deleteFolder))
+    if (options?.excludeFromAuthorMonitoring !== undefined)
+      params.set('excludeFromAuthorMonitoring', String(options.excludeFromAuthorMonitoring))
     const suffix = params.toString() ? `?${params.toString()}` : ''
     return this.request<{ message: string; id: number }>(`/library/${id}${suffix}`, {
       method: 'DELETE',
@@ -2000,6 +2013,9 @@ export const apiService = new ApiService()
 
 // Compatibility export for legacy code expecting apiService.search
 export const search = apiService.advancedSearch.bind(apiService)
+export const getAuthorMonitoringExclusions = () => apiService.getAuthorMonitoringExclusions()
+export const removeAuthorMonitoringExclusion = (id: number) =>
+  apiService.removeAuthorMonitoringExclusion(id)
 
 // Export individual indexer functions for convenience
 export const getIndexers = () => apiService.getIndexers()

--- a/fe/src/stores/library.ts
+++ b/fe/src/stores/library.ts
@@ -78,7 +78,7 @@ export const useLibraryStore = defineStore('library', () => {
 
   async function removeFromLibrary(
     id: number,
-    options?: { deleteFiles?: boolean; deleteFolder?: boolean },
+    options?: { deleteFiles?: boolean; deleteFolder?: boolean; excludeFromAuthorMonitoring?: boolean },
   ) {
     try {
       await apiService.removeFromLibrary(id, options)

--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -1109,3 +1109,11 @@ export interface RenameResult {
   error?: string
   renamedFiles: FileRenameResultItem[]
 }
+
+export interface AuthorMonitoringExclusion {
+  id: number
+  title: string
+  authorName?: string | null
+  asin?: string | null
+  createdAt: string
+}

--- a/fe/src/views/library/AudiobookDetailView.vue
+++ b/fe/src/views/library/AudiobookDetailView.vue
@@ -598,6 +598,24 @@
               </div>
             </label>
           </div>
+
+          <div class="checkbox-row">
+            <label class="checkbox-wrapper checkbox-label">
+              <input
+                v-model="excludeFromAuthorMonitoring"
+                type="checkbox"
+                class="checkbox-input"
+                aria-label="Keep this book out of author monitoring"
+              />
+              <div class="checkbox-content">
+                <span class="checkbox-title">Keep out of author monitoring</span>
+                <small
+                  >If this author is monitored, the daily catalog sync would otherwise re-add this
+                  book after you delete it. Check this to keep it out for good.</small
+                >
+              </div>
+            </label>
+          </div>
         </div>
       </template>
     </DeleteConfirmationModal>
@@ -730,6 +748,7 @@ const showManualSearchModal = ref(false)
 const deleting = ref(false)
 const deleteFilesOnDisk = ref(false)
 const deleteFolderOnDisk = ref(false)
+const excludeFromAuthorMonitoring = ref(false)
 const showFullDescription = ref(false)
 const scanning = ref(false)
 const rescanningMetadata = ref(false)
@@ -1556,6 +1575,7 @@ async function executeDelete() {
     const success = await libraryStore.removeFromLibrary(audiobook.value.id, {
       deleteFiles: shouldDeleteFiles,
       deleteFolder: shouldDeleteFolder,
+      excludeFromAuthorMonitoring: excludeFromAuthorMonitoring.value,
     })
     if (success) {
       const toast = useToast()
@@ -1588,6 +1608,7 @@ async function executeDelete() {
 function resetDeleteOptions() {
   deleteFilesOnDisk.value = false
   deleteFolderOnDisk.value = false
+  excludeFromAuthorMonitoring.value = false
 }
 
 watch(deleteFolderOnDisk, (checked) => {

--- a/fe/src/views/settings/GeneralSettingsTab.vue
+++ b/fe/src/views/settings/GeneralSettingsTab.vue
@@ -56,6 +56,8 @@
           @update:settings="(val) => Object.assign(localSettings, val)"
           @update:apiKey="(val) => emit('update:apiKey', val)"
         ></AuthenticationSection>
+
+        <AuthorMonitoringExclusionsSection />
       </div>
       <!-- settings-form -->
     </div>
@@ -74,6 +76,7 @@ import DownloadSettingsSection from '@/components/settings/DownloadSettingsSecti
 import FeaturesSection from '@/components/settings/FeaturesSection.vue'
 import SearchSettingsSection from '@/components/settings/SearchSettingsSection.vue'
 import AuthenticationSection from '@/components/settings/AuthenticationSection.vue'
+import AuthorMonitoringExclusionsSection from '@/components/settings/AuthorMonitoringExclusionsSection.vue'
 
 interface Props {
   settings: ApplicationSettings | null

--- a/listenarr.api/Features/Library/AuthorMonitoringController.cs
+++ b/listenarr.api/Features/Library/AuthorMonitoringController.cs
@@ -124,6 +124,53 @@ namespace Listenarr.Api.Features.Library
             }
         }
 
+        /// <summary>
+        /// List the books excluded from author-monitoring re-adds (created when a book is
+        /// deleted with "keep out of author monitoring").
+        /// </summary>
+        [HttpGet("exclusions")]
+        public async Task<IActionResult> GetExclusions(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var exclusions = await _authorMonitoringService.GetExclusionsAsync(cancellationToken);
+                return Ok(exclusions.Select(e => new AuthorMonitoringExclusionResponse
+                {
+                    Id = e.Id,
+                    Asin = e.Asin,
+                    Title = e.Title,
+                    AuthorName = e.AuthorName,
+                    CreatedAt = e.CreatedAt
+                }));
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogError(ex, "Failed to list author-monitoring exclusions");
+                return StatusCode(StatusCodes.Status500InternalServerError, "Internal server error");
+            }
+        }
+
+        /// <summary>Remove an author-monitoring exclusion, allowing the sweep to re-add that book again.</summary>
+        [HttpDelete("exclusions/{id:int}")]
+        public async Task<IActionResult> RemoveExclusion(int id, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var removed = await _authorMonitoringService.RemoveExclusionAsync(id, cancellationToken);
+                if (!removed)
+                {
+                    return NotFound();
+                }
+
+                return Ok(new { message = "Exclusion removed" });
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogError(ex, "Failed to remove author-monitoring exclusion {ExclusionId}", id);
+                return StatusCode(StatusCodes.Status500InternalServerError, "Internal server error");
+            }
+        }
+
         private static MonitoredAuthorResponse ToResponse(MonitoredAuthor monitoredAuthor)
         {
             return new MonitoredAuthorResponse
@@ -146,6 +193,15 @@ namespace Listenarr.Api.Features.Library
             public bool IsMonitored { get; set; }
 
             public MonitoredAuthorResponse? MonitoredAuthor { get; set; }
+        }
+
+        public sealed class AuthorMonitoringExclusionResponse
+        {
+            public int Id { get; set; }
+            public string? Asin { get; set; }
+            public string Title { get; set; } = string.Empty;
+            public string? AuthorName { get; set; }
+            public DateTime CreatedAt { get; set; }
         }
 
         public sealed class MonitorAuthorResponse

--- a/listenarr.api/Features/Library/LibraryController.cs
+++ b/listenarr.api/Features/Library/LibraryController.cs
@@ -196,9 +196,9 @@ namespace Listenarr.Api.Features.Library
         /// <param name="deleteFiles">When true, delete all files within the audiobook folder when it can be done safely; otherwise fall back to tracked audiobook files before removing the library record.</param>
         /// <param name="deleteFolder">When true, also delete the audiobook folder when it can be done safely.</param>
         [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteAudiobook(int id, [FromQuery] bool deleteFiles = false, [FromQuery] bool deleteFolder = false)
+        public async Task<IActionResult> DeleteAudiobook(int id, [FromQuery] bool deleteFiles = false, [FromQuery] bool deleteFolder = false, [FromQuery] bool excludeFromAuthorMonitoring = false)
         {
-            return await _deleteWorkflow.DeleteAsync(id, deleteFiles, deleteFolder);
+            return await _deleteWorkflow.DeleteAsync(id, deleteFiles, deleteFolder, excludeFromAuthorMonitoring);
         }
 
         /// <summary>

--- a/listenarr.api/Features/Library/LibraryDeleteWorkflow.cs
+++ b/listenarr.api/Features/Library/LibraryDeleteWorkflow.cs
@@ -31,12 +31,15 @@ namespace Listenarr.Api.Features.Library
         private readonly IFileSystem _fileSystem;
         private readonly ILogger<LibraryDeleteWorkflow> _logger;
 
+        private readonly IAuthorMonitoringService _authorMonitoringService;
+
         public LibraryDeleteWorkflow(
             IAudiobookRepository repo,
             IImageCacheService imageCacheService,
             IAudiobookFilesystemDeleteService audiobookFilesystemDeleteService,
             IApplicationPathService applicationPathService,
             IFileSystem fileSystem,
+            IAuthorMonitoringService authorMonitoringService,
             ILogger<LibraryDeleteWorkflow> logger)
         {
             _repo = repo;
@@ -44,15 +47,23 @@ namespace Listenarr.Api.Features.Library
             _audiobookFilesystemDeleteService = audiobookFilesystemDeleteService;
             _contentRootPath = applicationPathService.ContentRootPath;
             _fileSystem = fileSystem;
+            _authorMonitoringService = authorMonitoringService;
             _logger = logger;
         }
 
-        public async Task<IActionResult> DeleteAsync(int id, bool deleteFiles, bool deleteFolder)
+        public async Task<IActionResult> DeleteAsync(int id, bool deleteFiles, bool deleteFolder, bool excludeFromAuthorMonitoring = false)
         {
             var audiobook = await _repo.GetByIdAsync(id);
             if (audiobook == null)
             {
                 return new NotFoundObjectResult(new { message = "Audiobook not found" });
+            }
+
+            // Record an exclusion BEFORE deleting so a monitored author's sweep doesn't
+            // just re-discover this book as "missing" and add it straight back.
+            if (excludeFromAuthorMonitoring)
+            {
+                await _authorMonitoringService.AddExclusionForAudiobookAsync(audiobook);
             }
 
             deleteFiles = deleteFiles || deleteFolder;

--- a/listenarr.application/Audiobooks/Contracts/IAuthorMonitoringService.cs
+++ b/listenarr.application/Audiobooks/Contracts/IAuthorMonitoringService.cs
@@ -35,6 +35,12 @@ namespace Listenarr.Application.Audiobooks.Contracts
         Task<MonitorAuthorSyncResult> SyncAuthorAsync(int id, CancellationToken cancellationToken = default);
 
         Task<int> SyncDueAuthorsAsync(CancellationToken cancellationToken = default);
+
+        Task<List<AuthorMonitoringExclusion>> GetExclusionsAsync(CancellationToken cancellationToken = default);
+
+        Task<bool> RemoveExclusionAsync(int id, CancellationToken cancellationToken = default);
+
+        Task AddExclusionForAudiobookAsync(Audiobook audiobook, CancellationToken cancellationToken = default);
     }
 
     public sealed class MonitorAuthorRequest
@@ -60,6 +66,8 @@ namespace Listenarr.Application.Audiobooks.Contracts
         public int AddedCount { get; set; }
 
         public int ExistingCount { get; set; }
+
+        public int ExcludedCount { get; set; }
 
         public int FailedCount { get; set; }
 

--- a/listenarr.application/Audiobooks/Contracts/Repositories/IAuthorMonitoringExclusionRepository.cs
+++ b/listenarr.application/Audiobooks/Contracts/Repositories/IAuthorMonitoringExclusionRepository.cs
@@ -1,0 +1,27 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Listenarr.Application.Audiobooks.Contracts.Repositories
+{
+    public interface IAuthorMonitoringExclusionRepository
+    {
+        Task AddAsync(AuthorMonitoringExclusion exclusion, CancellationToken ct = default);
+        Task<List<AuthorMonitoringExclusion>> GetAllAsync(CancellationToken ct = default);
+        Task<bool> DeleteAsync(int id, CancellationToken ct = default);
+    }
+}

--- a/listenarr.application/Audiobooks/Monitoring/AuthorMonitoringService.Mapping.cs
+++ b/listenarr.application/Audiobooks/Monitoring/AuthorMonitoringService.Mapping.cs
@@ -101,6 +101,28 @@ namespace Listenarr.Application.Audiobooks.Monitoring
             return string.Equals(normalizedBookLanguage, preferredLanguage, StringComparison.OrdinalIgnoreCase);
         }
 
+        private static bool IsExcludedFromMonitoring(
+            AudibleSearchResult book,
+            HashSet<string> excludedAsins,
+            HashSet<string> excludedTitleKeys)
+        {
+            var asin = NormalizeIdentifier(book.Asin);
+            if (!string.IsNullOrWhiteSpace(asin) && excludedAsins.Contains(asin))
+            {
+                return true;
+            }
+
+            var titleAuthorKey = BuildTitleAuthorKey(
+                book.Title,
+                (book.Authors ?? new List<AudibleAuthor>())
+                    .Select(author => author.Name)
+                    .Where(author => !string.IsNullOrWhiteSpace(author))
+                    .Cast<string>()
+                    .ToList());
+
+            return !string.IsNullOrWhiteSpace(titleAuthorKey) && excludedTitleKeys.Contains(titleAuthorKey);
+        }
+
         private static string NormalizeAuthorName(string? name)
         {
             if (string.IsNullOrWhiteSpace(name))

--- a/listenarr.application/Audiobooks/Monitoring/AuthorMonitoringService.cs
+++ b/listenarr.application/Audiobooks/Monitoring/AuthorMonitoringService.cs
@@ -83,6 +83,7 @@ namespace Listenarr.Application.Audiobooks.Monitoring
         private readonly IAudiobookRepository _audiobooks;
         private readonly IAuthorCatalogService _authorCatalogService;
         private readonly ILibraryAddService _libraryAddService;
+        private readonly IAuthorMonitoringExclusionRepository _exclusions;
         private readonly ILogger<AuthorMonitoringService> _logger;
 
         public AuthorMonitoringService(
@@ -90,12 +91,14 @@ namespace Listenarr.Application.Audiobooks.Monitoring
             IAudiobookRepository audiobooks,
             IAuthorCatalogService authorCatalogService,
             ILibraryAddService libraryAddService,
+            IAuthorMonitoringExclusionRepository exclusions,
             ILogger<AuthorMonitoringService> logger)
         {
             _authors = authors;
             _audiobooks = audiobooks;
             _authorCatalogService = authorCatalogService;
             _libraryAddService = libraryAddService;
+            _exclusions = exclusions;
             _logger = logger;
         }
 
@@ -170,6 +173,43 @@ namespace Listenarr.Application.Audiobooks.Monitoring
             return await _authors.DeleteAsync(id, cancellationToken);
         }
 
+        public async Task<List<AuthorMonitoringExclusion>> GetExclusionsAsync(CancellationToken cancellationToken = default)
+        {
+            return await _exclusions.GetAllAsync(cancellationToken);
+        }
+
+        public async Task<bool> RemoveExclusionAsync(int id, CancellationToken cancellationToken = default)
+        {
+            return await _exclusions.DeleteAsync(id, cancellationToken);
+        }
+
+        public async Task AddExclusionForAudiobookAsync(Audiobook audiobook, CancellationToken cancellationToken = default)
+        {
+            var asin = NormalizeIdentifier(audiobook.Asin);
+            var titleAuthorKey = BuildTitleAuthorKey(audiobook.Title, audiobook.Authors);
+
+            if (string.IsNullOrWhiteSpace(asin) && string.IsNullOrWhiteSpace(titleAuthorKey))
+            {
+                // Nothing identifiable to match on — an exclusion row would be inert.
+                _logger.LogWarning(
+                    "Skipping author-monitoring exclusion for audiobook id {Id}: no ASIN or title/author to match on.",
+                    audiobook.Id);
+                return;
+            }
+
+            await _exclusions.AddAsync(
+                new AuthorMonitoringExclusion
+                {
+                    Asin = string.IsNullOrWhiteSpace(asin) ? null : asin,
+                    TitleAuthorKey = string.IsNullOrWhiteSpace(titleAuthorKey) ? null : titleAuthorKey,
+                    Title = audiobook.Title ?? string.Empty,
+                    AuthorName = (audiobook.Authors ?? new List<string>())
+                        .FirstOrDefault(author => !string.IsNullOrWhiteSpace(author)),
+                    CreatedAt = DateTime.UtcNow
+                },
+                cancellationToken);
+        }
+
         public async Task<MonitorAuthorSyncResult> SyncAuthorAsync(int id, CancellationToken cancellationToken = default)
         {
             var monitoredAuthor = await _authors.GetByIdAsync(id, cancellationToken);
@@ -239,12 +279,32 @@ namespace Listenarr.Application.Audiobooks.Monitoring
 
                 var existingLibrary = await _audiobooks.GetAllAsync();
 
+                // Books the user explicitly excluded (deleted "and keep out of monitoring")
+                // must never be re-added by the sweep. Load once and match by ASIN or
+                // title+author key, mirroring FindExistingLibraryMatch.
+                var allExclusions = await _exclusions.GetAllAsync(cancellationToken);
+                var excludedAsins = allExclusions
+                    .Select(e => NormalizeIdentifier(e.Asin))
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .ToHashSet(StringComparer.Ordinal);
+                var excludedTitleKeys = allExclusions
+                    .Select(e => e.TitleAuthorKey)
+                    .Where(value => !string.IsNullOrWhiteSpace(value))
+                    .Cast<string>()
+                    .ToHashSet(StringComparer.Ordinal);
+
                 foreach (var book in catalog.Books)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
                     if (!ShouldIncludeBookForLanguage(book, monitoredAuthor.Language))
                     {
+                        continue;
+                    }
+
+                    if (IsExcludedFromMonitoring(book, excludedAsins, excludedTitleKeys))
+                    {
+                        result.ExcludedCount++;
                         continue;
                     }
 

--- a/listenarr.domain/Audiobooks/AuthorMonitoringExclusion.cs
+++ b/listenarr.domain/Audiobooks/AuthorMonitoringExclusion.cs
@@ -1,0 +1,54 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.ComponentModel.DataAnnotations;
+
+namespace Listenarr.Domain.Audiobooks
+{
+    /// <summary>
+    /// A book the author-monitoring sweep must never re-add to the library.
+    /// Written when the user deletes an audiobook and opts to keep it out of a
+    /// monitored author's catalog sync: without it, deleting a book by a monitored
+    /// author only triggered the next sweep to re-discover it as "missing" and add
+    /// it straight back (then auto-search re-grabbed it).
+    ///
+    /// Identity mirrors how the sweep matches catalog books to the library
+    /// (<c>FindExistingLibraryMatch</c>): a normalized ASIN when known, plus a
+    /// normalized title+author key as a fallback for editions without an ASIN.
+    /// <see cref="Title"/> and <see cref="AuthorName"/> are stored purely for
+    /// display in the exclusions management UI.
+    /// </summary>
+    public class AuthorMonitoringExclusion
+    {
+        [Key]
+        public int Id { get; set; }
+
+        /// <summary>Normalized ASIN (letters+digits, upper-case) when known — the strongest identity.</summary>
+        public string? Asin { get; set; }
+
+        /// <summary>Normalized title+author key, used to match editions that have no ASIN.</summary>
+        public string? TitleAuthorKey { get; set; }
+
+        /// <summary>Original book title, for display only.</summary>
+        public string Title { get; set; } = string.Empty;
+
+        /// <summary>Primary author name, for display only.</summary>
+        public string? AuthorName { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/listenarr.infrastructure/DependencyInjection/Library/LibraryRegistrationExtensions.cs
+++ b/listenarr.infrastructure/DependencyInjection/Library/LibraryRegistrationExtensions.cs
@@ -38,6 +38,7 @@ internal static class LibraryRegistrationExtensions
         services.AddScoped<IMoveJobRepository, EfMoveJobRepository>();
         services.AddScoped<IMonitoredAuthorRepository, EfMonitoredAuthorRepository>();
         services.AddScoped<IMonitoredSeriesRepository, EfMonitoredSeriesRepository>();
+        services.AddScoped<IAuthorMonitoringExclusionRepository, EfAuthorMonitoringExclusionRepository>();
         services.AddScoped<IRootFolderRepository, EfRootFolderRepository>();
         return services;
     }

--- a/listenarr.infrastructure/Persistence/ListenArrDbContext.cs
+++ b/listenarr.infrastructure/Persistence/ListenArrDbContext.cs
@@ -42,6 +42,7 @@ namespace Listenarr.Infrastructure.Persistence
         public DbSet<RootFolder> RootFolders { get; set; } = null!;
         public DbSet<MonitoredAuthor> MonitoredAuthors { get; set; } = null!;
         public DbSet<MonitoredSeries> MonitoredSeries { get; set; } = null!;
+        public DbSet<AuthorMonitoringExclusion> AuthorMonitoringExclusions { get; set; } = null!;
         public DbSet<AuthorCacheEntry> AuthorCacheEntries { get; set; } = null!;
         public DbSet<SeriesCacheEntry> SeriesCacheEntries { get; set; } = null!;
         public DbSet<UserSession> UserSessions { get; set; } = null!;

--- a/listenarr.infrastructure/Persistence/Migrations/20260701180228_AddAuthorMonitoringExclusions.Designer.cs
+++ b/listenarr.infrastructure/Persistence/Migrations/20260701180228_AddAuthorMonitoringExclusions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Listenarr.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Listenarr.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ListenArrDbContext))]
-    partial class ListenArrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701180228_AddAuthorMonitoringExclusions")]
+    partial class AddAuthorMonitoringExclusions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/listenarr.infrastructure/Persistence/Migrations/20260701180228_AddAuthorMonitoringExclusions.cs
+++ b/listenarr.infrastructure/Persistence/Migrations/20260701180228_AddAuthorMonitoringExclusions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Listenarr.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAuthorMonitoringExclusions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AuthorMonitoringExclusions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Asin = table.Column<string>(type: "TEXT", nullable: true),
+                    TitleAuthorKey = table.Column<string>(type: "TEXT", nullable: true),
+                    Title = table.Column<string>(type: "TEXT", nullable: false),
+                    AuthorName = table.Column<string>(type: "TEXT", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AuthorMonitoringExclusions", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AuthorMonitoringExclusions");
+        }
+    }
+}

--- a/listenarr.infrastructure/Persistence/Repositories/EfAuthorMonitoringExclusionRepository.cs
+++ b/listenarr.infrastructure/Persistence/Repositories/EfAuthorMonitoringExclusionRepository.cs
@@ -1,0 +1,65 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Microsoft.EntityFrameworkCore;
+
+namespace Listenarr.Infrastructure.Persistence.Repositories
+{
+    public class EfAuthorMonitoringExclusionRepository : IAuthorMonitoringExclusionRepository
+    {
+        private readonly ListenArrDbContext _db;
+
+        public EfAuthorMonitoringExclusionRepository(ListenArrDbContext db)
+        {
+            _db = db ?? throw new ArgumentNullException(nameof(db));
+        }
+
+        public async Task AddAsync(AuthorMonitoringExclusion exclusion, CancellationToken ct = default)
+        {
+            // Idempotent per identity: excluding the same book twice (e.g. it was
+            // re-added and deleted again) must not stack duplicate rows. Match on
+            // ASIN when present, otherwise on the title+author key.
+            var asin = string.IsNullOrWhiteSpace(exclusion.Asin) ? null : exclusion.Asin;
+            var key = string.IsNullOrWhiteSpace(exclusion.TitleAuthorKey) ? null : exclusion.TitleAuthorKey;
+
+            var exists = await _db.AuthorMonitoringExclusions.AnyAsync(
+                e => (asin != null && e.Asin == asin)
+                     || (asin == null && key != null && e.TitleAuthorKey == key), ct);
+            if (exists) return;
+
+            _db.AuthorMonitoringExclusions.Add(exclusion);
+            await _db.SaveChangesAsync(ct);
+        }
+
+        public Task<List<AuthorMonitoringExclusion>> GetAllAsync(CancellationToken ct = default)
+        {
+            return _db.AuthorMonitoringExclusions
+                .AsNoTracking()
+                .OrderByDescending(e => e.CreatedAt)
+                .ToListAsync(ct);
+        }
+
+        public async Task<bool> DeleteAsync(int id, CancellationToken ct = default)
+        {
+            var exclusion = await _db.AuthorMonitoringExclusions.FindAsync(new object[] { id }, ct);
+            if (exclusion == null) return false;
+            _db.AuthorMonitoringExclusions.Remove(exclusion);
+            await _db.SaveChangesAsync(ct);
+            return true;
+        }
+    }
+}

--- a/tests/Features/Application/Audiobooks/Monitoring/AuthorMonitoringServiceTests.cs
+++ b/tests/Features/Application/Audiobooks/Monitoring/AuthorMonitoringServiceTests.cs
@@ -105,6 +105,7 @@ namespace Listenarr.Tests.Features.Application.Audiobooks.Monitoring
                 audiobooksRepo,
                 authorCatalogService.Object,
                 libraryAddService.Object,
+                new EfAuthorMonitoringExclusionRepository(dbContext),
                 Mock.Of<ILogger<AuthorMonitoringService>>());
 
             var result = await service.MonitorAuthorAsync(new MonitorAuthorRequest
@@ -133,6 +134,69 @@ namespace Listenarr.Tests.Features.Application.Audiobooks.Monitoring
             Assert.Equal("Andy Weir", storedAuthor.AuthorName);
             Assert.Equal("andy weir", storedAuthor.AuthorNameNormalized);
             Assert.Equal("AUTHOR123", storedAuthor.AuthorAsin);
+        }
+
+        [Fact]
+        public async Task MonitorAuthorAsync_SkipsExcludedBooks_WithoutAddingThem()
+        {
+            var dbOptions = new DbContextOptionsBuilder<ListenArrDbContext>()
+                .UseInMemoryDatabase(databaseName: $"author-monitor-excl-{System.Guid.NewGuid():N}")
+                .Options;
+
+            await using var dbContext = new ListenArrDbContext(dbOptions);
+            // The user deleted "The Martian" and kept it out of monitoring.
+            dbContext.AuthorMonitoringExclusions.Add(new AuthorMonitoringExclusion
+            {
+                Asin = "B000MARTIAN",
+                Title = "The Martian",
+                AuthorName = "Andy Weir"
+            });
+            await dbContext.SaveChangesAsync();
+
+            var authorCatalogService = new Mock<IAuthorCatalogService>();
+            authorCatalogService
+                .Setup(service => service.GetCatalogAsync("Andy Weir", "us", 500, null, false, It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(new AuthorCatalogFetchResult
+                {
+                    Author = new AuthorLookupItem { Asin = "AUTHOR123", Name = "Andy Weir" },
+                    Books = new List<AudibleSearchResult>
+                    {
+                        new()
+                        {
+                            Asin = "B000MARTIAN",
+                            Title = "The Martian",
+                            Authors = new List<AudibleAuthor> { new() { Name = "Andy Weir" } },
+                            Language = "english"
+                        }
+                    }
+                });
+
+            var libraryAddService = new Mock<ILibraryAddService>();
+
+            var service = new AuthorMonitoringService(
+                new EfMonitoredAuthorRepository(dbContext),
+                new AudiobookRepository(dbContext),
+                authorCatalogService.Object,
+                libraryAddService.Object,
+                new EfAuthorMonitoringExclusionRepository(dbContext),
+                Mock.Of<ILogger<AuthorMonitoringService>>());
+
+            var result = await service.MonitorAuthorAsync(new MonitorAuthorRequest
+            {
+                Name = "Andy Weir",
+                Region = "us",
+                Language = "english"
+            });
+
+            Assert.True(result.SyncResult.Succeeded);
+            Assert.Equal(0, result.SyncResult.AddedCount);
+            Assert.Equal(1, result.SyncResult.ExcludedCount);
+
+            // The excluded book must never reach the library-add path.
+            libraryAddService.Verify(service => service.AddToLibraryAsync(
+                It.IsAny<LibraryAddOperationRequest>(),
+                It.IsAny<System.Threading.CancellationToken>()),
+                Times.Never);
         }
 
         [Fact]
@@ -178,6 +242,7 @@ namespace Listenarr.Tests.Features.Application.Audiobooks.Monitoring
                 audiobooksRepo,
                 authorCatalogService.Object,
                 Mock.Of<ILibraryAddService>(),
+                new EfAuthorMonitoringExclusionRepository(dbContext),
                 Mock.Of<ILogger<AuthorMonitoringService>>());
 
             var syncedCount = await service.SyncDueAuthorsAsync();


### PR DESCRIPTION
> Draft — paced behind the currently-active PRs; will mark ready for review once a slot frees.

## Problem

Deleting a book by a **monitored author** was futile: the next author-monitoring sweep re-discovered it in the author's catalog, saw it "missing" from the library, and added it straight back — after which automatic search re-grabbed it. There was no way to say "remove this and keep it out."

## Change

An **exclusion list** the author sweep consults:

- New `AuthorMonitoringExclusion` entity + repository. `AddAsync` is **idempotent per identity** — it dedups on a normalized ASIN when present, else a normalized title+author key (mirrors how the sweep matches catalog books to the library). New table via `AddAuthorMonitoringExclusions` migration.
- `AuthorMonitoringService.SyncAuthorInternalAsync` loads exclusions **once per sweep**, builds ASIN + title-key sets, and **skips** matching catalog books (`ExcludedCount`) right after the language filter and **before** the library-match/add. Reuses the existing `NormalizeIdentifier` / `BuildTitleAuthorKey` helpers (no duplication).
- `LibraryController.DeleteAudiobook` gains `excludeFromAuthorMonitoring`; when set, an exclusion is recorded **before** the book is deleted. `AuthorMonitoringController` exposes `GET`/`DELETE /exclusions`.
- Frontend: an exclusions-management section in settings + a "keep out of author monitoring" checkbox in the delete dialog.

## Testing

`dotnet build` clean; full suite **1016 passed / 0 failed** (new `MonitorAuthorAsync_SkipsExcludedBooks_WithoutAddingThem` + the migration/snapshot integration tests); `vue-tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)