### PR TITLE
feat(library): move files to another audiobook record

### DIFF
--- a/fe/src/components/domain/audiobook/TransferFilesModal.vue
+++ b/fe/src/components/domain/audiobook/TransferFilesModal.vue
@@ -1,0 +1,355 @@
+<!--
+  Listenarr - Audiobook Management System
+  Copyright (C) 2024-2026 Listenarr Contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<!--
+  Move audio files from this record to ANOTHER EXISTING library record — the
+  remediation when files actually belong to a different book the library
+  already tracks (often still "wanted"): two books' tracks imported onto one
+  record, or a collection being split into its real books.
+-->
+<template>
+  <Modal :visible="visible" size="lg" title="Move files to another audiobook" @close="onClose">
+    <ModalBody>
+      <div v-if="!audiobook" class="transfer-empty">No audiobook selected.</div>
+      <template v-else>
+        <div class="transfer-section">
+          <div class="transfer-section-title">Files to move</div>
+          <label v-for="f in sourceFiles" :key="f.id" class="transfer-file-row">
+            <input
+              type="checkbox"
+              :checked="selectedFileIds.has(f.id)"
+              @change="toggleFile(f.id)"
+            />
+            <span class="transfer-file-name">{{ fileName(f.path) }}</span>
+          </label>
+          <div v-if="sourceFiles.length === 0" class="transfer-empty">
+            This audiobook has no tracked files.
+          </div>
+        </div>
+
+        <div class="transfer-section">
+          <div class="transfer-section-title">Destination record</div>
+          <input
+            v-model="query"
+            type="text"
+            class="transfer-search"
+            placeholder="Search your library by title…"
+            @input="chosenTargetId = null"
+          />
+          <div v-if="libraryLoading" class="transfer-empty">Loading library…</div>
+          <div v-else-if="candidates.length === 0" class="transfer-empty">
+            No library records match "{{ query }}".
+          </div>
+          <div v-else class="transfer-candidates">
+            <label v-for="c in candidates" :key="c.id" class="transfer-candidate">
+              <input type="radio" name="transfer-target" :value="c.id" v-model="chosenTargetId" />
+              <span class="transfer-candidate-text">
+                <strong>{{ c.title }}</strong>
+                <small>
+                  {{ (c.narrators || []).slice(0, 2).join(', ') || 'Unknown narrator' }}
+                  <template v-if="c.publishYear"> · {{ c.publishYear }}</template>
+                  · id {{ c.id }}
+                  <template v-if="(c.fileCount ?? 0) > 0">
+                    · <span class="transfer-has-files">{{ c.fileCount }} file(s)</span>
+                  </template>
+                </small>
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <div v-if="chosenTargetFileCount > 0" class="transfer-warning">
+          <strong>{{ chosenTarget?.title }}</strong> already has {{ chosenTargetFileCount }} audio
+          file(s). The moved files will be <strong>added alongside</strong> them — not replace them
+          — which can leave two books' tracks mixed in one record.
+        </div>
+
+        <div class="transfer-note">
+          Files keep their audio untouched: ownership moves to the destination record (and the file
+          relocates into its folder when possible).
+        </div>
+      </template>
+    </ModalBody>
+    <div class="modal-footer">
+      <button type="button" class="btn" @click="onClose">Cancel</button>
+      <button
+        type="button"
+        class="btn btn-primary"
+        :disabled="transferring || !chosenTargetId || selectedFileIds.size === 0"
+        @click="confirmTransfer"
+      >
+        {{ transferring ? 'Moving…' : `Move ${selectedFileIds.size} file(s)` }}
+      </button>
+    </div>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { Modal, ModalBody } from '@/components/feedback'
+import { apiService } from '@/services/api'
+import { useToast } from '@/services/toastService'
+import { showConfirm } from '@/composables/useConfirm'
+import { useLibraryStore } from '@/stores/library'
+import type { Audiobook } from '@/types'
+
+type SourceFile = { id: number; path?: string | null }
+
+const props = defineProps<{
+  visible: boolean
+  audiobook: Audiobook | null
+  // Seeds the destination search — e.g. the title the files' tags claim.
+  initialQuery?: string | null
+  // Pre-select a subset of files (e.g. a multi-select made in the file list).
+  // When omitted/empty, all of the source's files are selected as before.
+  initialFileIds?: number[] | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'done', result: { targetId: number; transferred: number }): void
+}>()
+
+const toast = useToast()
+const libraryStore = useLibraryStore()
+
+const query = ref('')
+const chosenTargetId = ref<number | null>(null)
+const selectedFileIds = ref<Set<number>>(new Set())
+const transferring = ref(false)
+const libraryLoading = ref(false)
+
+const sourceFiles = computed<SourceFile[]>(() => props.audiobook?.files ?? [])
+
+const chosenTarget = computed<Audiobook | null>(
+  () => libraryStore.audiobooks.find((b) => b.id === chosenTargetId.value) ?? null,
+)
+const chosenTargetFileCount = computed(() => chosenTarget.value?.fileCount ?? 0)
+
+watch(
+  () => props.visible,
+  (visible) => {
+    if (!visible) return
+    query.value = (props.initialQuery || '').trim()
+    chosenTargetId.value = null
+    selectedFileIds.value =
+      props.initialFileIds && props.initialFileIds.length
+        ? new Set(props.initialFileIds)
+        : new Set(sourceFiles.value.map((f) => f.id))
+    transferring.value = false
+    if (libraryStore.audiobooks.length === 0) {
+      libraryLoading.value = true
+      void libraryStore
+        .fetchLibrary()
+        .catch(() => {
+          /* candidates list shows empty; search still usable after retry */
+        })
+        .finally(() => {
+          libraryLoading.value = false
+        })
+    }
+  },
+)
+
+// Token-overlap ranking so a filename-ish query ("Warbreaker 2 of 3 Dramatized")
+// surfaces the matching record even when it isn't a substring of the title.
+const candidates = computed(() => {
+  const sourceId = props.audiobook?.id
+  const tokens = tokenize(query.value)
+  if (tokens.length === 0) return []
+  return libraryStore.audiobooks
+    .filter((b) => b.id !== sourceId)
+    .map((b) => ({ book: b, score: overlapScore(tokens, tokenize(b.title || '')) }))
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score || (a.book.title || '').localeCompare(b.book.title || ''))
+    .slice(0, 12)
+    .map((x) => x.book)
+})
+
+function tokenize(text: string): string[] {
+  return (text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 1)
+}
+
+function overlapScore(queryTokens: string[], titleTokens: string[]): number {
+  const titleSet = new Set(titleTokens)
+  return queryTokens.reduce((score, t) => score + (titleSet.has(t) ? 1 : 0), 0)
+}
+
+function toggleFile(id: number) {
+  const next = new Set(selectedFileIds.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  selectedFileIds.value = next
+}
+
+function fileName(path?: string | null): string {
+  if (!path) return 'Unknown file'
+  const parts = path.split(/[\\/]/)
+  return parts[parts.length - 1] || path
+}
+
+async function confirmTransfer() {
+  const book = props.audiobook
+  const targetId = chosenTargetId.value
+  if (!book || !targetId || transferring.value) return
+
+  // Moving into a record that already has audio merges the two sets (it never
+  // overwrites) — confirm so a wrong destination doesn't silently end up with
+  // two books' tracks mixed together.
+  if (chosenTargetFileCount.value > 0) {
+    const ok = await showConfirm(
+      `${chosenTarget.value?.title || 'This record'} already has ${chosenTargetFileCount.value} audio ` +
+        `file(s). The ${selectedFileIds.value.size} moved file(s) will be added alongside the ` +
+        `existing ones, not replace them.\n\nMove them anyway?`,
+      'Destination already has files',
+    )
+    if (!ok) return
+  }
+
+  transferring.value = true
+  try {
+    const allSelected = selectedFileIds.value.size === sourceFiles.value.length
+    const result = await apiService.transferAudiobookFiles(
+      book.id,
+      targetId,
+      allSelected ? null : Array.from(selectedFileIds.value),
+    )
+    if (result.warnings?.length) {
+      toast.warning('Files moved with warnings', result.warnings.join(' '))
+    } else {
+      toast.success('Files moved', result.message)
+    }
+    emit('done', { targetId, transferred: result.transferred })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    toast.error('Could not move files', message)
+    transferring.value = false
+  }
+}
+
+function onClose() {
+  if (!transferring.value) emit('close')
+}
+</script>
+
+<style scoped>
+.transfer-section {
+  margin-bottom: 1.25rem;
+}
+
+.transfer-section-title {
+  font-weight: 500;
+  color: #fff;
+  margin-bottom: 0.5rem;
+}
+
+.transfer-file-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0;
+  cursor: pointer;
+}
+
+.transfer-file-name {
+  font-size: 0.9rem;
+  color: #d8dee6;
+  overflow-wrap: anywhere;
+}
+
+.transfer-search {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #444;
+  border-radius: 6px;
+  background-color: #1a1a1a;
+  color: #fff;
+  font-size: 0.95rem;
+  margin-bottom: 0.6rem;
+}
+
+.transfer-candidates {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.transfer-candidate {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.transfer-candidate:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.transfer-candidate-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.transfer-candidate-text small {
+  color: #8a93a0;
+}
+
+.transfer-has-files {
+  color: #e0a458;
+}
+
+.transfer-warning {
+  margin-bottom: 0.85rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: #f0c674;
+  background-color: rgba(224, 164, 88, 0.1);
+  border: 1px solid rgba(224, 164, 88, 0.3);
+}
+
+.transfer-warning strong {
+  color: #fff;
+}
+
+.transfer-note {
+  font-size: 0.85rem;
+  color: #adb5bd;
+}
+
+.transfer-empty {
+  color: #8a93a0;
+  font-size: 0.9rem;
+  padding: 0.4rem 0;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+}
+</style>

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -1238,6 +1238,24 @@ class ApiService {
     })
   }
 
+  async transferAudiobookFiles(
+    sourceId: number,
+    targetAudiobookId: number,
+    fileIds: number[] | null,
+  ): Promise<{
+    message: string
+    sourceId: number
+    targetId: number
+    transferred: number
+    physicallyMoved: number
+    warnings: string[]
+  }> {
+    return this.request(`/library/${sourceId}/files/transfer`, {
+      method: 'POST',
+      body: JSON.stringify({ targetAudiobookId, fileIds }),
+    })
+  }
+
   async removeFromLibrary(
     id: number,
     options?: { deleteFiles?: boolean; deleteFolder?: boolean },

--- a/fe/src/services/toastService.ts
+++ b/fe/src/services/toastService.ts
@@ -80,9 +80,13 @@ export function useToast() {
       push('info', title, message, timeoutMs),
     success: (title: string, message: string, timeoutMs?: number) =>
       push('success', title, message, timeoutMs),
-    warning: (title: string, message: string, timeoutMs?: number) =>
+    // Warnings and errors are sticky by default (timeoutMs = 0): they carry
+    // information the user needs to act on — a 5s auto-dismiss too often vanishes
+    // before it can be read. They're dismissed via the toast's close button.
+    // Callers can still pass an explicit timeout to opt back into auto-dismiss.
+    warning: (title: string, message: string, timeoutMs = 0) =>
       push('warning', title, message, timeoutMs),
-    error: (title: string, message: string, timeoutMs?: number) =>
+    error: (title: string, message: string, timeoutMs = 0) =>
       push('error', title, message, timeoutMs),
   }
 }

--- a/fe/src/views/library/AudiobookDetailView.vue
+++ b/fe/src/views/library/AudiobookDetailView.vue
@@ -642,6 +642,16 @@
     @close="showOrganizeModal = false"
     @done="handleOrganizeDone"
   />
+
+  <!-- Move files to another EXISTING library record (e.g. tracks imported onto
+       the wrong book, or a collection being split into its real books). -->
+  <TransferFilesModal
+    :visible="showTransferModal"
+    :audiobook="audiobook"
+    :initial-query="audiobook?.title || ''"
+    @close="showTransferModal = false"
+    @done="onTransferDone"
+  />
 </template>
 
 <script setup lang="ts">
@@ -671,6 +681,7 @@ import { errorTracking } from '@/services/errorTracking'
 import { useProtectedImages } from '@/composables/useProtectedImages'
 import { buildAudibleProductUrl } from '@/utils/marketDomains'
 import EditAudiobookModal from '@/components/domain/audiobook/EditAudiobookModal.vue'
+import TransferFilesModal from '@/components/domain/audiobook/TransferFilesModal.vue'
 import ManualSearchModal from '@/components/domain/search/ManualSearchModal.vue'
 import RenamePreviewModal from '@/components/domain/organize/RenamePreviewModal.vue'
 import CustomSelect from '@/components/form/CustomSelect.vue'
@@ -710,6 +721,7 @@ import {
   PhFileMinus,
   PhCircle,
   PhDiscordLogo,
+  PhArrowsLeftRight,
 } from '@phosphor-icons/vue'
 
 const route = useRoute()
@@ -737,6 +749,7 @@ const scanQueued = ref(false)
 const scanJobId = ref<string | null>(null)
 const showEditModal = ref(false)
 const showOrganizeModal = ref(false)
+const showTransferModal = ref(false)
 const showMoreActions = ref(false)
 
 // History state
@@ -834,6 +847,18 @@ const topActions = computed<DetailTopAction[]>(() => [
     },
   },
   {
+    key: 'transfer-files',
+    label: 'Move Files to Another Book',
+    title: 'Move files to the existing library record they actually belong to',
+    ariaLabel: 'Move Files to Another Book',
+    icon: PhArrowsLeftRight,
+    disabled: !audiobook.value?.files?.length,
+    desktopGroup: 'secondary',
+    onClick: () => {
+      showTransferModal.value = true
+    },
+  },
+  {
     key: 'delete',
     label: 'Delete',
     title: 'Delete',
@@ -878,6 +903,7 @@ type DetailTopAction = {
     | 'edit'
     | 'rescan-metadata'
     | 'organize'
+    | 'transfer-files'
     | 'delete'
   label: string
   title: string
@@ -1618,6 +1644,14 @@ async function handleEditSaved() {
 async function handleOrganizeDone() {
   showOrganizeModal.value = false
   await loadAudiobook()
+}
+
+async function onTransferDone() {
+  showTransferModal.value = false
+  // Files left this record — reload it, and refresh the library list so the
+  // destination's file counts are current too.
+  await loadAudiobook()
+  void libraryStore.fetchLibrary()
 }
 
 function formatRuntime(minutes: number): string {

--- a/listenarr.api/Features/Library/LibraryController.Models.cs
+++ b/listenarr.api/Features/Library/LibraryController.Models.cs
@@ -51,4 +51,12 @@ public partial class LibraryController
         public bool? MoveFiles { get; set; }
         public bool? DeleteEmptySource { get; set; }
     }
+
+    public class TransferFilesRequest
+    {
+        public int TargetAudiobookId { get; set; }
+
+        /// <summary>Files to move; null/empty transfers every file on the source.</summary>
+        public List<int>? FileIds { get; set; }
+    }
 }

--- a/listenarr.api/Features/Library/LibraryController.cs
+++ b/listenarr.api/Features/Library/LibraryController.cs
@@ -40,6 +40,7 @@ namespace Listenarr.Api.Features.Library
         private readonly LibraryPreviewPathWorkflow _previewPathWorkflow;
         private readonly LibraryQueryWorkflow _queryWorkflow;
         private readonly LibraryRenameWorkflow _renameWorkflow;
+        private readonly LibraryTransferFilesWorkflow _transferFilesWorkflow;
         /// <summary>Initializes the library transport façade.</summary>
         public LibraryController(
             ILibraryListService libraryListService,
@@ -55,7 +56,8 @@ namespace Listenarr.Api.Features.Library
             LibraryIdentifierWorkflow identifierWorkflow,
             LibraryPreviewPathWorkflow previewPathWorkflow,
             LibraryQueryWorkflow queryWorkflow,
-            LibraryRenameWorkflow renameWorkflow)
+            LibraryRenameWorkflow renameWorkflow,
+            LibraryTransferFilesWorkflow transferFilesWorkflow)
         {
             _libraryListService = libraryListService;
             _addWorkflow = addWorkflow;
@@ -71,6 +73,22 @@ namespace Listenarr.Api.Features.Library
             _previewPathWorkflow = previewPathWorkflow;
             _queryWorkflow = queryWorkflow;
             _renameWorkflow = renameWorkflow;
+            _transferFilesWorkflow = transferFilesWorkflow;
+        }
+
+        /// <summary>
+        /// Move audio files from this audiobook to another existing library record.
+        /// DB ownership is reassigned always; the physical file moves into the
+        /// target's folder best-effort (failures leave it in place with a warning).
+        /// Null/empty <see cref="TransferFilesRequest.FileIds"/> transfers every file.
+        /// </summary>
+        /// <param name="id">Source audiobook ID.</param>
+        /// <param name="request">Target audiobook and optional subset of file IDs to move.</param>
+        /// <param name="ct">Cancellation token bound to the request.</param>
+        [HttpPost("{id}/files/transfer")]
+        public async Task<IActionResult> TransferFiles(int id, [FromBody] TransferFilesRequest request, CancellationToken ct)
+        {
+            return await _transferFilesWorkflow.TransferAsync(id, request, ct);
         }
 
         /// <summary>

--- a/listenarr.api/Features/Library/LibraryTransferFilesWorkflow.cs
+++ b/listenarr.api/Features/Library/LibraryTransferFilesWorkflow.cs
@@ -1,0 +1,240 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Api.Features.Library
+{
+    /// <summary>
+    /// Move audio files from one audiobook to another existing library record —
+    /// the remediation for "these files are actually a different book I track"
+    /// (e.g. two books' tracks imported onto one record, or a collection being
+    /// split into its real books). DB ownership is reassigned always; the
+    /// physical file is moved into the target's folder best-effort (failures
+    /// leave it in place with a warning — the Organize tool can relocate it
+    /// later).
+    /// </summary>
+    public sealed class LibraryTransferFilesWorkflow
+    {
+        private readonly IAudiobookRepository _repo;
+        private readonly IAudiobookFileRepository _audioFileRepository;
+        private readonly IHistoryRepository _historyRepository;
+        private readonly IFileMover _fileMover;
+        private readonly IFileSystem _fileSystem;
+        private readonly ILogger<LibraryTransferFilesWorkflow> _logger;
+
+        public LibraryTransferFilesWorkflow(
+            IAudiobookRepository repo,
+            IAudiobookFileRepository audioFileRepository,
+            IHistoryRepository historyRepository,
+            IFileMover fileMover,
+            IFileSystem fileSystem,
+            ILogger<LibraryTransferFilesWorkflow> logger)
+        {
+            _repo = repo;
+            _audioFileRepository = audioFileRepository;
+            _historyRepository = historyRepository;
+            _fileMover = fileMover;
+            _fileSystem = fileSystem;
+            _logger = logger;
+        }
+
+        public async Task<IActionResult> TransferAsync(int id, LibraryController.TransferFilesRequest? request, CancellationToken ct)
+        {
+            if (request == null)
+            {
+                return new BadRequestObjectResult(new { message = "Request body required" });
+            }
+
+            if (request.TargetAudiobookId == id)
+            {
+                return new BadRequestObjectResult(new { message = "Target audiobook must be different from the source" });
+            }
+
+            var source = await _repo.GetByIdAsync(id);
+            if (source == null)
+            {
+                return new NotFoundObjectResult(new { message = "Source audiobook not found" });
+            }
+
+            var target = await _repo.GetByIdAsync(request.TargetAudiobookId);
+            if (target == null)
+            {
+                return new NotFoundObjectResult(new { message = "Target audiobook not found" });
+            }
+
+            var sourceFiles = await _audioFileRepository.GetByAudiobookIdAsync(id, ct);
+            var toMove = request.FileIds is { Count: > 0 }
+                ? sourceFiles.Where(f => request.FileIds.Contains(f.Id)).ToList()
+                : sourceFiles.ToList();
+            if (toMove.Count == 0)
+            {
+                return new BadRequestObjectResult(new { message = "No matching files to transfer" });
+            }
+
+            if (request.FileIds is { Count: > 0 } && toMove.Count != request.FileIds.Distinct().Count())
+            {
+                return new BadRequestObjectResult(new { message = "One or more file ids do not belong to this audiobook" });
+            }
+
+            var targetFiles = await _audioFileRepository.GetByAudiobookIdAsync(target.Id, ct);
+
+            var warnings = new List<string>();
+            var physicallyMoved = 0;
+            var reassigned = 0;
+
+            foreach (var file in toMove)
+            {
+                // Determine the path this file would occupy under the target, and bail BEFORE
+                // touching disk if the target already owns a row there — a duplicate from a prior
+                // (partial) transfer, or the same physical file dual-referenced by both records.
+                // Reassigning would violate the (AudiobookId, Path) unique key; moving first and
+                // only then discovering the collision relocates the file on disk but orphans the
+                // source's DB row (the file leaves but never reassigns). Skip it entirely so the
+                // rest of the transfer still goes through; the user can delete the redundant copy
+                // from the source if it's a true duplicate.
+                var candidatePath = (!string.IsNullOrWhiteSpace(target.BasePath) && !string.IsNullOrWhiteSpace(file.Path))
+                    ? Path.Join(target.BasePath, Path.GetFileName(file.Path))
+                    : file.Path;
+                if (!string.IsNullOrWhiteSpace(candidatePath)
+                    && targetFiles.Any(tf => tf.Id != file.Id && string.Equals(tf.Path, candidatePath, StringComparison.OrdinalIgnoreCase)))
+                {
+                    warnings.Add($"{Path.GetFileName(candidatePath)} already exists under the target — left in place (delete the redundant copy if it's a duplicate)");
+                    continue;
+                }
+
+                // Physical relocation is best-effort: ownership (the DB row) is the
+                // core semantic, and a file left in the old folder is fixable via
+                // the Organize tool. A failed disk move must not abort the transfer.
+                var newPath = file.Path;
+                if (!string.IsNullOrWhiteSpace(target.BasePath) && !string.IsNullOrWhiteSpace(file.Path))
+                {
+                    try
+                    {
+                        var destination = Path.Join(target.BasePath, Path.GetFileName(file.Path));
+                        if (!_fileSystem.FileExists(file.Path))
+                        {
+                            warnings.Add($"File missing on disk, reassigned in place: {Path.GetFileName(file.Path)}");
+                        }
+                        else if (string.Equals(Path.GetFullPath(destination), Path.GetFullPath(file.Path), StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Already where it belongs.
+                        }
+                        else if (_fileSystem.FileExists(destination))
+                        {
+                            warnings.Add($"Target folder already has {Path.GetFileName(file.Path)} — file left in place");
+                        }
+                        else
+                        {
+                            if (!_fileSystem.DirectoryExists(target.BasePath))
+                            {
+                                _fileSystem.CreateDirectory(target.BasePath);
+                            }
+
+                            if (await _fileMover.PerformActionOn(FileAction.Move, file.Path, destination))
+                            {
+                                newPath = destination;
+                                physicallyMoved++;
+                            }
+                            else
+                            {
+                                warnings.Add($"Could not move {Path.GetFileName(file.Path)} on disk — file left in place");
+                            }
+                        }
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+                    {
+                        warnings.Add($"Could not move {Path.GetFileName(file.Path)} on disk — file left in place");
+                        _logger.LogWarning(ex, "transfer-files: disk move failed for file {FileId}", file.Id);
+                    }
+                }
+
+                try
+                {
+                    await _audioFileRepository.ReassignAsync(file.Id, target.Id, newPath, ct);
+                    // Mutate the in-memory row only after the DB update succeeds, so a caught
+                    // failure can't leave a stale path in the collision checks below.
+                    file.AudiobookId = target.Id;
+                    file.Path = newPath;
+                    reassigned++;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+                {
+                    // Last-resort guard: any per-file DB failure (e.g. a same-name collision within
+                    // this batch) becomes a warning, never a 500 that aborts the whole transfer.
+                    warnings.Add($"Could not reassign {Path.GetFileName(newPath)} — left in place");
+                    _logger.LogWarning(ex, "transfer-files: DB reassign failed for file {FileId}", file.Id);
+                }
+            }
+
+            // Source bookkeeping: when its audio is gone, the legacy single-file
+            // columns describe content it no longer owns. Gate on what actually
+            // reassigned — a skipped/collided file means the source still holds audio.
+            if (reassigned > 0 && reassigned == sourceFiles.Count)
+            {
+                source.FilePath = null;
+                source.FileSize = null;
+                await _repo.UpdateAsync(source);
+            }
+
+            try
+            {
+                await _historyRepository.AddAsync(new History
+                {
+                    AudiobookId = source.Id,
+                    AudiobookTitle = source.Title ?? "Unknown Title",
+                    EventType = "Files Transferred",
+                    Message = $"Moved {reassigned} file(s) to '{target.Title}' (id {target.Id}).",
+                    Source = "transfer-files",
+                    Timestamp = DateTime.UtcNow
+                }, ct);
+                await _historyRepository.AddAsync(new History
+                {
+                    AudiobookId = target.Id,
+                    AudiobookTitle = target.Title ?? "Unknown Title",
+                    EventType = "Files Received",
+                    Message = $"Received {reassigned} file(s) from '{source.Title}' (id {source.Id}).",
+                    Source = "transfer-files",
+                    Timestamp = DateTime.UtcNow
+                }, ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogWarning(ex, "transfer-files: failed to record history (non-critical)");
+            }
+
+            // Post-transfer hook point: when content verification lands, this is where
+            // the target gets re-verified against its new audio (and stale verdicts on
+            // both records get reset).
+
+            _logger.LogInformation(
+                "Transferred {Count} file(s) ({Physical} moved on disk) from audiobook {SourceId} to {TargetId}",
+                reassigned, physicallyMoved, source.Id, target.Id);
+
+            return new OkObjectResult(new
+            {
+                message = $"Transferred {reassigned} file(s) to '{target.Title}'",
+                sourceId = source.Id,
+                targetId = target.Id,
+                transferred = reassigned,
+                physicallyMoved,
+                warnings
+            });
+        }
+    }
+}

--- a/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
+++ b/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
@@ -86,6 +86,7 @@ public static class ListenarrWorkflowRegistration
         services.AddScoped<LibraryPreviewPathWorkflow>();
         services.AddScoped<LibraryQueryWorkflow>();
         services.AddScoped<LibraryRenameWorkflow>();
+        services.AddScoped<LibraryTransferFilesWorkflow>();
         services.AddScoped<SearchResponseMapper>();
         services.AddScoped<ImagePlaceholderResolver>();
         services.AddScoped<IndexerTestWorkflow>();

--- a/listenarr.application/Audiobooks/Contracts/Repositories/IAudiobookFileRepository.cs
+++ b/listenarr.application/Audiobooks/Contracts/Repositories/IAudiobookFileRepository.cs
@@ -25,6 +25,13 @@ namespace Listenarr.Application.Audiobooks.Contracts.Repositories
         Task<List<AudiobookFile>> GetMissingMetadataAsync(int max, CancellationToken ct = default);
         Task<AudiobookFile> AddAsync(AudiobookFile file, CancellationToken ct = default);
         Task UpdateAsync(AudiobookFile file, CancellationToken ct = default);
+
+        /// <summary>
+        /// Reassign a file row to another audiobook (optionally with a new path)
+        /// via a targeted column update — no entity tracking, so bulk transfers
+        /// can't trip EF identity-map conflicts on overlapping navigation graphs.
+        /// </summary>
+        Task ReassignAsync(int fileId, int newAudiobookId, string? newPath, CancellationToken ct = default);
         Task DeleteByAudiobookIdAsync(int audiobookId, CancellationToken ct = default);
         Task DeleteAsync(int id, CancellationToken ct = default);
         Task<bool> ExistsAtPathAsync(int audiobookId, string path, CancellationToken ct = default);

--- a/listenarr.infrastructure/Persistence/Repositories/EfAudiobookFileRepository.cs
+++ b/listenarr.infrastructure/Persistence/Repositories/EfAudiobookFileRepository.cs
@@ -64,6 +64,40 @@ namespace Listenarr.Infrastructure.Persistence.Repositories
             await _db.SaveChangesAsync(ct);
         }
 
+        public async Task ReassignAsync(int fileId, int newAudiobookId, string? newPath, CancellationToken ct = default)
+        {
+            // Targeted column update via a detached stub: Update(entity) on rows
+            // loaded with their navigation graphs trips EF's identity map on the
+            // second file of a bulk transfer ("instance with the same key is
+            // already being tracked"). Marking only the reassigned columns
+            // modified loads and tracks no graphs. (ExecuteUpdate would also
+            // work, but isn't supported by the InMemory test provider.)
+            var tracked = _db.AudiobookFiles.Local.FirstOrDefault(f => f.Id == fileId);
+            if (tracked != null)
+            {
+                _db.Entry(tracked).State = EntityState.Detached;
+            }
+
+            var stub = new AudiobookFile { Id = fileId, AudiobookId = newAudiobookId, Path = newPath };
+            var entry = _db.Entry(stub);
+            entry.Property(f => f.AudiobookId).IsModified = true;
+            if (newPath != null)
+            {
+                entry.Property(f => f.Path).IsModified = true;
+            }
+
+            try
+            {
+                await _db.SaveChangesAsync(ct);
+            }
+            finally
+            {
+                // Always detach: a failed save (e.g. unique-key collision) must not
+                // leave a dirty stub behind for an unrelated later SaveChanges.
+                entry.State = EntityState.Detached;
+            }
+        }
+
         public async Task DeleteByAudiobookIdAsync(int audiobookId, CancellationToken ct = default)
         {
             var files = await _db.AudiobookFiles.Where(f => f.AudiobookId == audiobookId).ToListAsync(ct);

--- a/tests/Builders/ServiceCollectionBuilder.cs
+++ b/tests/Builders/ServiceCollectionBuilder.cs
@@ -201,6 +201,7 @@ namespace Listenarr.Tests.Builders
             services.AddSingleton<LibraryPreviewPathWorkflow>();
             services.AddSingleton<LibraryQueryWorkflow>();
             services.AddSingleton<LibraryRenameWorkflow>();
+            services.AddSingleton<LibraryTransferFilesWorkflow>();
             services.AddSingleton<SearchResponseMapper>();
             services.AddSingleton<ImagePlaceholderResolver>();
             services.AddSingleton<IndexerTestWorkflow>();

--- a/tests/Features/Api/Features/Library/LibraryController_TransferFilesTests.cs
+++ b/tests/Features/Api/Features/Library/LibraryController_TransferFilesTests.cs
@@ -1,0 +1,342 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Listenarr.Tests.Builders;
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Api.Features.Library
+{
+    [Trait("Area", "LibraryApi")]
+    [Trait("Name", "LibraryController_TransferFilesTests")]
+    [Trait("Category", "LibraryController")]
+    public class LibraryController_TransferFilesTests : BaseTests
+    {
+        private static JsonElement ToJson(object? value)
+        {
+            return JsonSerializer.SerializeToElement(value);
+        }
+
+        private async Task<(Audiobook source, Audiobook target)> CreateSourceAndTargetAsync(
+            string sourceFolderName = "transfer-src",
+            string targetFolderName = "transfer-dst")
+        {
+            var sourceFolder = FileService.GetTempDirectory(sourceFolderName);
+            var targetFolder = Path.Join(FileService.GetTempPath(), targetFolderName);
+
+            var source = await _audiobookRepository.AddAsync(new AudiobookBuilder()
+                .WithTitle("Arcanum Unbounded")
+                .WithBasePath(sourceFolder)
+                .Build());
+
+            var target = await _audiobookRepository.AddAsync(new AudiobookBuilder()
+                .WithTitle("Warbreaker")
+                .WithBasePath(targetFolder)
+                .Build());
+
+            return (source, target);
+        }
+
+        private async Task<AudiobookFile> AddFileOnDiskAsync(Audiobook owner, string fileName)
+        {
+            var path = Path.Join(owner.BasePath, fileName);
+            Directory.CreateDirectory(owner.BasePath!);
+            await File.WriteAllTextAsync(path, "audio");
+            return await _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(owner)
+                .WithPath(path)
+                .Build());
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "ReturnsBadRequest_WhenTargetIsSource")]
+        public async Task TransferFiles_ReturnsBadRequest_WhenTargetIsSource()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, _) = await CreateSourceAndTargetAsync();
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = source.Id },
+                CancellationToken.None);
+
+            var bad = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Contains("different", bad.Value?.ToString() ?? string.Empty);
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "ReturnsNotFound_WhenSourceOrTargetMissing")]
+        public async Task TransferFiles_ReturnsNotFound_WhenSourceOrTargetMissing()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, _) = await CreateSourceAndTargetAsync();
+
+            var missingSource = await controller.TransferFiles(
+                999_001,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = source.Id },
+                CancellationToken.None);
+            Assert.IsType<NotFoundObjectResult>(missingSource);
+
+            var missingTarget = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = 999_002 },
+                CancellationToken.None);
+            Assert.IsType<NotFoundObjectResult>(missingTarget);
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "ReturnsBadRequest_WhenFileIdsDoNotBelongToSource")]
+        public async Task TransferFiles_ReturnsBadRequest_WhenFileIdsDoNotBelongToSource()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+            var file = await AddFileOnDiskAsync(source, "part1.m4b");
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest
+                {
+                    TargetAudiobookId = target.Id,
+                    FileIds = [file.Id, 999_003]
+                },
+                CancellationToken.None);
+
+            var bad = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Contains("do not belong", bad.Value?.ToString() ?? string.Empty);
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "ReturnsBadRequest_WhenSourceHasNoFiles")]
+        public async Task TransferFiles_ReturnsBadRequest_WhenSourceHasNoFiles()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = target.Id },
+                CancellationToken.None);
+
+            var bad = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Contains("No matching files", bad.Value?.ToString() ?? string.Empty);
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "MovesAllFiles_ReassignsOwnership_AndClearsLegacyColumns")]
+        public async Task TransferFiles_MovesAllFiles_ReassignsOwnership_AndClearsLegacyColumns()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+            var file1 = await AddFileOnDiskAsync(source, "part1.m4b");
+            var file2 = await AddFileOnDiskAsync(source, "part2.m4b");
+
+            // Legacy single-file columns describe the audio the source is about to lose.
+            source.FilePath = file1.Path;
+            source.FileSize = 5;
+            await _audiobookRepository.UpdateAsync(source);
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = target.Id },
+                CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.Equal(2, payload.GetProperty("transferred").GetInt32());
+            Assert.Equal(2, payload.GetProperty("physicallyMoved").GetInt32());
+            Assert.Empty(payload.GetProperty("warnings").EnumerateArray());
+
+            // DB ownership moved to the target, paths point into its folder.
+            var sourceFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(source.Id);
+            var targetFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(target.Id);
+            Assert.Empty(sourceFiles);
+            Assert.Equal(2, targetFiles.Count);
+            Assert.All(targetFiles, f => Assert.StartsWith(target.BasePath!, f.Path!));
+
+            // Physically relocated.
+            Assert.True(File.Exists(Path.Join(target.BasePath, "part1.m4b")));
+            Assert.True(File.Exists(Path.Join(target.BasePath, "part2.m4b")));
+            Assert.False(File.Exists(Path.Join(source.BasePath, "part1.m4b")));
+
+            // Legacy columns cleared: the source no longer owns any audio.
+            var reloadedSource = await _audiobookRepository.GetByIdAsync(source.Id);
+            Assert.Null(reloadedSource!.FilePath);
+            Assert.Null(reloadedSource.FileSize);
+
+            // History recorded on both records.
+            var sourceHistory = await _historyRepository.GetByAudiobookIdAsync(source.Id);
+            var targetHistory = await _historyRepository.GetByAudiobookIdAsync(target.Id);
+            Assert.Contains(sourceHistory, h => h.EventType == "Files Transferred");
+            Assert.Contains(targetHistory, h => h.EventType == "Files Received");
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "SubsetTransfer_KeepsSourceLegacyColumns")]
+        public async Task TransferFiles_SubsetTransfer_KeepsSourceLegacyColumns()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+            var file1 = await AddFileOnDiskAsync(source, "part1.m4b");
+            var file2 = await AddFileOnDiskAsync(source, "part2.m4b");
+
+            source.FilePath = file2.Path;
+            source.FileSize = 5;
+            await _audiobookRepository.UpdateAsync(source);
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest
+                {
+                    TargetAudiobookId = target.Id,
+                    FileIds = [file1.Id]
+                },
+                CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.Equal(1, payload.GetProperty("transferred").GetInt32());
+
+            var sourceFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(source.Id);
+            var targetFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(target.Id);
+            Assert.Single(sourceFiles);
+            Assert.Equal(file2.Id, sourceFiles[0].Id);
+            Assert.Single(targetFiles);
+
+            // Source still holds audio — legacy columns must survive.
+            var reloadedSource = await _audiobookRepository.GetByIdAsync(source.Id);
+            Assert.Equal(file2.Path, reloadedSource!.FilePath);
+            Assert.Equal(5, reloadedSource.FileSize);
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "FileMissingOnDisk_ReassignsInPlace_WithWarning")]
+        public async Task TransferFiles_FileMissingOnDisk_ReassignsInPlace_WithWarning()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+
+            // DB row whose physical file does not exist.
+            var ghostPath = Path.Join(source.BasePath, "ghost.m4b");
+            var ghost = await _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(source)
+                .WithPath(ghostPath)
+                .Build());
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = target.Id },
+                CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.Equal(1, payload.GetProperty("transferred").GetInt32());
+            Assert.Equal(0, payload.GetProperty("physicallyMoved").GetInt32());
+            Assert.Contains(
+                payload.GetProperty("warnings").EnumerateArray(),
+                w => w.GetString()!.Contains("missing on disk"));
+
+            // Ownership reassigned; path unchanged (nothing to move).
+            var targetFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(target.Id);
+            var moved = Assert.Single(targetFiles);
+            Assert.Equal(ghost.Id, moved.Id);
+            Assert.Equal(ghostPath, moved.Path);
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "TargetAlreadyOwnsRowAtPath_SkipsFile_NoDiskMove")]
+        public async Task TransferFiles_TargetAlreadyOwnsRowAtPath_SkipsFile_NoDiskMove()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+            var sourceFile = await AddFileOnDiskAsync(source, "part1.m4b");
+
+            // The target already owns a row at the exact path the file would occupy —
+            // a duplicate from a prior partial transfer. Reassigning would violate the
+            // (AudiobookId, Path) unique key; moving first would orphan the source row.
+            Directory.CreateDirectory(target.BasePath!);
+            await _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(target)
+                .WithPath(Path.Join(target.BasePath, "part1.m4b"))
+                .Build());
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = target.Id },
+                CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.Equal(0, payload.GetProperty("transferred").GetInt32());
+            Assert.Equal(0, payload.GetProperty("physicallyMoved").GetInt32());
+            Assert.Contains(
+                payload.GetProperty("warnings").EnumerateArray(),
+                w => w.GetString()!.Contains("already exists under the target"));
+
+            // File stayed with the source, on disk and in the DB.
+            Assert.True(File.Exists(sourceFile.Path));
+            var sourceFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(source.Id);
+            Assert.Single(sourceFiles);
+
+            // A skipped file means the source still holds audio — no history spam either.
+            var sourceHistory = await _historyRepository.GetByAudiobookIdAsync(source.Id);
+            Assert.Contains(sourceHistory, h => h.EventType == "Files Transferred" && h.Message!.Contains("0 file(s)"));
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "DestinationFileOnDiskWithoutRow_LeavesInPlace_ButReassigns")]
+        public async Task TransferFiles_DestinationFileOnDiskWithoutRow_LeavesInPlace_ButReassigns()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+            var sourceFile = await AddFileOnDiskAsync(source, "part1.m4b");
+
+            // A same-named file already sits in the target folder, but the target has
+            // no DB row for it — ownership can still transfer, the disk move cannot.
+            Directory.CreateDirectory(target.BasePath!);
+            await File.WriteAllTextAsync(Path.Join(target.BasePath, "part1.m4b"), "other audio");
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = target.Id },
+                CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.Equal(1, payload.GetProperty("transferred").GetInt32());
+            Assert.Equal(0, payload.GetProperty("physicallyMoved").GetInt32());
+            Assert.Contains(
+                payload.GetProperty("warnings").EnumerateArray(),
+                w => w.GetString()!.Contains("file left in place"));
+
+            // Ownership moved; the file's path still points at the source folder.
+            var targetFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(target.Id);
+            var moved = Assert.Single(targetFiles);
+            Assert.Equal(sourceFile.Path, moved.Path);
+            Assert.True(File.Exists(sourceFile.Path));
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a "Move Files to Another Book" action to the audiobook detail page: move audio files from one library record to another existing record, for when files actually belong to a different book the library already tracks — two books' tracks imported onto one record, or a collection that needs splitting into its real books.

- **`POST /library/{id}/files/transfer`** (new `LibraryTransferFilesWorkflow`): DB ownership reassigns always; the physical file moves into the destination folder best-effort — a failed disk move leaves the file in place with a warning (Organize can relocate it later) and never aborts the transfer.
- **Collision safety**: if the target already owns a row at the path a file would occupy (duplicate from a prior partial transfer, or a dual-referenced file), the file is skipped with a clear warning *before* any disk move — moving first would orphan the source row. Any other per-file DB failure also degrades to a warning instead of a 500.
- **Bookkeeping**: a source left without audio gets its legacy single-file columns (`FilePath`/`FileSize`) reset, gated on what actually reassigned; history entries land on both records ("Files Transferred" / "Files Received").
- **`IAudiobookFileRepository.ReassignAsync`**: targeted column update via a detached stub (only `AudiobookId`/`Path` marked modified, nothing tracked) — a full-entity `Update` on rows sharing navigation graphs trips EF's identity map on the second file of a bulk transfer. Implemented without `ExecuteUpdate` so the InMemory test provider exercises the same code path production runs.
- **UI**: transfer modal with per-file checkboxes and a library search ranked by token overlap (so a filename-ish query still surfaces the right record), a merge warning + confirm when the destination already has files, and a detail-page action next to Organize.
- **Toasts**: warning/error toasts are now sticky by default (dismissed via the close button) — transfer warnings carry information the user needs to read and act on. Info/success keep the 5s auto-dismiss; callers can still pass an explicit timeout to opt back in.

## Why

Live case: a dramatized adaptation's parts were sitting on the wrong record while the book's own entry sat wanted with zero files. Today the only remedies are delete-and-rescan or manual filesystem surgery; this makes the fix a two-click operation that keeps history and never loses a file.

## Tests

9 new tests in `LibraryController_TransferFilesTests` (validation, full + subset transfer, legacy-column gating, missing-on-disk, DB-row collision skip, on-disk collision reassign-in-place, history). Full suite: **1024/1024 passing**. `vue-tsc` + eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)