### PR TITLE
feat(search): live automatic-search activity indicator (sidebar)

### DIFF
--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -458,6 +458,7 @@
             </RouterLink>
           </div>
         </nav>
+        <SidebarSearchActivity />
         <div v-if="version && version.length > 0" class="sidebar-footer">
           <span class="sidebar-version-text">v{{ version }}</span>
           <a
@@ -574,6 +575,7 @@ import GlobalToast from '@/components/ui/GlobalToast.vue'
 import { useToast } from '@/services/toastService'
 import { logger } from '@/utils/logger'
 import BrandLogo from '@/components/base/BrandLogo.vue'
+import SidebarSearchActivity from '@/components/layout/SidebarSearchActivity.vue'
 import {
   SECURITY_WARNING_BANNER_PREF_EVENT,
   SECURITY_WARNING_BANNER_PREF_KEY,

--- a/fe/src/__tests__/searchActivity.store.spec.ts
+++ b/fe/src/__tests__/searchActivity.store.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('@/services/api', () => ({
+  apiService: {
+    getSearchActivity: vi.fn().mockResolvedValue({
+      current: { message: 'Search idle', stage: 'idle', timestamp: '2026-06-13T00:00:00Z' },
+      recent: [
+        {
+          message: 'Grabbed 1 for A',
+          stage: 'grabbed',
+          audiobookId: 7,
+          timestamp: '2026-06-13T00:00:01Z',
+        },
+      ],
+    }),
+  },
+}))
+
+vi.mock('@/services/signalr', () => ({
+  signalRService: { onSearchProgress: vi.fn(() => () => {}) },
+}))
+
+vi.mock('@/utils/logger', () => ({ logger: { debug: vi.fn() } }))
+
+import { useSearchActivityStore } from '@/stores/searchActivity'
+
+describe('searchActivity store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('hydrates current + recent from the API', async () => {
+    const store = useSearchActivityStore()
+    await store.hydrate()
+    expect(store.current?.stage).toBe('idle')
+    expect(store.recent).toHaveLength(1)
+    expect(store.recent[0].audiobookId).toBe(7)
+  })
+
+  it('isSearching reflects the searching stage', () => {
+    const store = useSearchActivityStore()
+    store.applyEvent({ message: 'Searching 13 indexers for X', stage: 'searching' })
+    expect(store.isSearching).toBe(true)
+    store.applyEvent({ message: 'No results for X', stage: 'no_results' })
+    expect(store.isSearching).toBe(false)
+  })
+
+  it('appends only outcomes to the feed (newest first), not transient stages', () => {
+    const store = useSearchActivityStore()
+    store.applyEvent({ message: 'Searching for X', stage: 'searching' })
+    expect(store.recent).toHaveLength(0)
+    store.applyEvent({ message: 'Grabbed 1 for X', stage: 'grabbed', audiobookId: 1 })
+    store.applyEvent({ message: 'No results for Y', stage: 'no_results', audiobookId: 2 })
+    expect(store.recent.map((e) => e.message)).toEqual(['No results for Y', 'Grabbed 1 for X'])
+  })
+})

--- a/fe/src/components/layout/SidebarSearchActivity.vue
+++ b/fe/src/components/layout/SidebarSearchActivity.vue
@@ -1,0 +1,115 @@
+<!--
+  Listenarr - Audiobook Management System
+  Copyright (C) 2024-2026 Listenarr Contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { storeToRefs } from 'pinia'
+import { PhMagnifyingGlass, PhCircleNotch } from '@phosphor-icons/vue'
+import { useSearchActivityStore } from '@/stores/searchActivity'
+
+const store = useSearchActivityStore()
+const { current, isSearching } = storeToRefs(store)
+
+onMounted(() => store.start())
+
+// The live line: the current message while a sweep is active, otherwise a muted
+// idle label (preferring the backend's idle summary if we have one).
+const label = computed(() => {
+  const c = current.value
+  if (!c) return 'Search idle'
+  if (c.stage === 'idle') return c.message || 'Search idle'
+  return c.message
+})
+
+const idle = computed(() => !isSearching.value)
+</script>
+
+<template>
+  <div
+    class="sidebar-search-activity"
+    :class="{ active: isSearching, idle }"
+    :title="idle ? 'Automatic search is idle' : label"
+  >
+    <span class="ssa-icon">
+      <PhCircleNotch v-if="isSearching" class="ssa-spin" :size="15" weight="bold" />
+      <PhMagnifyingGlass v-else :size="15" />
+    </span>
+    <span class="ssa-text">{{ label }}</span>
+  </div>
+</template>
+
+<style scoped>
+.sidebar-search-activity {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  margin: 0 0.5rem 0.25rem;
+  border-radius: 8px;
+  font-size: 0.72rem;
+  line-height: 1.25;
+  color: #aeb6c2;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid transparent;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    border-color 0.2s ease;
+  overflow: hidden;
+}
+
+.sidebar-search-activity.active {
+  color: var(--brand, #5aa9e6);
+  border-color: rgba(var(--brand-rgb, 90, 169, 230), 0.35);
+  background: rgba(var(--brand-rgb, 90, 169, 230), 0.1);
+}
+
+.sidebar-search-activity.idle .ssa-icon {
+  opacity: 0.6;
+}
+
+.ssa-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+}
+
+.ssa-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ssa-spin {
+  animation: ssa-rotate 0.9s linear infinite;
+}
+
+@keyframes ssa-rotate {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ssa-spin {
+    animation: none;
+  }
+}
+</style>

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -60,6 +60,7 @@ import type {
   RenamePreview,
   RenameOperation,
   RenameResult,
+  SearchActivityResponse,
 } from '@/types'
 import { getStartupConfigCached, resetCache as resetStartupConfigCache } from './startupConfigCache'
 import { sessionTokenManager } from '@/utils/sessionToken'
@@ -312,6 +313,14 @@ class ApiService {
     if (sortDirection) params.append('sortDirection', sortDirection)
 
     return this.request<SearchResult[]>(`/search/indexers?${params}`)
+  }
+
+  /**
+   * Current background automatic-search activity + recent outcomes, for hydrating
+   * the live indicator (sidebar) on page load before SignalR streams.
+   */
+  async getSearchActivity(): Promise<SearchActivityResponse> {
+    return this.request<SearchActivityResponse>(`/search/activity`)
   }
 
   async searchByApi(

--- a/fe/src/services/signalr.ts
+++ b/fe/src/services/signalr.ts
@@ -454,6 +454,8 @@ class SignalRService {
             asin?: string | null
             type?: string
             audiobookId?: number
+            stage?: string
+            timestamp?: string
           }
           // Deliver payload to callbacks that opted-in to automatic messages
           for (const [cb, includeAutomatic] of Array.from(this.searchProgressCallbacks.entries())) {
@@ -754,6 +756,8 @@ class SignalRService {
       asin?: string | null
       type?: string
       audiobookId?: number
+      stage?: string
+      timestamp?: string
     }) => void,
     includeAutomatic = false,
   ): () => void {

--- a/fe/src/stores/searchActivity.ts
+++ b/fe/src/stores/searchActivity.ts
@@ -1,0 +1,107 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import type { SearchActivityEvent } from '@/types'
+import { apiService } from '@/services/api'
+import { signalRService } from '@/services/signalr'
+import { logger } from '@/utils/logger'
+
+// Mirrors the backend ring-buffer cap; trims the live-appended feed so it can't
+// grow without bound between hydrations.
+const MAX_RECENT = 30
+
+/**
+ * Ambient view of what the background automatic-search sweep is doing. Hydrates
+ * once from /search/activity (so a freshly-loaded page shows state immediately,
+ * even if the sweep is idle and the next SignalR event is hours away), then
+ * stays live via the `SearchProgress` channel with `includeAutomatic`.
+ */
+export const useSearchActivityStore = defineStore('searchActivity', () => {
+  const current = ref<SearchActivityEvent | null>(null)
+  const recent = ref<SearchActivityEvent[]>([])
+  const hydrated = ref(false)
+
+  let unsubscribe: (() => void) | null = null
+
+  // True while a book is actively being queried — drives the pulsing indicator.
+  const isSearching = computed(() => current.value?.stage === 'searching')
+
+  function applyEvent(payload: {
+    message: string
+    stage?: string
+    audiobookId?: number
+    asin?: string | null
+    timestamp?: string
+  }) {
+    const evt: SearchActivityEvent = {
+      message: payload.message,
+      stage: (payload.stage as SearchActivityEvent['stage']) || 'searching',
+      audiobookId: payload.audiobookId ?? null,
+      asin: payload.asin ?? null,
+      timestamp: payload.timestamp ?? new Date().toISOString(),
+    }
+    current.value = evt
+    // Outcomes form the feed; transient stages (searching/idle) only update the
+    // live line — matching the backend's addToFeed semantics.
+    if (evt.stage === 'grabbed' || evt.stage === 'no_results') {
+      recent.value = [evt, ...recent.value].slice(0, MAX_RECENT)
+    }
+  }
+
+  async function hydrate() {
+    try {
+      const snapshot = await apiService.getSearchActivity()
+      current.value = snapshot.current
+      recent.value = snapshot.recent ?? []
+    } catch (err) {
+      logger.debug('Failed to hydrate search activity', err)
+    } finally {
+      hydrated.value = true
+    }
+  }
+
+  /**
+   * Idempotent: hydrate once and attach the live subscription. Defensive — a
+   * not-yet-ready or partially-stubbed SignalR service must never break the app
+   * shell that mounts the indicator.
+   */
+  function start() {
+    if (!hydrated.value) {
+      void hydrate()
+    }
+    if (!unsubscribe && typeof signalRService.onSearchProgress === 'function') {
+      try {
+        unsubscribe = signalRService.onSearchProgress((payload) => {
+          if (payload.type && payload.type !== 'automatic') return
+          applyEvent(payload)
+        }, true)
+      } catch (err) {
+        logger.debug('Failed to subscribe to search activity', err)
+      }
+    }
+  }
+
+  function stop() {
+    unsubscribe?.()
+    unsubscribe = null
+  }
+
+  return { current, recent, hydrated, isSearching, hydrate, start, stop, applyEvent }
+})

--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -1109,3 +1109,21 @@ export interface RenameResult {
   error?: string
   renamedFiles: FileRenameResultItem[]
 }
+
+/**
+ * One background automatic-search activity event. `stage` is a small vocabulary
+ * the UI styles by: `searching` (a book is being queried), `grabbed` (a release
+ * was queued), `no_results` (nothing found), `idle` (the sweep isn't running).
+ */
+export interface SearchActivityEvent {
+  message: string
+  stage: 'searching' | 'grabbed' | 'no_results' | 'idle' | string
+  audiobookId?: number | null
+  asin?: string | null
+  timestamp: string
+}
+
+export interface SearchActivityResponse {
+  current: SearchActivityEvent | null
+  recent: SearchActivityEvent[]
+}

--- a/listenarr.api/Features/Search/SearchController.Activity.cs
+++ b/listenarr.api/Features/Search/SearchController.Activity.cs
@@ -1,0 +1,74 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Application.Notifications.Progress;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Api.Features.Search
+{
+    public partial class SearchController
+    {
+        /// <summary>
+        /// Current background automatic-search activity plus a short rolling history
+        /// of recent outcomes. Lets the live UI indicator (sidebar) hydrate
+        /// immediately on load instead of waiting for the next SignalR event —
+        /// which during an idle window could be hours away. Volatile,
+        /// process-local ambient status; not an audit log (History persists grabs).
+        /// </summary>
+        [HttpGet("activity")]
+        [ProducesResponseType(typeof(SearchActivityResponse), StatusCodes.Status200OK)]
+        public ActionResult<SearchActivityResponse> GetSearchActivity()
+        {
+            if (_searchActivityTracker == null)
+            {
+                return Ok(new SearchActivityResponse { Current = null, Recent = new List<SearchActivityEventDto>() });
+            }
+
+            var (current, recent) = _searchActivityTracker.Snapshot();
+            return Ok(new SearchActivityResponse
+            {
+                Current = current == null ? null : SearchActivityEventDto.From(current),
+                Recent = recent.Select(SearchActivityEventDto.From).ToList(),
+            });
+        }
+
+        public sealed class SearchActivityResponse
+        {
+            public SearchActivityEventDto? Current { get; set; }
+            public List<SearchActivityEventDto> Recent { get; set; } = new();
+        }
+
+        public sealed class SearchActivityEventDto
+        {
+            public string Message { get; set; } = string.Empty;
+            public string Stage { get; set; } = string.Empty;
+            public int? AudiobookId { get; set; }
+            public string? Asin { get; set; }
+            public DateTime Timestamp { get; set; }
+
+            public static SearchActivityEventDto From(SearchActivityEvent e) => new()
+            {
+                Message = e.Message,
+                Stage = e.Stage,
+                AudiobookId = e.AudiobookId,
+                Asin = e.Asin,
+                Timestamp = e.Timestamp,
+            };
+        }
+    }
+}

--- a/listenarr.api/Features/Search/SearchController.cs
+++ b/listenarr.api/Features/Search/SearchController.cs
@@ -17,6 +17,7 @@
  */
 
 using System.Text.Json;
+using Listenarr.Application.Notifications.Progress;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Listenarr.Api.Features.Search
@@ -36,6 +37,7 @@ namespace Listenarr.Api.Features.Search
         private readonly SearchByTitleWorkflow _searchByTitleWorkflow;
         private readonly IDownloadReferenceService? _downloadReferenceService;
         private readonly IConfigurationService? _configurationService;
+        private readonly ISearchActivityTracker? _searchActivityTracker;
 
         public SearchController(
             ISearchService searchService,
@@ -48,7 +50,8 @@ namespace Listenarr.Api.Features.Search
             StructuredSearchWorkflow? structuredSearchWorkflow = null,
             SearchByTitleWorkflow? searchByTitleWorkflow = null,
             IDownloadReferenceService? downloadReferenceService = null,
-            IConfigurationService? configurationService = null)
+            IConfigurationService? configurationService = null,
+            ISearchActivityTracker? searchActivityTracker = null)
         {
             _searchService = searchService;
             _logger = logger;
@@ -77,6 +80,7 @@ namespace Listenarr.Api.Features.Search
                 Microsoft.Extensions.Logging.Abstractions.NullLogger<SearchByTitleWorkflow>.Instance,
                 configurationService);
             _downloadReferenceService = downloadReferenceService;
+            _searchActivityTracker = searchActivityTracker;
         }
 
         /// <summary>

--- a/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
+++ b/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
@@ -53,6 +53,7 @@ public static class ListenarrWorkflowRegistration
 
     private static IServiceCollection AddListenarrSearchWorkflows(this IServiceCollection services)
     {
+        services.AddSingleton<ISearchActivityTracker, SearchActivityTracker>();
         services.AddScoped<SearchProgressReporter>();
         services.AddScoped<IndexerAdditionalSettingsParser>();
         services.AddScoped<IndexerSearchWorkflow>();

--- a/listenarr.application/Notifications/Progress/SearchActivityTracker.cs
+++ b/listenarr.application/Notifications/Progress/SearchActivityTracker.cs
@@ -1,0 +1,100 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Listenarr.Application.Notifications.Progress
+{
+    /// <summary>
+    /// One automatic-search activity event. <see cref="Stage"/> is a small
+    /// machine-readable vocabulary the UI styles by:
+    /// <c>searching</c> (a book is being queried), <c>grabbed</c> (a release was
+    /// queued), <c>no_results</c> (nothing found), <c>idle</c> (the sweep is not
+    /// running). <see cref="Timestamp"/> is UTC.
+    /// </summary>
+    public sealed record SearchActivityEvent(
+        string Message,
+        string Stage,
+        int? AudiobookId,
+        string? Asin,
+        DateTime Timestamp);
+
+    /// <summary>
+    /// In-memory, process-wide record of what the automatic-search sweep is
+    /// doing right now plus a short rolling history of recent outcomes. Lets a
+    /// freshly-loaded page hydrate the live indicator immediately instead of
+    /// waiting for the next SignalR event (which during an idle period could be
+    /// hours away). Volatile by design — this is ambient status, not audit data;
+    /// History already persists grabs.
+    /// </summary>
+    public interface ISearchActivityTracker
+    {
+        /// <summary>The most recent event of any stage (including idle).</summary>
+        SearchActivityEvent? Current { get; }
+
+        /// <summary>
+        /// Record an event. When <paramref name="addToFeed"/> is true the event
+        /// also enters the rolling recent-history buffer; transient stages
+        /// (<c>searching</c>, <c>idle</c>) pass false so the feed reads as a list
+        /// of outcomes rather than a doubled play-by-play.
+        /// </summary>
+        void Record(SearchActivityEvent evt, bool addToFeed = true);
+
+        /// <summary>Current event plus the recent-outcome buffer (newest first).</summary>
+        (SearchActivityEvent? Current, IReadOnlyList<SearchActivityEvent> Recent) Snapshot();
+    }
+
+    /// <inheritdoc />
+    public sealed class SearchActivityTracker : ISearchActivityTracker
+    {
+        // Enough history to fill an activity panel without unbounded growth.
+        private const int MaxRecent = 30;
+
+        private readonly object _gate = new();
+        private readonly LinkedList<SearchActivityEvent> _recent = new();
+        private SearchActivityEvent? _current;
+
+        public SearchActivityEvent? Current
+        {
+            get { lock (_gate) { return _current; } }
+        }
+
+        public void Record(SearchActivityEvent evt, bool addToFeed = true)
+        {
+            if (evt == null) return;
+            lock (_gate)
+            {
+                _current = evt;
+                if (addToFeed)
+                {
+                    _recent.AddFirst(evt);
+                    while (_recent.Count > MaxRecent)
+                    {
+                        _recent.RemoveLast();
+                    }
+                }
+            }
+        }
+
+        public (SearchActivityEvent? Current, IReadOnlyList<SearchActivityEvent> Recent) Snapshot()
+        {
+            lock (_gate)
+            {
+                return (_current, _recent.ToList());
+            }
+        }
+    }
+}

--- a/listenarr.application/Notifications/Progress/SearchProgressReporter.cs
+++ b/listenarr.application/Notifications/Progress/SearchProgressReporter.cs
@@ -26,15 +26,23 @@ namespace Listenarr.Application.Notifications.Progress
     {
         private readonly IHubBroadcaster? _hubBroadcaster;
         private readonly ILogger<SearchProgressReporter> _logger;
+        private readonly ISearchActivityTracker? _activityTracker;
 
-        public SearchProgressReporter(IHubBroadcaster? hubBroadcaster, ILogger<SearchProgressReporter> logger)
+        public SearchProgressReporter(
+            IHubBroadcaster? hubBroadcaster,
+            ILogger<SearchProgressReporter> logger,
+            ISearchActivityTracker? activityTracker = null)
         {
             _hubBroadcaster = hubBroadcaster;
             _logger = logger;
+            _activityTracker = activityTracker;
         }
 
         /// <summary>
-        /// Broadcasts a search progress message to all connected realtime clients.
+        /// Broadcasts an interactive (user-initiated) search progress message to
+        /// all connected realtime clients. These are scoped to the page that
+        /// started the search (e.g. Add New) and are not recorded in the
+        /// background-activity tracker.
         /// </summary>
         /// <param name="message">The progress message to broadcast</param>
         /// <param name="asin">Optional ASIN associated with this progress update</param>
@@ -51,6 +59,45 @@ namespace Listenarr.Application.Notifications.Progress
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
             {
                 _logger.LogDebug(ex, "Failed to broadcast SearchProgress: {Message}", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Broadcasts a background automatic-search activity update and records it
+        /// in the <see cref="ISearchActivityTracker"/> so freshly-loaded clients
+        /// can hydrate the live indicator. Clients opt in to these via the
+        /// <c>includeAutomatic</c> flag on their SearchProgress subscription.
+        /// </summary>
+        /// <param name="message">Human-readable status (e.g. "Searching 13 indexers for …").</param>
+        /// <param name="stage">One of <c>searching</c>/<c>grabbed</c>/<c>no_results</c>/<c>idle</c>.</param>
+        /// <param name="audiobookId">The book this event concerns, if any.</param>
+        /// <param name="asin">Associated ASIN, if any.</param>
+        /// <param name="addToFeed">
+        /// Whether the event enters the recent-outcomes feed. Transient stages
+        /// (searching/idle) pass false so the feed lists outcomes, not play-by-play.
+        /// </param>
+        public async Task BroadcastAutomaticAsync(
+            string message,
+            string stage,
+            int? audiobookId = null,
+            string? asin = null,
+            bool addToFeed = true)
+        {
+            var evt = new SearchActivityEvent(message, stage, audiobookId, asin, DateTime.UtcNow);
+            _activityTracker?.Record(evt, addToFeed);
+
+            try
+            {
+                if (_hubBroadcaster != null)
+                {
+                    await _hubBroadcaster.BroadcastAsync(
+                        "SearchProgress",
+                        new { message, asin, audiobookId, type = "automatic", stage, timestamp = evt.Timestamp });
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogDebug(ex, "Failed to broadcast automatic SearchProgress: {Message}", ex.Message);
             }
         }
     }

--- a/listenarr.application/Search/Indexers/Common/IndexerSearchWorkflow.cs
+++ b/listenarr.application/Search/Indexers/Common/IndexerSearchWorkflow.cs
@@ -29,6 +29,7 @@ public class IndexerSearchWorkflow
     private readonly IndexerAdditionalSettingsParser _additionalSettingsParser;
     private readonly TorznabResponseParser _torznabResponseParser;
     private readonly ILogger<IndexerSearchWorkflow> _logger;
+    private readonly SearchProgressReporter? _searchProgressReporter;
 
     public IndexerSearchWorkflow(
         HttpClient httpClient,
@@ -37,7 +38,8 @@ public class IndexerSearchWorkflow
         IEnumerable<IIndexerSearchProvider> searchProviders,
         IndexerAdditionalSettingsParser additionalSettingsParser,
         ILogger<IndexerSearchWorkflow> logger,
-        IHtmlTextExtractor? htmlTextExtractor = null)
+        IHtmlTextExtractor? htmlTextExtractor = null,
+        SearchProgressReporter? searchProgressReporter = null)
     {
         _httpClient = httpClient;
         _configurationService = configurationService;
@@ -46,6 +48,7 @@ public class IndexerSearchWorkflow
         _additionalSettingsParser = additionalSettingsParser;
         _logger = logger;
         _torznabResponseParser = new TorznabResponseParser(httpClient, logger, htmlTextExtractor);
+        _searchProgressReporter = searchProgressReporter;
     }
 
     public async Task<List<IndexerSearchResult>> SearchIndexersAsync(
@@ -60,6 +63,16 @@ public class IndexerSearchWorkflow
         var indexers = await _indexerRepository.GetEnabledAsync(isAutomaticSearch);
 
         _logger.LogInformation("Searching {Count} enabled indexers for query: {Query}", indexers.Count, query);
+
+        // Surface the background sweep's per-book activity to the live UI
+        // indicator (sidebar). Transient stage — not added to the recent-outcomes
+        // feed; the per-book outcome from the automatic-search sweep is.
+        // Best-effort: a notification hiccup must never affect the search.
+        if (isAutomaticSearch && _searchProgressReporter != null)
+        {
+            await _searchProgressReporter.BroadcastAutomaticAsync(
+                $"Searching {indexers.Count} indexers for {query}", "searching", addToFeed: false);
+        }
 
         if (!indexers.Any())
         {

--- a/listenarr.infrastructure/HostedServices/Search/AutomaticSearchService.cs
+++ b/listenarr.infrastructure/HostedServices/Search/AutomaticSearchService.cs
@@ -16,6 +16,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using Listenarr.Application.Notifications.Progress;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -75,6 +76,8 @@ namespace Listenarr.Infrastructure.HostedServices.Search
             var searchService = scope.ServiceProvider.GetRequiredService<ISearchService>();
             var qualityProfileService = scope.ServiceProvider.GetRequiredService<IQualityProfileService>();
             var downloadService = scope.ServiceProvider.GetRequiredService<IDownloadService>();
+            // Optional: drives the live search-activity indicator (sidebar).
+            var searchProgressReporter = scope.ServiceProvider.GetService<SearchProgressReporter>();
 
             // Get all monitored audiobooks that haven't been searched in the last 6 hours
             var cutoffTime = DateTime.UtcNow.AddHours(-6);
@@ -85,6 +88,10 @@ namespace Listenarr.Infrastructure.HostedServices.Search
             if (!monitoredAudiobooks.Any())
             {
                 _logger.LogInformation("No audiobooks require automatic search at this time");
+                if (searchProgressReporter != null)
+                {
+                    await searchProgressReporter.BroadcastAutomaticAsync("Search idle", "idle", addToFeed: false);
+                }
                 return;
             }
 
@@ -103,6 +110,16 @@ namespace Listenarr.Infrastructure.HostedServices.Search
 
                     downloadsQueued += downloadsQueuedForBook;
                     processedCount++;
+
+                    // Per-book outcome for the live activity indicator. Best-effort —
+                    // never let a notification failure interrupt the sweep.
+                    if (searchProgressReporter != null)
+                    {
+                        var (outcomeMessage, outcomeStage) = downloadsQueuedForBook > 0
+                            ? ($"Grabbed {downloadsQueuedForBook} release(s) for {audiobook.Title}", "grabbed")
+                            : ($"No results for {audiobook.Title}", "no_results");
+                        await searchProgressReporter.BroadcastAutomaticAsync(outcomeMessage, outcomeStage, audiobook.Id, audiobook.Asin);
+                    }
 
                     // Update last search time
                     audiobook.LastSearchTime = DateTime.UtcNow;
@@ -127,6 +144,13 @@ namespace Listenarr.Infrastructure.HostedServices.Search
 
             _logger.LogInformation("Automatic search cycle completed. Processed {ProcessedCount} audiobooks, queued {DownloadsQueued} total downloads",
                 processedCount, downloadsQueued);
+
+            // Sweep finished — the live indicator returns to idle until the next cycle.
+            if (searchProgressReporter != null)
+            {
+                await searchProgressReporter.BroadcastAutomaticAsync(
+                    $"Search idle — last sweep processed {processedCount} book(s)", "idle", addToFeed: false);
+            }
         }
 
         private async Task<int> ProcessAudiobookAsync(

--- a/tests/Builders/ServiceCollectionBuilder.cs
+++ b/tests/Builders/ServiceCollectionBuilder.cs
@@ -174,6 +174,7 @@ namespace Listenarr.Tests.Builders
             services.AddSingleton<IRootFolderService, RootFolderService>();
             services.AddSingleton<MetadataConverters>();
             services.AddSingleton<MetadataMerger>();
+            services.AddSingleton<ISearchActivityTracker, SearchActivityTracker>();
             services.AddSingleton<SearchProgressReporter>();
             services.AddSingleton<IndexerAdditionalSettingsParser>();
             services.AddSingleton<IndexerSearchWorkflow>();

--- a/tests/Features/Application/Notifications/SearchActivityTrackerTests.cs
+++ b/tests/Features/Application/Notifications/SearchActivityTrackerTests.cs
@@ -1,0 +1,89 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Application.Notifications.Progress;
+
+namespace Listenarr.Tests.Features.Application.Notifications
+{
+    [Trait("Category", "SearchActivityTracker")]
+    public class SearchActivityTrackerTests
+    {
+        private static SearchActivityEvent Evt(string stage, string message = "msg")
+            => new(message, stage, null, null, DateTime.UtcNow);
+
+        [Fact(DisplayName = "Records set Current; outcomes enter the feed, transient stages do not")]
+        public void Record_FeedSemantics()
+        {
+            var tracker = new SearchActivityTracker();
+
+            // Transient: updates Current but not the feed.
+            tracker.Record(Evt("searching", "Searching 13 indexers for X"), addToFeed: false);
+            var (current1, recent1) = tracker.Snapshot();
+            Assert.Equal("searching", current1!.Stage);
+            Assert.Empty(recent1);
+
+            // Outcome: updates Current AND the feed.
+            tracker.Record(Evt("grabbed", "Grabbed 1 for X"));
+            var (current2, recent2) = tracker.Snapshot();
+            Assert.Equal("grabbed", current2!.Stage);
+            Assert.Single(recent2);
+
+            // Idle: transient, current-only.
+            tracker.Record(Evt("idle", "Search idle"), addToFeed: false);
+            var (current3, recent3) = tracker.Snapshot();
+            Assert.Equal("idle", current3!.Stage);
+            Assert.Single(recent3); // unchanged
+        }
+
+        [Fact(DisplayName = "Feed is newest-first")]
+        public void Feed_NewestFirst()
+        {
+            var tracker = new SearchActivityTracker();
+            tracker.Record(Evt("grabbed", "first"));
+            tracker.Record(Evt("no_results", "second"));
+
+            var (_, recent) = tracker.Snapshot();
+            Assert.Equal(new[] { "second", "first" }, recent.Select(e => e.Message).ToArray());
+        }
+
+        [Fact(DisplayName = "Feed is capped at 30 (oldest dropped)")]
+        public void Feed_Capped()
+        {
+            var tracker = new SearchActivityTracker();
+            for (int i = 0; i < 45; i++)
+            {
+                tracker.Record(Evt("no_results", $"book {i}"));
+            }
+
+            var (_, recent) = tracker.Snapshot();
+            Assert.Equal(30, recent.Count);
+            // Newest first → book 44 at the head, book 15 at the tail (0..14 dropped).
+            Assert.Equal("book 44", recent.First().Message);
+            Assert.Equal("book 15", recent.Last().Message);
+        }
+
+        [Fact(DisplayName = "Empty tracker snapshots to null current and empty feed")]
+        public void Empty_Snapshot()
+        {
+            var tracker = new SearchActivityTracker();
+            var (current, recent) = tracker.Snapshot();
+            Assert.Null(current);
+            Assert.Empty(recent);
+        }
+    }
+}

--- a/tests/Features/Application/Notifications/SearchProgressReporterAutomaticTests.cs
+++ b/tests/Features/Application/Notifications/SearchProgressReporterAutomaticTests.cs
@@ -1,0 +1,72 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Application.Notifications.Progress;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Listenarr.Tests.Features.Application.Notifications
+{
+    [Trait("Category", "SearchActivityTracker")]
+    public class SearchProgressReporterAutomaticTests
+    {
+        // Null hub context is supported by the reporter, so these exercise the
+        // tracker-recording path without needing a SignalR mock.
+
+        [Fact(DisplayName = "Automatic broadcast records the event in the tracker")]
+        public async Task BroadcastAutomatic_RecordsToTracker()
+        {
+            var tracker = new SearchActivityTracker();
+            var reporter = new SearchProgressReporter(null, NullLogger<SearchProgressReporter>.Instance, tracker);
+
+            await reporter.BroadcastAutomaticAsync("Grabbed 1 for The Way of Kings", "grabbed", audiobookId: 51, asin: "B003ZWFO7E");
+
+            var (current, recent) = tracker.Snapshot();
+            Assert.NotNull(current);
+            Assert.Equal("grabbed", current!.Stage);
+            Assert.Equal(51, current.AudiobookId);
+            Assert.Equal("B003ZWFO7E", current.Asin);
+            Assert.Single(recent);
+        }
+
+        [Fact(DisplayName = "Transient automatic stage updates current but not the feed")]
+        public async Task BroadcastAutomatic_Transient_NotInFeed()
+        {
+            var tracker = new SearchActivityTracker();
+            var reporter = new SearchProgressReporter(null, NullLogger<SearchProgressReporter>.Instance, tracker);
+
+            await reporter.BroadcastAutomaticAsync("Searching 13 indexers for X", "searching", addToFeed: false);
+
+            var (current, recent) = tracker.Snapshot();
+            Assert.Equal("searching", current!.Stage);
+            Assert.Empty(recent);
+        }
+
+        [Fact(DisplayName = "Interactive broadcast does not touch the automatic tracker")]
+        public async Task BroadcastInteractive_DoesNotRecord()
+        {
+            var tracker = new SearchActivityTracker();
+            var reporter = new SearchProgressReporter(null, NullLogger<SearchProgressReporter>.Instance, tracker);
+
+            await reporter.BroadcastAsync("Looking up ASIN…", "B000000000");
+
+            var (current, recent) = tracker.Snapshot();
+            Assert.Null(current);
+            Assert.Empty(recent);
+        }
+    }
+}


### PR DESCRIPTION
## What

A live activity indicator for the automatic-search sweep: a sidebar pill that shows what the background search is doing right now ("Searching 4 indexers for …", "Grabbed 2 release(s) for …", "Search idle — last sweep processed 31 book(s)"), driven over the existing search-progress SignalR channel.

- **`SearchActivityTracker`** (singleton): holds the current stage + a rolling 30-entry feed of recent per-book outcomes; hydrated on page load via a new `GET /search/activity` endpoint (in a `SearchController.Activity.cs` partial, keeping the main controller under the 500-line architecture cap).
- **`SearchProgressReporter.BroadcastAutomaticAsync`**: broadcasts `type: "automatic"` progress events through the existing `IHubBroadcaster` plumbing and records them in the tracker.
- **Hooks** (all optional + best-effort — a notification hiccup can never affect a search): per-book "searching" in `IndexerSearchWorkflow` (gated on `isAutomaticSearch`), per-book outcome + idle transitions in the automatic-search sweep.
- **Frontend**: a `searchActivity` Pinia store (SignalR + hydration) and a `SidebarSearchActivity` pill.

Note: the kevin/live original also had a dashboard "recent outcomes" panel; canary has no dashboard view, so this PR ships the sidebar half. The endpoint and store already carry the 30-outcome feed, so a future panel (e.g. on the Activity view) can consume it with zero backend changes.

## Why

The automatic-search sweep is invisible today — you can't tell whether it's running, stuck, or idle without reading logs. This surfaces it where you already are.

## Tests

7 new backend tests (tracker state/feed + reporter automatic-broadcast) and a 3-case vitest spec for the store. Full suite passing; `vue-tsc` + eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)