### PR TITLE
feat(organize): library-wide organize sweep with metadata-stub target replacement

### DIFF
--- a/fe/src/components/domain/organize/MoveQueueStatusBanner.vue
+++ b/fe/src/components/domain/organize/MoveQueueStatusBanner.vue
@@ -1,0 +1,414 @@
+<!--
+  Listenarr - Audiobook Management System
+  Copyright (C) 2024-2026 Listenarr Contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<!--
+  Polls GET /library/move/summary on a 5s interval while mounted (paused
+  automatically when the browser tab is hidden — Page Visibility API).
+  Displays counts + the most recent completed/failed entries so the user
+  can see at-a-glance whether the move queue is draining, stuck, or
+  failing.
+
+  Renders nothing when the queue is completely empty AND no history exists
+  (total === 0), so a brand-new instance doesn't show an empty banner.
+
+  Embedded in both OrganizeLibraryModal (top of body) and the Settings
+  Library Maintenance section. No SignalR plumbing — polling is cheap
+  (single table-count query backend-side, ~tens of bytes over the wire)
+  and avoids the connect / reconnect / fallback complexity of subscribing
+  to MoveJobUpdate from inside a transient modal.
+-->
+<template>
+  <div v-if="visible" class="move-queue-banner" :class="bannerClass">
+    <div class="banner-row">
+      <span class="banner-label">Move queue:</span>
+      <span class="banner-counts">
+        <strong>{{ summary!.completed }}</strong> of <strong>{{ totalActive }}</strong> done
+        <span v-if="summary!.processing > 0"
+          ><span class="dot">·</span
+          ><span class="counts-processing">{{ summary!.processing }} processing</span></span
+        >
+        <span v-if="summary!.queued > 0"
+          ><span class="dot">·</span
+          ><span class="counts-queued">{{ summary!.queued }} queued</span></span
+        >
+        <span v-if="summary!.failed > 0"
+          ><span class="dot">·</span
+          ><span class="counts-failed">{{ summary!.failed }} failed</span></span
+        >
+        <span v-if="summary!.other > 0"
+          ><span class="dot">·</span
+          ><span class="counts-other">{{ summary!.other }} other / cancelled</span></span
+        >
+      </span>
+      <span v-if="lastFetched" class="banner-updated" :title="lastFetchedAbsolute">
+        updated {{ lastFetchedRelative }}
+      </span>
+    </div>
+
+    <div
+      v-for="proc in summary!.currentlyProcessing"
+      :key="proc.id"
+      class="banner-row banner-detail banner-detail-processing"
+    >
+      <span class="banner-detail-label">Now moving:</span>
+      <span class="banner-detail-text" :title="proc.requestedPath || ''">
+        <strong>{{ proc.audiobookTitle || `ab #${proc.audiobookId}` }}</strong>
+        <span v-if="proc.fileCount > 0" class="size-meta">
+          ({{ proc.fileCount }} file{{ proc.fileCount === 1 ? '' : 's'
+          }}<span v-if="proc.totalBytes > 0"> · {{ formatBytes(proc.totalBytes) }}</span
+          >)
+        </span>
+        → {{ shortPath(proc.requestedPath) || '(unknown target)' }}
+      </span>
+      <span v-if="proc.updatedAt" class="banner-detail-time" :title="`Started ${proc.updatedAt}`">
+        running {{ formatRelative(proc.updatedAt) }}
+      </span>
+    </div>
+
+    <div v-if="summary!.queued > 0 && summary!.queuedFiles > 0" class="banner-row banner-detail">
+      <span class="banner-detail-label">Queue remaining:</span>
+      <span class="banner-detail-text">
+        {{ summary!.queued }} book{{ summary!.queued === 1 ? '' : 's' }} ·
+        {{ summary!.queuedFiles.toLocaleString() }} file{{ summary!.queuedFiles === 1 ? '' : 's'
+        }}<span v-if="summary!.queuedBytes > 0"> · {{ formatBytes(summary!.queuedBytes) }}</span>
+      </span>
+    </div>
+
+    <div v-if="latestCompleted" class="banner-row banner-detail">
+      <span class="banner-detail-label">Last completed:</span>
+      <span class="banner-detail-text" :title="latestCompleted.requestedPath || ''">
+        {{ latestCompleted.audiobookTitle || `ab #${latestCompleted.audiobookId}`
+        }}<span v-if="latestCompleted.fileCount > 0" class="size-meta">
+          ({{ latestCompleted.fileCount }} file{{ latestCompleted.fileCount === 1 ? '' : 's'
+          }}<span v-if="latestCompleted.totalBytes > 0">
+            · {{ formatBytes(latestCompleted.totalBytes) }}</span
+          >)
+        </span>
+        → {{ shortPath(latestCompleted.requestedPath) || '(unknown target)' }}
+      </span>
+      <span v-if="latestCompleted.updatedAt" class="banner-detail-time">
+        {{ formatRelative(latestCompleted.updatedAt) }}
+      </span>
+    </div>
+
+    <div v-if="latestFailed" class="banner-row banner-detail banner-detail-failed">
+      <span class="banner-detail-label">Last failure:</span>
+      <span class="banner-detail-text" :title="latestFailed.error || ''">
+        {{ latestFailed.audiobookTitle || `ab #${latestFailed.audiobookId}` }}:
+        {{ (latestFailed.error || 'unknown error').slice(0, 140)
+        }}{{ (latestFailed.error || '').length > 140 ? '…' : '' }}
+      </span>
+      <span v-if="latestFailed.updatedAt" class="banner-detail-time">
+        {{ formatRelative(latestFailed.updatedAt) }}
+      </span>
+    </div>
+
+    <div v-if="loadError" class="banner-row banner-detail banner-detail-failed">
+      <span class="banner-detail-label">Couldn't fetch summary:</span>
+      <span class="banner-detail-text">{{ loadError }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
+import { apiService } from '@/services/api'
+import { errorTracking } from '@/services/errorTracking'
+import type { MoveQueueSummary, MoveQueueJobSummary } from '@/types'
+
+const props = withDefaults(
+  defineProps<{
+    /** Poll interval in milliseconds. Default 5000. Set to 0 to disable polling (single fetch on mount). */
+    intervalMs?: number
+    /** How many recent completed/failed jobs to ask the API for (passed through to recentLimit). Default 3. */
+    recentLimit?: number
+  }>(),
+  { intervalMs: 5000, recentLimit: 3 },
+)
+
+const summary = ref<MoveQueueSummary | null>(null)
+const loadError = ref<string | null>(null)
+const lastFetched = ref<Date | null>(null)
+
+// Refresh "updated X ago" on a 1s tick — purely cosmetic, lets the timestamp
+// in the corner age in real time instead of jumping every poll interval.
+const now = ref<number>(Date.now())
+let nowTimer: number | null = null
+
+let pollTimer: number | null = null
+let visibilityHandler: (() => void) | null = null
+
+// The banner is ambient — only render when there's active work (queued or
+// processing) so historical counts from prior sessions don't linger as a
+// permanent UI tombstone. A failure within RECENT_FAILURE_WINDOW_MS stays
+// visible briefly so the user still notices something just went wrong.
+const RECENT_FAILURE_WINDOW_MS = 10 * 60 * 1000
+
+const visible = computed(() => {
+  // Require summary to be non-null even if loadError is set — the template
+  // dereferences summary!.completed and related fields, so a banner shown
+  // before the first successful poll would crash.
+  if (!summary.value) return false
+  if (loadError.value) return true
+  if (summary.value.processing > 0 || summary.value.queued > 0) return true
+  // Keep the banner up briefly after a recent failure so it isn't missed.
+  const failedAt = summary.value.recentFailed?.[0]?.updatedAt
+  if (failedAt) {
+    try {
+      const age = now.value - new Date(failedAt).getTime()
+      if (age >= 0 && age < RECENT_FAILURE_WINDOW_MS) return true
+    } catch {
+      /* unparseable timestamp — fall through to hide */
+    }
+  }
+  return false
+})
+
+// Most operations are "X of Y done" where Y is the active set (queued +
+// processing + completed + failed). Cancelled jobs are excluded from Y so a
+// stale cancel-all doesn't make the denominator misleading.
+const totalActive = computed(() => {
+  if (!summary.value) return 0
+  return (
+    summary.value.completed + summary.value.queued + summary.value.processing + summary.value.failed
+  )
+})
+
+const bannerClass = computed(() => {
+  if (!summary.value) return ''
+  if (summary.value.processing > 0 || summary.value.queued > 0) return 'is-active'
+  if (summary.value.failed > 0 && summary.value.completed === 0) return 'is-failing'
+  if (summary.value.completed > 0) return 'is-done'
+  return ''
+})
+
+const latestCompleted = computed<MoveQueueJobSummary | null>(
+  () => summary.value?.recentCompleted?.[0] ?? null,
+)
+const latestFailed = computed<MoveQueueJobSummary | null>(
+  () => summary.value?.recentFailed?.[0] ?? null,
+)
+
+function shortPath(p: string | null): string {
+  if (!p) return ''
+  // Trim /audiobooks/ prefix to save horizontal space. Full path is in title attr.
+  return p.replace(/^\/?audiobooks\//i, '')
+}
+
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes <= 0) return '—'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unitIdx = 0
+  while (value >= 1024 && unitIdx < units.length - 1) {
+    value /= 1024
+    unitIdx++
+  }
+  const decimals = value < 10 && unitIdx > 0 ? 1 : 0
+  return `${value.toFixed(decimals)} ${units[unitIdx]}`
+}
+
+function formatRelative(iso: string): string {
+  try {
+    const then = new Date(iso).getTime()
+    const seconds = Math.floor((now.value - then) / 1000)
+    if (seconds < 0) return 'just now'
+    if (seconds < 5) return 'just now'
+    if (seconds < 60) return `${seconds}s ago`
+    const minutes = Math.floor(seconds / 60)
+    if (minutes < 60) return `${minutes}m ago`
+    const hours = Math.floor(minutes / 60)
+    if (hours < 24) return `${hours}h ago`
+    const days = Math.floor(hours / 24)
+    return `${days}d ago`
+  } catch {
+    return ''
+  }
+}
+
+const lastFetchedRelative = computed(() => {
+  if (!lastFetched.value) return ''
+  return formatRelative(lastFetched.value.toISOString())
+})
+const lastFetchedAbsolute = computed(() => {
+  if (!lastFetched.value) return ''
+  return lastFetched.value.toLocaleString()
+})
+
+async function fetchSummary() {
+  try {
+    summary.value = await apiService.getMoveQueueSummary(props.recentLimit)
+    loadError.value = null
+    lastFetched.value = new Date()
+  } catch (err) {
+    loadError.value = err instanceof Error ? err.message : 'unknown error'
+    errorTracking.captureException(err as Error, {
+      component: 'MoveQueueStatusBanner',
+      operation: 'fetchSummary',
+    })
+  }
+}
+
+function startPolling() {
+  stopPolling()
+  // Fire once immediately so the banner populates without waiting an interval.
+  void fetchSummary()
+  if (props.intervalMs > 0) {
+    pollTimer = window.setInterval(() => {
+      // Skip the network call when the tab is hidden — saves bandwidth and
+      // avoids piling up polls during long backgrounded sessions. The next
+      // visibility-change handler will fire a fresh fetch.
+      if (document.hidden) return
+      void fetchSummary()
+    }, props.intervalMs)
+  }
+}
+
+function stopPolling() {
+  if (pollTimer != null) {
+    window.clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
+onMounted(() => {
+  startPolling()
+  nowTimer = window.setInterval(() => {
+    now.value = Date.now()
+  }, 1000)
+  visibilityHandler = () => {
+    if (!document.hidden) void fetchSummary()
+  }
+  document.addEventListener('visibilitychange', visibilityHandler)
+})
+
+onBeforeUnmount(() => {
+  stopPolling()
+  if (nowTimer != null) {
+    window.clearInterval(nowTimer)
+    nowTimer = null
+  }
+  if (visibilityHandler) {
+    document.removeEventListener('visibilitychange', visibilityHandler)
+    visibilityHandler = null
+  }
+})
+
+// If the parent updates intervalMs at runtime (rare but supported), restart.
+watch(
+  () => props.intervalMs,
+  () => startPolling(),
+)
+</script>
+
+<style scoped>
+.move-queue-banner {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.025);
+  border-radius: 6px;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  font-size: 12px;
+  color: #c0c0c0;
+}
+.move-queue-banner.is-active {
+  border-left: 3px solid #5ea1ff;
+  background: rgba(94, 161, 255, 0.05);
+}
+.move-queue-banner.is-failing {
+  border-left: 3px solid #f06060;
+  background: rgba(240, 96, 96, 0.06);
+}
+.move-queue-banner.is-done {
+  border-left: 3px solid #6fc080;
+  background: rgba(111, 192, 128, 0.04);
+}
+.banner-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+}
+.banner-row + .banner-row {
+  margin-top: 4px;
+}
+.banner-label {
+  font-weight: 600;
+  color: #e0e0e0;
+}
+.banner-counts {
+  flex: 1 1 auto;
+}
+.banner-counts strong {
+  color: #fff;
+}
+.dot {
+  margin: 0 6px;
+  color: #555;
+}
+.counts-processing {
+  color: #5ea1ff;
+}
+.counts-queued {
+  color: #c0c0c0;
+}
+.counts-failed {
+  color: #f08080;
+}
+.counts-other {
+  color: #888;
+}
+.banner-updated {
+  font-size: 10px;
+  color: #888;
+  cursor: help;
+}
+.banner-detail {
+  font-size: 11px;
+  color: #aaa;
+}
+.banner-detail-label {
+  color: #888;
+}
+.banner-detail-text {
+  flex: 1 1 auto;
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.banner-detail-time {
+  font-size: 10px;
+  color: #777;
+}
+.banner-detail-failed .banner-detail-text {
+  color: #f0a0a0;
+}
+.banner-detail-processing .banner-detail-text {
+  color: #b8d4ff;
+}
+.banner-detail-processing .banner-detail-text strong {
+  color: #fff;
+}
+.size-meta {
+  font-family: monospace;
+  font-size: 10px;
+  color: #888;
+  margin-left: 4px;
+  white-space: nowrap;
+}
+</style>

--- a/fe/src/components/domain/organize/OrganizeLibraryModal.vue
+++ b/fe/src/components/domain/organize/OrganizeLibraryModal.vue
@@ -1,0 +1,1203 @@
+<!--
+  Listenarr - Audiobook Management System
+  Copyright (C) 2024-2026 Listenarr Contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<template>
+  <transition name="modal-fade">
+    <div v-if="visible" class="modal-overlay" @click.self="onClose">
+      <div
+        class="modal organize-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="org-modal-title"
+      >
+        <header class="modal-header">
+          <h2 id="org-modal-title">Organize library folders</h2>
+          <button class="modal-close" :disabled="applying" @click="onClose" aria-label="Close">
+            <PhX />
+          </button>
+        </header>
+
+        <div class="modal-body">
+          <!-- Always-visible move-queue status banner: polls /library/move/summary
+               on a 5s tick while open. Useful both BEFORE Apply (shows leftover
+               state from a previous run) and AFTER (live progress). Renders
+               nothing when the queue has never had any jobs. -->
+          <MoveQueueStatusBanner v-if="visible" />
+
+          <div v-if="loading" class="state-msg">Computing canonical paths for your library…</div>
+
+          <div v-else-if="loadError" class="state-msg error">
+            Failed to load preview: {{ loadError }}
+          </div>
+
+          <template v-else-if="preview">
+            <p class="help-text">
+              Each audiobook below has been compared against its canonical
+              <code>{Author}/{Title}</code> path under the configured
+              <strong>Folder Naming Pattern</strong>. Confirm the selection then click Apply to
+              queue per-book moves. <strong>Collision</strong> and
+              <strong>Invalid target</strong> rows are surfaced for your awareness — they must be
+              resolved by hand (run the duplicates tool, or fix missing metadata) before they can be
+              organized.
+            </p>
+
+            <div class="bucket-summary">
+              <span class="bucket pill pill-action">{{ preview.willMoveCount }} will move</span>
+              <span class="bucket pill pill-ok"
+                >{{ preview.alreadyCanonicalCount }} already canonical</span
+              >
+              <span class="bucket pill pill-warn"
+                >{{ preview.collisionCount }} collision{{
+                  preview.collisionCount === 1 ? '' : 's'
+                }}</span
+              >
+              <span class="bucket pill pill-warn"
+                >{{ preview.invalidTargetCount }} invalid target{{
+                  preview.invalidTargetCount === 1 ? '' : 's'
+                }}</span
+              >
+            </div>
+
+            <section v-if="willMoveRows.length > 0" class="section">
+              <header class="section-header">
+                <h3>Will move ({{ willMoveRows.length }})</h3>
+                <div class="section-tools">
+                  <button type="button" class="link" @click="toggleAll(true)">Select all</button>
+                  <button type="button" class="link" @click="toggleAll(false)">Select none</button>
+                  <span class="section-count"
+                    >{{ selectedCount }} selected · {{ formatBytes(selectedBytes) }}</span
+                  >
+                </div>
+              </header>
+              <div class="rows">
+                <label v-for="row in willMoveRows" :key="row.id" class="row">
+                  <input
+                    type="checkbox"
+                    :checked="selected[row.id] === true"
+                    :disabled="applying"
+                    @change="onToggleRow(row.id, ($event.target as HTMLInputElement).checked)"
+                  />
+                  <div class="row-body">
+                    <div class="row-title">
+                      <strong>{{ row.title || '(no title)' }}</strong>
+                      <span class="row-author">{{ row.author || 'Unknown Author' }}</span>
+                    </div>
+                    <div class="row-paths">
+                      <div class="row-path" :title="row.currentPath || ''">
+                        <span class="path-label">from</span>
+                        <span class="path-value">{{ row.currentPath || '(empty)' }}</span>
+                      </div>
+                      <div class="row-path" :title="row.targetPath || ''">
+                        <span class="path-label">to</span>
+                        <span class="path-value path-target">{{ row.targetPath }}</span>
+                      </div>
+                    </div>
+                    <div class="row-meta">
+                      {{ row.fileCount }} file{{ row.fileCount === 1 ? '' : 's' }} ·
+                      {{ formatBytes(row.totalSize) }}
+                      <span
+                        v-if="row.replacesStubTarget"
+                        class="stub-replace-tag"
+                        title="The target folder exists but only holds leftover metadata (covers, .opf, playlists) that nothing references. The move will replace it."
+                        >replaces leftover metadata</span
+                      >
+                    </div>
+                  </div>
+                </label>
+              </div>
+            </section>
+
+            <section v-if="collisionGroups.length > 0" class="section">
+              <header class="section-header">
+                <h3>Collisions ({{ preview.collisionCount }})</h3>
+                <p class="section-help">
+                  These audiobooks compute to the same canonical folder. Organizing them would
+                  clobber each other on disk. Resolve via the duplicates tool (same ASIN) or by
+                  fixing the metadata difference (different ASIN but identical
+                  <code>{Author}/{Title}</code>).
+                </p>
+              </header>
+              <div v-for="group in collisionGroups" :key="group.key" class="collision-group">
+                <div class="collision-target">→ {{ group.targetPath }}</div>
+                <ul class="collision-members">
+                  <li v-for="r in group.rows" :key="r.id">
+                    <strong>id {{ r.id }}</strong
+                    >: {{ r.title || '(no title)' }} —
+                    <em>{{ r.author || 'Unknown Author' }}</em>
+                    <div class="row-path">
+                      <span class="path-label">from</span>
+                      <span class="path-value">{{ r.currentPath || '(empty)' }}</span>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </section>
+
+            <section v-if="invalidRows.length > 0" class="section">
+              <header class="section-header">
+                <h3>Invalid target ({{ invalidRows.length }})</h3>
+                <p class="section-help">
+                  These rows can't be safely organized as-is. They're grouped by problem below, each
+                  with how to resolve it. Open any record in a new tab to fix it, then re-run the
+                  preview.
+                </p>
+              </header>
+              <div v-for="group in invalidGroups" :key="group.code" class="invalid-group">
+                <div class="invalid-group-head">
+                  <span class="invalid-group-title">{{ group.title }}</span>
+                  <span class="invalid-group-count">{{ group.rows.length }}</span>
+                </div>
+                <p v-if="group.help" class="invalid-group-help">{{ group.help }}</p>
+                <ul class="invalid-list">
+                  <li v-for="row in group.rows" :key="row.id" class="invalid-row">
+                    <div class="invalid-row-head">
+                      <strong>{{ row.title || '(no title)' }}</strong>
+                      <span class="row-author">{{ row.author || 'Unknown Author' }}</span>
+                      <a
+                        class="row-link"
+                        :href="`/audiobooks/${row.id}`"
+                        target="_blank"
+                        rel="noopener"
+                        title="Open audiobook detail in a new tab"
+                        @click.stop
+                        >id {{ row.id }} ↗</a
+                      >
+                    </div>
+                    <div class="invalid-row-paths">
+                      <div class="row-path" :title="row.currentPath || ''">
+                        <span class="path-label">from</span>
+                        <span class="path-value">{{ row.currentPath || '(empty)' }}</span>
+                      </div>
+                      <div v-if="row.targetPath" class="row-path" :title="row.targetPath">
+                        <span class="path-label">to</span>
+                        <span class="path-value path-target">{{ row.targetPath }}</span>
+                      </div>
+                    </div>
+                    <div v-if="!group.help" class="invalid-reason">{{ row.reason }}</div>
+                    <div
+                      v-if="group.code === 'target_ancestor' && !row.canFlatten"
+                      class="invalid-row-note"
+                    >
+                      Automatic flatten isn't available here — the canonical folder already holds
+                      other files. Move this book's files up a level by hand, then re-run the
+                      preview.
+                    </div>
+                    <div
+                      v-if="group.code === 'target_ancestor' && row.canFlatten"
+                      class="invalid-row-action"
+                    >
+                      <template v-if="flattenConfirmId !== row.id">
+                        <button
+                          type="button"
+                          class="link"
+                          :disabled="flatteningId !== null"
+                          @click="flattenConfirmId = row.id"
+                        >
+                          Flatten into canonical folder
+                        </button>
+                      </template>
+                      <template v-else>
+                        <span class="flatten-confirm-text">
+                          Move {{ row.fileCount }} file{{ row.fileCount === 1 ? '' : 's' }} up into
+                          the canonical folder and remove the empty subfolder?
+                        </span>
+                        <button
+                          type="button"
+                          class="link flatten-go"
+                          :disabled="flatteningId !== null"
+                          @click="flattenRow(row)"
+                        >
+                          {{ flatteningId === row.id ? 'Flattening…' : 'Confirm' }}
+                        </button>
+                        <button
+                          type="button"
+                          class="link flatten-cancel"
+                          :disabled="flatteningId !== null"
+                          @click="flattenConfirmId = null"
+                        >
+                          Cancel
+                        </button>
+                      </template>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </section>
+
+            <div
+              v-if="
+                willMoveRows.length === 0 &&
+                collisionGroups.length === 0 &&
+                invalidRows.length === 0
+              "
+              class="state-msg"
+            >
+              Nothing to organize — every audiobook is already at its canonical folder.
+            </div>
+          </template>
+        </div>
+
+        <footer v-if="!results" class="modal-footer">
+          <template v-if="!pendingConfirm">
+            <div class="footer-summary">
+              <span v-if="!loading && preview">
+                {{ selectedCount }} of {{ willMoveRows.length }} ready to move ·
+                {{ formatBytes(selectedBytes) }}
+              </span>
+              <span v-if="applyError" class="error">{{ applyError }}</span>
+            </div>
+            <div class="footer-actions">
+              <button type="button" class="btn" :disabled="applying" @click="onClose">Close</button>
+              <button
+                type="button"
+                class="btn btn-primary"
+                :disabled="applying || loading || selectedCount === 0"
+                @click="pendingConfirm = true"
+              >
+                Apply…
+              </button>
+            </div>
+          </template>
+
+          <template v-else-if="results">
+            <div class="results-panel">
+              <div class="results-title">Move queue status</div>
+              <div class="results-tally">
+                <span class="pill pill-action">{{ runningCount }} in flight</span>
+                <span class="pill pill-ok">{{ completedCount }} completed</span>
+                <span class="pill pill-err">{{ failedCount }} failed</span>
+                <span class="results-meta"
+                  >{{ queuedCount }} queued · {{ skippedCount }} skipped ·
+                  {{ failedToQueueCount }} failed to queue</span
+                >
+              </div>
+              <ul v-if="failedJobs.length > 0" class="results-failures">
+                <li v-for="job in failedJobs" :key="job.jobId">
+                  <strong>{{
+                    jobTitleFor(job.jobId) || `id ${jobAudiobookFor(job.jobId)}`
+                  }}</strong>
+                  <span class="results-error">{{
+                    jobErrorFor(job.jobId) || '(no error text)'
+                  }}</span>
+                </li>
+              </ul>
+              <ul v-if="skippedDetails.length > 0" class="results-failures">
+                <li v-for="(s, i) in skippedDetails" :key="`skip-${i}`">
+                  <strong>id {{ s.audiobookId }}</strong>
+                  <span class="results-error">{{ s.reason }}</span>
+                </li>
+              </ul>
+              <div class="confirm-actions">
+                <button type="button" class="btn" @click="onClose">Close</button>
+              </div>
+            </div>
+          </template>
+
+          <template v-else>
+            <div class="confirm-panel">
+              <div class="confirm-title">
+                About to queue {{ selectedCount }} folder move{{ selectedCount === 1 ? '' : 's' }}:
+              </div>
+              <ul class="confirm-list">
+                <li>
+                  <strong>{{ selectedCount }}</strong> audiobook{{
+                    selectedCount === 1 ? '' : 's'
+                  }}
+                  totaling {{ formatBytes(selectedBytes) }} will be moved to
+                  <code>{Author}/{Title}</code>.
+                </li>
+                <li>
+                  Each move runs through the existing background queue with the same safety checks
+                  as the per-book Organize button.
+                </li>
+              </ul>
+              <div class="confirm-warning">
+                File moves are queued but execute on disk. If your FolderNamingPattern is
+                misconfigured, books will land in the wrong place. Back up the SQLite DB before
+                running a real sweep on a live library.
+              </div>
+              <div class="confirm-actions">
+                <button
+                  type="button"
+                  class="btn"
+                  :disabled="applying"
+                  @click="pendingConfirm = false"
+                >
+                  Back
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-primary"
+                  :disabled="applying"
+                  @click="executeApply"
+                >
+                  {{ applying ? 'Queuing…' : 'Confirm and queue moves' }}
+                </button>
+              </div>
+              <div v-if="applyError" class="error confirm-error">{{ applyError }}</div>
+            </div>
+          </template>
+        </footer>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, reactive } from 'vue'
+import { PhX } from '@phosphor-icons/vue'
+import { apiService } from '@/services/api'
+import { useToast } from '@/services/toastService'
+import { signalRService } from '@/services/signalr'
+import { errorTracking } from '@/services/errorTracking'
+import MoveQueueStatusBanner from '@/components/domain/organize/MoveQueueStatusBanner.vue'
+import type {
+  OrganizeLibraryPreview,
+  OrganizeLibraryApplyResult,
+  OrganizePreviewRow,
+} from '@/types'
+
+interface JobState {
+  audiobookId: number
+  audiobookTitle: string | null
+  targetPath: string | null
+  status: string
+  error: string | null
+}
+
+const props = defineProps<{ visible: boolean }>()
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'organized', result: OrganizeLibraryApplyResult): void
+}>()
+
+const toast = useToast()
+
+const loading = ref(false)
+const loadError = ref<string | null>(null)
+const preview = ref<OrganizeLibraryPreview | null>(null)
+const selected = reactive<Record<number, boolean>>({})
+const applying = ref(false)
+const applyError = ref<string | null>(null)
+const pendingConfirm = ref(false)
+const results = ref<OrganizeLibraryApplyResult | null>(null)
+const jobs = reactive<Record<string, JobState>>({})
+let unsubMoveJob: (() => void) | null = null
+
+const queuedCount = computed(() => results.value?.queued ?? 0)
+const skippedCount = computed(() => results.value?.skipped ?? 0)
+const failedToQueueCount = computed(() => results.value?.failedToQueue ?? 0)
+const skippedDetails = computed(() => results.value?.skippedDetails ?? [])
+
+const failedJobs = computed(() => {
+  if (!results.value) return []
+  return results.value.queuedJobs.filter((j) => jobs[j.jobId]?.status === 'Failed')
+})
+const completedCount = computed(() => {
+  if (!results.value) return 0
+  return results.value.queuedJobs.filter((j) => jobs[j.jobId]?.status === 'Completed').length
+})
+const failedCount = computed(() => failedJobs.value.length)
+const runningCount = computed(() => {
+  if (!results.value) return 0
+  return results.value.queuedJobs.length - completedCount.value - failedCount.value
+})
+
+function jobTitleFor(jobId: string): string | null {
+  return jobs[jobId]?.audiobookTitle || null
+}
+function jobAudiobookFor(jobId: string): number | null {
+  return jobs[jobId]?.audiobookId ?? null
+}
+function jobErrorFor(jobId: string): string | null {
+  return jobs[jobId]?.error || null
+}
+
+const willMoveRows = computed(
+  () => preview.value?.rows.filter((r) => r.status === 'will_move') ?? [],
+)
+const invalidRows = computed(
+  () => preview.value?.rows.filter((r) => r.status === 'invalid_target') ?? [],
+)
+const collisionRows = computed(
+  () => preview.value?.rows.filter((r) => r.status === 'collision') ?? [],
+)
+
+interface CollisionGroup {
+  key: string
+  targetPath: string
+  rows: OrganizePreviewRow[]
+}
+
+const collisionGroups = computed<CollisionGroup[]>(() => {
+  const byKey = new Map<string, CollisionGroup>()
+  for (const r of collisionRows.value) {
+    const key = r.collisionKey || r.targetPath || `id-${r.id}`
+    const existing = byKey.get(key)
+    if (existing) {
+      existing.rows.push(r)
+    } else {
+      byKey.set(key, { key, targetPath: r.targetPath || '(unknown)', rows: [r] })
+    }
+  }
+  return Array.from(byKey.values()).sort((a, b) => a.targetPath.localeCompare(b.targetPath))
+})
+
+interface InvalidGroup {
+  code: string
+  title: string
+  help: string
+  rows: OrganizePreviewRow[]
+}
+
+// Human copy + resolution guidance keyed by the backend's machine-readable
+// reasonCode (OrganizeInvalidReasonCode). Order here is also the display
+// order of the groups. Keep prose here so the backend's `reason` string can
+// be reworded without touching grouping/styling. Codes not listed fall into
+// an "Other" bucket that shows each row's raw `reason` verbatim.
+const INVALID_REASON_META: Record<string, { title: string; help: string }> = {
+  missing_author: {
+    title: 'Missing author',
+    help: 'No author metadata, so no canonical folder can be built. Open the record, set an author, then re-run the preview.',
+  },
+  missing_title: {
+    title: 'Missing title',
+    help: 'No title metadata, so no canonical folder can be built. Open the record, set a title, then re-run the preview.',
+  },
+  source_at_root: {
+    title: 'Folder is the library root',
+    help: "The record's path points at a library root itself rather than the book's own subfolder. Re-scan the library to correct BasePath before organizing.",
+  },
+  target_ancestor: {
+    title: 'Nested one level too deep',
+    help: 'The files sit in an extra subfolder beneath their canonical folder (a historical import artifact). Where the canonical folder is otherwise empty, use "Flatten" to collapse it in one click; where it already holds other files, the button is hidden — move those up a level on disk by hand first.',
+  },
+  source_missing: {
+    title: 'Files missing on disk',
+    help: "The record's folder no longer exists on disk — its files are gone (a stale record left by an earlier move or deletion). Re-scan the library to clear it, or open the record and remove it.",
+  },
+  target_exists: {
+    title: 'Canonical folder already occupied',
+    help: 'Another folder already exists at the canonical path (shown under "to") and contains files — usually a leftover duplicate copy from an earlier import. Check the Duplicates tool to see if it is a tracked duplicate you can resolve there; otherwise remove or merge the stale folder on disk, then re-run the preview.',
+  },
+  outside_root: {
+    title: 'Outside library roots',
+    help: 'This book lives outside every configured library root. Add the root (or move the folder under one) and re-scan, then re-run the preview.',
+  },
+  pattern_not_configured: {
+    title: 'Naming pattern not configured',
+    help: 'No Folder Naming Pattern is set. Configure one under Settings → Media Management, then re-run the preview.',
+  },
+  empty_pattern: {
+    title: 'Pattern produced an empty path',
+    help: "The naming pattern rendered to an empty path for this book's metadata. Check the pattern and the record's fields.",
+  },
+}
+
+const invalidGroups = computed<InvalidGroup[]>(() => {
+  const order = Object.keys(INVALID_REASON_META)
+  const byCode = new Map<string, InvalidGroup>()
+  for (const r of invalidRows.value) {
+    const code = r.reasonCode || 'other'
+    let group = byCode.get(code)
+    if (!group) {
+      const meta = INVALID_REASON_META[code]
+      group = { code, title: meta?.title || 'Other', help: meta?.help || '', rows: [] }
+      byCode.set(code, group)
+    }
+    group.rows.push(r)
+  }
+  return Array.from(byCode.values()).sort((a, b) => {
+    const ia = order.indexOf(a.code)
+    const ib = order.indexOf(b.code)
+    return (ia < 0 ? 999 : ia) - (ib < 0 ? 999 : ib)
+  })
+})
+
+// Per-row "flatten" action for the nested-one-level-too-deep group. Tracks
+// which row is awaiting confirmation and which is mid-request so the buttons
+// can disable/spinner without a heavier state machine.
+const flattenConfirmId = ref<number | null>(null)
+const flatteningId = ref<number | null>(null)
+
+async function flattenRow(row: OrganizePreviewRow) {
+  flatteningId.value = row.id
+  try {
+    const res = await apiService.flattenOrganizeRow(row.id)
+    if (res.success) {
+      const label = row.title || `id ${row.id}`
+      const suffix = res.error ? ` — ${res.error}` : ''
+      toast.success(
+        'Organize library',
+        `Flattened "${label}" (${res.filesMoved} file${res.filesMoved === 1 ? '' : 's'})${suffix}`,
+      )
+      await load()
+    } else {
+      toast.error('Flatten failed', res.error || 'Unknown error')
+    }
+  } catch (err) {
+    toast.error('Flatten failed', err instanceof Error ? err.message : 'Unknown error')
+    errorTracking.captureException(err as Error, {
+      component: 'OrganizeLibraryModal',
+      operation: 'flatten',
+    })
+  } finally {
+    flatteningId.value = null
+    flattenConfirmId.value = null
+  }
+}
+
+const selectedCount = computed(
+  () => willMoveRows.value.filter((r) => selected[r.id] === true).length,
+)
+const selectedBytes = computed(() =>
+  willMoveRows.value
+    .filter((r) => selected[r.id] === true)
+    .reduce((acc, r) => acc + (r.totalSize || 0), 0),
+)
+
+function onToggleRow(id: number, checked: boolean) {
+  selected[id] = checked
+}
+
+function toggleAll(checked: boolean) {
+  for (const r of willMoveRows.value) selected[r.id] = checked
+}
+
+async function load() {
+  loading.value = true
+  loadError.value = null
+  applyError.value = null
+  for (const k of Object.keys(selected)) delete selected[Number(k)]
+  for (const k of Object.keys(jobs)) delete jobs[k]
+  results.value = null
+  unsubscribeMoveJobs()
+  pendingConfirm.value = false
+  try {
+    const resp = await apiService.getOrganizeLibraryPreview()
+    preview.value = resp
+    // Default every will_move row to selected so the user starts from "move everything".
+    for (const r of resp.rows) {
+      if (r.status === 'will_move') selected[r.id] = true
+    }
+  } catch (err) {
+    loadError.value = err instanceof Error ? err.message : 'Unknown error'
+    errorTracking.captureException(err as Error, {
+      component: 'OrganizeLibraryModal',
+      operation: 'load',
+    })
+  } finally {
+    loading.value = false
+  }
+}
+
+async function executeApply() {
+  applyError.value = null
+  const ids = willMoveRows.value.filter((r) => selected[r.id] === true).map((r) => r.id)
+  if (ids.length === 0) {
+    applyError.value = 'Nothing selected to move.'
+    return
+  }
+  applying.value = true
+  try {
+    const result = await apiService.applyOrganizeLibrary(ids)
+    emit('organized', result)
+    // Seed jobs state from the apply response so the results panel can
+    // render immediately; SignalR MoveJobUpdate then fills in error text
+    // as each background move finishes (Completed or Failed).
+    for (const k of Object.keys(jobs)) delete jobs[k]
+    for (const j of result.queuedJobs) {
+      jobs[j.jobId] = {
+        audiobookId: j.audiobookId,
+        audiobookTitle: j.audiobookTitle,
+        targetPath: j.targetPath,
+        status: 'Queued',
+        error: null,
+      }
+    }
+    subscribeMoveJobs()
+    results.value = result
+    const parts: string[] = [`Queued ${result.queued} move${result.queued === 1 ? '' : 's'}`]
+    if (result.skipped > 0) parts.push(`${result.skipped} skipped`)
+    if (result.failedToQueue > 0) parts.push(`${result.failedToQueue} failed to queue`)
+    const summary = parts.join(', ')
+    if (result.failedToQueue > 0 || result.warnings.length > 0) {
+      toast.warning('Organize library', summary)
+    } else {
+      toast.success('Organize library', summary)
+    }
+  } catch (err) {
+    applyError.value = err instanceof Error ? err.message : 'Unknown error'
+    errorTracking.captureException(err as Error, {
+      component: 'OrganizeLibraryModal',
+      operation: 'apply',
+    })
+  } finally {
+    applying.value = false
+  }
+}
+
+function subscribeMoveJobs() {
+  if (unsubMoveJob) return
+  unsubMoveJob = signalRService.onMoveJobUpdate((job) => {
+    if (!job || !job.jobId) return
+    const existing = jobs[job.jobId]
+    if (!existing) return // not one of ours
+    existing.status = job.status
+    existing.error = job.error || null
+  })
+}
+
+function unsubscribeMoveJobs() {
+  if (unsubMoveJob) {
+    try {
+      unsubMoveJob()
+    } catch {
+      /* ignore */
+    }
+    unsubMoveJob = null
+  }
+}
+
+function onClose() {
+  if (applying.value) return
+  unsubscribeMoveJobs()
+  emit('close')
+}
+
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes <= 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let n = bytes
+  let i = 0
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024
+    i++
+  }
+  return `${n.toFixed(n >= 100 || i === 0 ? 0 : 1)} ${units[i]}`
+}
+
+watch(
+  () => props.visible,
+  (v) => {
+    if (v) {
+      preview.value = null
+      void load()
+    }
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 3000;
+  padding: 1rem;
+}
+.modal {
+  background: #1a1a1a;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 1100px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+.modal-header h2 {
+  font-size: 16px;
+  margin: 0;
+  color: #fff;
+}
+.modal-close {
+  background: transparent;
+  border: 0;
+  color: #aaa;
+  cursor: pointer;
+  font-size: 18px;
+}
+.modal-close:hover {
+  color: #fff;
+}
+.modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 16px;
+}
+.modal-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.footer-summary {
+  font-size: 12px;
+  color: #aaa;
+}
+.footer-summary .error {
+  color: #f06060;
+  display: block;
+  margin-top: 4px;
+}
+.footer-actions {
+  display: flex;
+  gap: 8px;
+}
+.help-text {
+  font-size: 12px;
+  color: #bbb;
+  margin: 0 0 14px;
+  line-height: 1.5;
+}
+.help-text code {
+  background: rgba(255, 255, 255, 0.06);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+.bucket-summary {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  border: 1px solid transparent;
+}
+.pill-action {
+  background: rgba(42, 111, 208, 0.16);
+  color: #6fa8e8;
+  border-color: rgba(42, 111, 208, 0.25);
+}
+.pill-ok {
+  background: rgba(96, 192, 128, 0.12);
+  color: #80c896;
+  border-color: rgba(96, 192, 128, 0.2);
+}
+.pill-warn {
+  background: rgba(240, 176, 96, 0.12);
+  color: #e8b070;
+  border-color: rgba(176, 128, 64, 0.3);
+}
+.pill-err {
+  background: rgba(240, 96, 96, 0.12);
+  color: #f06060;
+  border-color: rgba(176, 64, 64, 0.3);
+}
+.results-panel {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.results-title {
+  font-size: 13px;
+  color: #fff;
+  font-weight: 600;
+}
+.results-tally {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.results-meta {
+  font-size: 11px;
+  color: #999;
+}
+.results-failures {
+  margin: 0;
+  padding-left: 16px;
+  color: #ddd;
+  font-size: 12px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+.results-failures li {
+  margin-bottom: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.results-failures strong {
+  color: #fff;
+  font-size: 12px;
+}
+.results-error {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+  color: #f06060;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.section {
+  margin-bottom: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.015);
+}
+.section-header {
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.section-header h3 {
+  margin: 0;
+  font-size: 13px;
+  color: #fff;
+}
+.section-help {
+  width: 100%;
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: #aaa;
+  line-height: 1.45;
+}
+.section-tools {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  color: #999;
+}
+.section-count {
+  color: #ccc;
+}
+.link {
+  background: transparent;
+  border: 0;
+  color: #6fa8e8;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+}
+.link:hover {
+  text-decoration: underline;
+}
+.rows {
+  padding: 4px 0;
+}
+.row {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  cursor: pointer;
+}
+.row:last-child {
+  border-bottom: 0;
+}
+.row:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+.row input[type='checkbox'] {
+  margin-top: 4px;
+  flex-shrink: 0;
+}
+.row-body {
+  flex: 1;
+  min-width: 0;
+}
+.row-title {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+.row-title strong {
+  color: #fff;
+  font-size: 13px;
+}
+.row-author {
+  color: #aaa;
+  font-size: 12px;
+}
+.row-paths {
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.row-path {
+  display: flex;
+  gap: 6px;
+  font-size: 11px;
+  color: #999;
+  overflow: hidden;
+}
+.path-label {
+  flex-shrink: 0;
+  color: #777;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.path-value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.path-target {
+  color: #80c896;
+}
+.row-meta {
+  margin-top: 3px;
+  font-size: 11px;
+  color: #777;
+}
+.stub-replace-tag {
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  border: 1px solid rgba(230, 175, 46, 0.45);
+  background: rgba(230, 175, 46, 0.12);
+  color: #e6af2e;
+  cursor: help;
+}
+.collision-group {
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+}
+.collision-group:last-child {
+  border-bottom: 0;
+}
+.collision-target {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  color: #e8b070;
+  margin-bottom: 6px;
+}
+.collision-members {
+  margin: 0;
+  padding-left: 16px;
+  color: #ccc;
+  font-size: 12px;
+}
+.collision-members li {
+  margin-bottom: 4px;
+}
+.invalid-group {
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+}
+.invalid-group:last-child {
+  border-bottom: 0;
+}
+.invalid-group-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.invalid-group-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #e8b070;
+}
+.invalid-group-count {
+  font-size: 11px;
+  color: #aaa;
+  background: rgba(240, 176, 96, 0.12);
+  border: 1px solid rgba(176, 128, 64, 0.3);
+  border-radius: 999px;
+  padding: 1px 8px;
+}
+.invalid-group-help {
+  margin: 5px 0 8px;
+  font-size: 12px;
+  color: #aaa;
+  line-height: 1.45;
+}
+.invalid-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: #ccc;
+  font-size: 12px;
+}
+.invalid-row {
+  padding: 6px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.03);
+}
+.invalid-row:first-child {
+  border-top: 0;
+}
+.invalid-row-head {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+.invalid-row-head strong {
+  color: #fff;
+  font-size: 12px;
+}
+.invalid-row-paths {
+  margin-top: 3px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.row-link {
+  font-size: 11px;
+  color: #6fa8e8;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.row-link:hover {
+  text-decoration: underline;
+}
+.invalid-reason {
+  margin-top: 3px;
+  color: #e8b070;
+}
+.invalid-row-note {
+  margin-top: 4px;
+  font-size: 11px;
+  color: #999;
+  font-style: italic;
+}
+.invalid-row-action {
+  margin-top: 5px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.flatten-confirm-text {
+  font-size: 11px;
+  color: #e8b070;
+}
+.flatten-go {
+  color: #80c896;
+  font-weight: 600;
+}
+.flatten-cancel {
+  color: #999;
+}
+.btn {
+  padding: 6px 14px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  color: #ddd;
+  font-size: 13px;
+  cursor: pointer;
+}
+.btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn-primary {
+  background: #2a6fd0;
+  border-color: #2a6fd0;
+  color: #fff;
+}
+.btn-primary:hover:not(:disabled) {
+  background: #3380e5;
+}
+.confirm-panel {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.confirm-title {
+  font-size: 13px;
+  color: #fff;
+  font-weight: 600;
+}
+.confirm-list {
+  margin: 0;
+  padding-left: 18px;
+  color: #ddd;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.confirm-list li {
+  margin-bottom: 2px;
+}
+.confirm-list code {
+  background: rgba(255, 255, 255, 0.06);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+.confirm-warning {
+  font-size: 12px;
+  color: #f0b060;
+  padding: 6px 10px;
+  background: rgba(240, 176, 96, 0.08);
+  border-left: 3px solid #b08040;
+  border-radius: 3px;
+}
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+.confirm-error {
+  font-size: 12px;
+}
+.state-msg {
+  padding: 24px 8px;
+  text-align: center;
+  color: #aaa;
+}
+.state-msg.error {
+  color: #f06060;
+}
+.error {
+  color: #f06060;
+}
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 0.18s ease;
+}
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/fe/src/components/settings/LibraryMaintenanceSection.vue
+++ b/fe/src/components/settings/LibraryMaintenanceSection.vue
@@ -1,0 +1,114 @@
+<!--
+  Listenarr - Audiobook Management System
+  Copyright (C) 2024-2026 Listenarr Contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<template>
+  <div class="settings-section">
+    <h3><PhWrench /> Library Maintenance</h3>
+
+    <!-- Live move-queue status: in-flight moves, queue depth, recent failures. -->
+    <MoveQueueStatusBanner />
+
+    <div class="maintenance-action">
+      <div class="maintenance-action-text">
+        <strong>Organize library</strong>
+        <small>
+          Preview every audiobook against the folder your naming pattern computes for it, then queue
+          background moves for the ones you confirm. Read-only until you apply.
+        </small>
+      </div>
+      <button type="button" class="action-button" @click="showOrganizeModal = true">
+        <PhFolderOpen />
+        Organize library…
+      </button>
+    </div>
+
+    <OrganizeLibraryModal :visible="showOrganizeModal" @close="showOrganizeModal = false" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { PhWrench, PhFolderOpen } from '@phosphor-icons/vue'
+import OrganizeLibraryModal from '@/components/domain/organize/OrganizeLibraryModal.vue'
+import MoveQueueStatusBanner from '@/components/domain/organize/MoveQueueStatusBanner.vue'
+
+const showOrganizeModal = ref(false)
+</script>
+
+<style scoped>
+.settings-section {
+  margin-top: 2rem;
+}
+
+.settings-section h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #fff;
+  font-size: 1.15rem;
+  font-weight: 500;
+  margin: 0 0 1rem;
+}
+
+.maintenance-action {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  margin-top: 1rem;
+}
+
+.maintenance-action-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.maintenance-action-text strong {
+  color: #fff;
+}
+
+.maintenance-action-text small {
+  color: #8a93a0;
+  max-width: 46rem;
+  line-height: 1.5;
+}
+
+.action-button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.1rem;
+  background: rgba(var(--brand-rgb), 0.1);
+  border: 1px solid var(--brand-500);
+  border-radius: 6px;
+  color: var(--brand-500);
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.action-button:hover {
+  background: rgba(var(--brand-rgb), 0.2);
+}
+</style>

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -60,6 +60,10 @@ import type {
   RenamePreview,
   RenameOperation,
   RenameResult,
+  OrganizeLibraryPreview,
+  OrganizeLibraryApplyResult,
+  OrganizeFlattenResult,
+  MoveQueueSummary,
 } from '@/types'
 import { getStartupConfigCached, resetCache as resetStartupConfigCache } from './startupConfigCache'
 import { sessionTokenManager } from '@/utils/sessionToken'
@@ -1236,6 +1240,43 @@ class ApiService {
       method: 'POST',
       body: JSON.stringify(body),
     })
+  }
+
+  async getOrganizeLibraryPreview(): Promise<OrganizeLibraryPreview> {
+    return this.request<OrganizeLibraryPreview>(`/library/organize/preview`, {
+      method: 'GET',
+    })
+  }
+
+  async applyOrganizeLibrary(audiobookIds: number[]): Promise<OrganizeLibraryApplyResult> {
+    return this.request<OrganizeLibraryApplyResult>(`/library/organize/apply`, {
+      method: 'POST',
+      body: JSON.stringify({ audiobookIds }),
+    })
+  }
+
+  /**
+   * Collapse a single nested-one-level-too-deep row into its canonical parent
+   * folder. Only valid for `target_ancestor` invalid rows; the server
+   * re-validates and refuses anything else.
+   */
+  async flattenOrganizeRow(audiobookId: number): Promise<OrganizeFlattenResult> {
+    return this.request<OrganizeFlattenResult>(`/library/organize/flatten`, {
+      method: 'POST',
+      body: JSON.stringify({ audiobookId }),
+    })
+  }
+
+  /**
+   * Read the persisted move-queue state — status counts plus the most-recent
+   * completed and failed jobs. Backs the in-modal and Maintenance-page
+   * progress banner. `recentLimit` is clamped to [0, 200] server-side.
+   */
+  async getMoveQueueSummary(recentLimit = 5): Promise<MoveQueueSummary> {
+    return this.request<MoveQueueSummary>(
+      `/library/move/summary?recentLimit=${encodeURIComponent(String(recentLimit))}`,
+      { method: 'GET' },
+    )
   }
 
   async removeFromLibrary(

--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -1109,3 +1109,130 @@ export interface RenameResult {
   error?: string
   renamedFiles: FileRenameResultItem[]
 }
+
+/**
+ * One audiobook in the organize-library preview. The server has bucketed
+ * each row into one of `already_canonical` / `will_move` / `collision` /
+ * `invalid_target` based on the configured FolderNamingPattern.
+ */
+export type OrganizePreviewStatus =
+  | 'already_canonical'
+  | 'will_move'
+  | 'collision'
+  | 'invalid_target'
+
+export interface OrganizePreviewRow {
+  id: number
+  title: string | null
+  author: string | null
+  currentPath: string | null
+  targetPath: string | null
+  fileCount: number
+  totalSize: number
+  status: OrganizePreviewStatus
+  /** Set when status is `collision` — the shared normalized target. */
+  collisionKey: string | null
+  /** Set when status is `invalid_target` — the human-readable reason. */
+  reason: string | null
+  /**
+   * Set when status is `invalid_target` — machine-readable companion to
+   * `reason`. One of the `OrganizeInvalidReasonCode` values the backend emits
+   * (`missing_title`, `missing_author`, `source_at_root`, `target_ancestor`,
+   * `target_exists`, `source_missing`, …). The UI groups invalid rows by this code.
+   */
+  reasonCode: string | null
+  /**
+   * True only for `target_ancestor` rows that pass the backend's read-only
+   * flatten feasibility check. The UI shows the one-click "Flatten" action only
+   * when this is true.
+   */
+  canFlatten: boolean
+  /**
+   * True for `will_move` rows whose target folder exists on disk but holds only
+   * leftover metadata (no audio, nothing referenced by the DB). The move will
+   * replace the stub.
+   */
+  replacesStubTarget: boolean
+}
+
+/**
+ * One row in the currently-processing / recent-completed / recent-failed
+ * tails of a `GET /library/move/summary` response. Mirrors `MoveJob`
+ * fields the summary endpoint projects, plus the audiobook's title and
+ * per-job file count / total bytes so the UI can show size context
+ * without a second round-trip.
+ */
+export interface MoveQueueJobSummary {
+  id: string
+  audiobookId: number
+  audiobookTitle: string | null
+  status: string
+  error: string | null
+  requestedPath: string | null
+  sourcePath: string | null
+  enqueuedAt: string
+  updatedAt: string | null
+  attemptCount: number
+  /** Number of tracked AudiobookFile rows for the referenced audiobook. */
+  fileCount: number
+  /** Sum of AudiobookFile.Size (bytes) for the referenced audiobook. 0 when unknown. */
+  totalBytes: number
+}
+
+/**
+ * Shape returned by `GET /library/move/summary`. `total` is the sum of
+ * every non-purged MoveJob row; the per-status counts always sum to it
+ * (with anything unrecognized falling into `other` so the UI never
+ * silently drops a count). `queuedFiles` / `queuedBytes` aggregate
+ * across all Queued rows so the banner can show "queue: N files, M GB
+ * remaining" for ETA context.
+ */
+export interface MoveQueueSummary {
+  total: number
+  queued: number
+  processing: number
+  completed: number
+  failed: number
+  other: number
+  queuedFiles: number
+  queuedBytes: number
+  currentlyProcessing: MoveQueueJobSummary[]
+  recentCompleted: MoveQueueJobSummary[]
+  recentFailed: MoveQueueJobSummary[]
+}
+
+export interface OrganizeLibraryPreview {
+  rows: OrganizePreviewRow[]
+  alreadyCanonicalCount: number
+  willMoveCount: number
+  collisionCount: number
+  invalidTargetCount: number
+}
+
+export interface OrganizeApplySkipped {
+  audiobookId: number
+  reason: string
+}
+
+export interface OrganizeFlattenResult {
+  success: boolean
+  filesMoved: number
+  newPath: string | null
+  error: string | null
+}
+
+export interface OrganizeQueuedJob {
+  jobId: string
+  audiobookId: number
+  audiobookTitle: string | null
+  targetPath: string | null
+}
+
+export interface OrganizeLibraryApplyResult {
+  queued: number
+  skipped: number
+  failedToQueue: number
+  queuedJobs: OrganizeQueuedJob[]
+  skippedDetails: OrganizeApplySkipped[]
+  warnings: string[]
+}

--- a/fe/src/views/settings/GeneralSettingsTab.vue
+++ b/fe/src/views/settings/GeneralSettingsTab.vue
@@ -56,6 +56,7 @@
           @update:settings="(val) => Object.assign(localSettings, val)"
           @update:apiKey="(val) => emit('update:apiKey', val)"
         ></AuthenticationSection>
+        <LibraryMaintenanceSection />
       </div>
       <!-- settings-form -->
     </div>
@@ -74,6 +75,7 @@ import DownloadSettingsSection from '@/components/settings/DownloadSettingsSecti
 import FeaturesSection from '@/components/settings/FeaturesSection.vue'
 import SearchSettingsSection from '@/components/settings/SearchSettingsSection.vue'
 import AuthenticationSection from '@/components/settings/AuthenticationSection.vue'
+import LibraryMaintenanceSection from '@/components/settings/LibraryMaintenanceSection.vue'
 
 interface Props {
   settings: ApplicationSettings | null

--- a/listenarr.api/Features/Library/LibraryController.Organize.cs
+++ b/listenarr.api/Features/Library/LibraryController.Organize.cs
@@ -1,0 +1,75 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Api.Features.Library
+{
+    public partial class LibraryController
+    {
+        /// <summary>
+        /// Aggregate view of the background move queue (counts + in-flight +
+        /// recent tails) for the maintenance banner.
+        /// </summary>
+        /// <param name="recentLimit">How many recent completed/failed jobs to include (clamped to [0, 200]).</param>
+        /// <param name="ct">Cancellation token bound to the request.</param>
+        [HttpGet("move/summary")]
+        public async Task<IActionResult> GetMoveQueueSummary([FromQuery] int recentLimit = 25, CancellationToken ct = default)
+        {
+            return await _moveSummaryWorkflow.SummaryAsync(recentLimit, ct);
+        }
+
+        /// <summary>
+        /// Preview the library-wide Organize sweep: bucket every audiobook
+        /// into already_canonical / will_move / collision / invalid_target
+        /// against the path its metadata computes to. Read-only.
+        /// </summary>
+        /// <param name="ct">Cancellation token bound to the request.</param>
+        [HttpGet("organize/preview")]
+        public async Task<IActionResult> GetOrganizePreview(CancellationToken ct)
+        {
+            return await _organizeSweepWorkflow.PreviewAsync(ct);
+        }
+
+        /// <summary>
+        /// Queue a background move for each confirmed preview row. Every id is
+        /// re-validated against live state before queuing; rows that no longer
+        /// qualify are skipped with a reason instead of aborting the rest.
+        /// </summary>
+        /// <param name="request">Audiobook ids confirmed in the preview UI.</param>
+        /// <param name="ct">Cancellation token bound to the request.</param>
+        [HttpPost("organize/apply")]
+        public async Task<IActionResult> ApplyOrganize([FromBody] OrganizeLibraryApplyRequest request, CancellationToken ct)
+        {
+            return await _organizeSweepWorkflow.ApplyAsync(request, ct);
+        }
+
+        /// <summary>
+        /// Collapse a single "nested one level too deep" preview row into its
+        /// canonical parent folder. Strongly guarded — only empty wrapper
+        /// directories are ever collapsed.
+        /// </summary>
+        /// <param name="request">The audiobook id of the nested row.</param>
+        /// <param name="ct">Cancellation token bound to the request.</param>
+        [HttpPost("organize/flatten")]
+        public async Task<IActionResult> FlattenOrganize([FromBody] OrganizeFlattenRequest request, CancellationToken ct)
+        {
+            return await _organizeSweepWorkflow.FlattenAsync(request, ct);
+        }
+    }
+}

--- a/listenarr.api/Features/Library/LibraryController.cs
+++ b/listenarr.api/Features/Library/LibraryController.cs
@@ -40,6 +40,8 @@ namespace Listenarr.Api.Features.Library
         private readonly LibraryPreviewPathWorkflow _previewPathWorkflow;
         private readonly LibraryQueryWorkflow _queryWorkflow;
         private readonly LibraryRenameWorkflow _renameWorkflow;
+        private readonly LibraryOrganizeSweepWorkflow _organizeSweepWorkflow;
+        private readonly LibraryMoveSummaryWorkflow _moveSummaryWorkflow;
         /// <summary>Initializes the library transport façade.</summary>
         public LibraryController(
             ILibraryListService libraryListService,
@@ -55,7 +57,9 @@ namespace Listenarr.Api.Features.Library
             LibraryIdentifierWorkflow identifierWorkflow,
             LibraryPreviewPathWorkflow previewPathWorkflow,
             LibraryQueryWorkflow queryWorkflow,
-            LibraryRenameWorkflow renameWorkflow)
+            LibraryRenameWorkflow renameWorkflow,
+            LibraryOrganizeSweepWorkflow organizeSweepWorkflow,
+            LibraryMoveSummaryWorkflow moveSummaryWorkflow)
         {
             _libraryListService = libraryListService;
             _addWorkflow = addWorkflow;
@@ -71,6 +75,8 @@ namespace Listenarr.Api.Features.Library
             _previewPathWorkflow = previewPathWorkflow;
             _queryWorkflow = queryWorkflow;
             _renameWorkflow = renameWorkflow;
+            _organizeSweepWorkflow = organizeSweepWorkflow;
+            _moveSummaryWorkflow = moveSummaryWorkflow;
         }
 
         /// <summary>

--- a/listenarr.api/Features/Library/LibraryMoveSummaryWorkflow.cs
+++ b/listenarr.api/Features/Library/LibraryMoveSummaryWorkflow.cs
@@ -1,0 +1,152 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Api.Features.Library
+{
+    /// <summary>
+    /// Aggregate view of the background move queue for the maintenance UI:
+    /// per-status counts, the jobs processing right now, and short tails of
+    /// recent completions/failures — each annotated with the audiobook's title
+    /// and file count/bytes so the banner can say "moving X (12 files, 3.4 GB)"
+    /// and "queue: N files, M GB remaining".
+    /// </summary>
+    public sealed class LibraryMoveSummaryWorkflow
+    {
+        private readonly IMoveJobRepository _moveJobRepository;
+        private readonly IAudiobookRepository _audiobookRepository;
+        private readonly IAudiobookFileRepository _audioFileRepository;
+
+        public LibraryMoveSummaryWorkflow(
+            IMoveJobRepository moveJobRepository,
+            IAudiobookRepository audiobookRepository,
+            IAudiobookFileRepository audioFileRepository)
+        {
+            _moveJobRepository = moveJobRepository;
+            _audiobookRepository = audiobookRepository;
+            _audioFileRepository = audioFileRepository;
+        }
+
+        public async Task<IActionResult> SummaryAsync(int recentLimit, CancellationToken ct)
+        {
+            if (recentLimit < 0) recentLimit = 0;
+            if (recentLimit > 200) recentLimit = 200;
+
+            var all = await _moveJobRepository.GetAllAsync(ct);
+
+            var byStatus = all
+                .GroupBy(j => j.Status ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.Count(), StringComparer.OrdinalIgnoreCase);
+
+            int CountOf(string s) => byStatus.TryGetValue(s, out var n) ? n : 0;
+
+            var recentCompleted = all
+                .Where(j => string.Equals(j.Status, "Completed", StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(j => j.UpdatedAt ?? j.EnqueuedAt)
+                .Take(recentLimit)
+                .ToList();
+            var recentFailed = all
+                .Where(j => string.Equals(j.Status, "Failed", StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(j => j.UpdatedAt ?? j.EnqueuedAt)
+                .Take(recentLimit)
+                .ToList();
+            var processingNow = all
+                .Where(j => string.Equals(j.Status, "Processing", StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(j => j.UpdatedAt ?? j.EnqueuedAt)
+                .ToList();
+            var queuedNow = all
+                .Where(j => string.Equals(j.Status, "Queued", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            // File counts + byte totals + titles for the in-scope audiobooks so
+            // the banner can render meaningful per-job and per-queue size info.
+            var inScopeAudiobookIds = new HashSet<int>();
+            foreach (var j in recentCompleted) inScopeAudiobookIds.Add(j.AudiobookId);
+            foreach (var j in recentFailed) inScopeAudiobookIds.Add(j.AudiobookId);
+            foreach (var j in processingNow) inScopeAudiobookIds.Add(j.AudiobookId);
+            foreach (var j in queuedNow) inScopeAudiobookIds.Add(j.AudiobookId);
+
+            var fileStatsByAudiobookId = new Dictionary<int, (int Count, long Bytes)>();
+            var titlesByAudiobookId = new Dictionary<int, string?>();
+            if (inScopeAudiobookIds.Count > 0)
+            {
+                var allFiles = await _audioFileRepository.GetAllAsync(ct);
+                fileStatsByAudiobookId = allFiles
+                    .Where(f => inScopeAudiobookIds.Contains(f.AudiobookId))
+                    .GroupBy(f => f.AudiobookId)
+                    .ToDictionary(g => g.Key, g => (g.Count(), g.Sum(f => f.Size ?? 0L)));
+
+                var allAudiobooks = await _audiobookRepository.GetAllAsync();
+                titlesByAudiobookId = allAudiobooks
+                    .Where(a => inScopeAudiobookIds.Contains(a.Id))
+                    .ToDictionary(a => a.Id, a => a.Title);
+            }
+
+            (int FileCount, long TotalBytes) StatsFor(int audiobookId) =>
+                fileStatsByAudiobookId.TryGetValue(audiobookId, out var s) ? s : (0, 0L);
+
+            object Project(MoveJob j)
+            {
+                var (fc, tb) = StatsFor(j.AudiobookId);
+                titlesByAudiobookId.TryGetValue(j.AudiobookId, out var title);
+                return new
+                {
+                    id = j.Id,
+                    audiobookId = j.AudiobookId,
+                    audiobookTitle = title,
+                    status = j.Status,
+                    error = j.Error,
+                    requestedPath = j.RequestedPath,
+                    sourcePath = j.SourcePath,
+                    enqueuedAt = j.EnqueuedAt,
+                    updatedAt = j.UpdatedAt,
+                    attemptCount = j.AttemptCount,
+                    fileCount = fc,
+                    totalBytes = tb,
+                };
+            }
+
+            var queuedFiles = 0;
+            var queuedBytes = 0L;
+            foreach (var j in queuedNow)
+            {
+                var (fc, tb) = StatsFor(j.AudiobookId);
+                queuedFiles += fc;
+                queuedBytes += tb;
+            }
+
+            return new OkObjectResult(new
+            {
+                total = all.Count,
+                queued = CountOf("Queued"),
+                processing = CountOf("Processing"),
+                completed = CountOf("Completed"),
+                failed = CountOf("Failed"),
+                // Any status the server hasn't seen the producer use yet falls
+                // into a residual bucket so the FE never silently drops a count.
+                other = all.Count - CountOf("Queued") - CountOf("Processing") - CountOf("Completed") - CountOf("Failed"),
+                queuedFiles,
+                queuedBytes,
+                currentlyProcessing = processingNow.Select(Project).ToList(),
+                recentCompleted = recentCompleted.Select(Project).ToList(),
+                recentFailed = recentFailed.Select(Project).ToList(),
+            });
+        }
+    }
+}

--- a/listenarr.api/Features/Library/LibraryOrganizeModels.cs
+++ b/listenarr.api/Features/Library/LibraryOrganizeModels.cs
@@ -1,0 +1,181 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Listenarr.Api.Features.Library
+{
+    /// <summary>
+    /// Bucket assigned to each audiobook in the organize-library preview.
+    /// </summary>
+    public static class OrganizePreviewStatus
+    {
+        public const string AlreadyCanonical = "already_canonical";
+        public const string WillMove = "will_move";
+        public const string Collision = "collision";
+        public const string InvalidTarget = "invalid_target";
+    }
+
+    /// <summary>
+    /// Machine-readable code accompanying an <c>invalid_target</c> row's
+    /// human-readable <see cref="OrganizePreviewRowDto.Reason"/>. Lets the UI
+    /// group rows by failure kind and pick the right "how to resolve" copy /
+    /// action without parsing the prose reason string (the prose may be
+    /// reworded freely without breaking the frontend or tests).
+    /// </summary>
+    public static class OrganizeInvalidReasonCode
+    {
+        /// <summary>Title metadata is blank — no canonical path can be built.</summary>
+        public const string MissingTitle = "missing_title";
+        /// <summary>Author metadata is blank — no canonical path can be built.</summary>
+        public const string MissingAuthor = "missing_author";
+        /// <summary>No <c>FolderNamingPattern</c> is configured.</summary>
+        public const string PatternNotConfigured = "pattern_not_configured";
+        /// <summary>Current path lives outside every configured library root.</summary>
+        public const string OutsideRoot = "outside_root";
+        /// <summary>The naming pattern rendered to an empty path for this row.</summary>
+        public const string EmptyPattern = "empty_pattern";
+        /// <summary>BasePath equals a library root folder — re-scan needed.</summary>
+        public const string SourceAtRoot = "source_at_root";
+        /// <summary>Target is an ancestor of source (move would flatten/nest-collapse).</summary>
+        public const string TargetAncestor = "target_ancestor";
+        /// <summary>Target directory already exists on disk and contains files.</summary>
+        public const string TargetExists = "target_exists";
+        /// <summary>
+        /// An ancestor/nested row whose source folder no longer exists on disk —
+        /// the record's files are gone. Re-scan the library or remove the record.
+        /// </summary>
+        public const string SourceMissing = "source_missing";
+    }
+
+    /// <summary>
+    /// One row in the organize-library preview. Computed by applying the
+    /// configured <c>FolderNamingPattern</c> to the audiobook's metadata and
+    /// comparing the resulting path against the current <c>BasePath</c>.
+    /// </summary>
+    public class OrganizePreviewRowDto
+    {
+        public int Id { get; set; }
+        public string? Title { get; set; }
+        public string? Author { get; set; }
+        public string? CurrentPath { get; set; }
+        public string? TargetPath { get; set; }
+        public int FileCount { get; set; }
+        public long TotalSize { get; set; }
+        /// <summary>One of <see cref="OrganizePreviewStatus"/>.</summary>
+        public string Status { get; set; } = string.Empty;
+        /// <summary>
+        /// Set when <see cref="Status"/> is <c>collision</c> — the normalized
+        /// target path shared by multiple audiobooks. Lets the UI group
+        /// collision rows together.
+        /// </summary>
+        public string? CollisionKey { get; set; }
+        /// <summary>
+        /// Set when <see cref="Status"/> is <c>invalid_target</c> — the
+        /// reason the target couldn't be computed (e.g. "Missing author").
+        /// </summary>
+        public string? Reason { get; set; }
+        /// <summary>
+        /// Set when <see cref="Status"/> is <c>invalid_target</c> — the
+        /// machine-readable companion to <see cref="Reason"/>. One of
+        /// <see cref="OrganizeInvalidReasonCode"/>. The UI groups invalid rows
+        /// by this code and renders per-kind resolution guidance.
+        /// </summary>
+        public string? ReasonCode { get; set; }
+        /// <summary>
+        /// True only for <c>invalid_target</c> rows whose <see cref="ReasonCode"/>
+        /// is <c>target_ancestor</c> and that pass the read-only flatten
+        /// feasibility check (source exists on disk, target holds no foreign
+        /// files). The UI shows the one-click "Flatten" action only when this is
+        /// true, so it never offers a flatten the executor would refuse.
+        /// </summary>
+        public bool CanFlatten { get; set; }
+        /// <summary>
+        /// True for <c>will_move</c> rows whose target directory exists on disk
+        /// but holds only leftover metadata (no audio files, nothing referenced
+        /// by the DB). The move will delete and replace the stub instead of
+        /// refusing; the UI labels these so the operator knows the target isn't
+        /// pristine.
+        /// </summary>
+        public bool ReplacesStubTarget { get; set; }
+    }
+
+    public class OrganizeLibraryPreviewDto
+    {
+        public List<OrganizePreviewRowDto> Rows { get; set; } = new();
+        public int AlreadyCanonicalCount { get; set; }
+        public int WillMoveCount { get; set; }
+        public int CollisionCount { get; set; }
+        public int InvalidTargetCount { get; set; }
+    }
+
+    /// <summary>
+    /// Apply-endpoint body. Caller passes the explicit ids confirmed in the
+    /// preview UI; the server re-validates each one before queuing.
+    /// </summary>
+    public class OrganizeLibraryApplyRequest
+    {
+        public List<int> AudiobookIds { get; set; } = new();
+    }
+
+    public class OrganizeApplySkippedDto
+    {
+        public int AudiobookId { get; set; }
+        public string Reason { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// One queued background move surfaced in the apply response. The
+    /// frontend uses <see cref="JobId"/> to correlate SignalR
+    /// <c>MoveJobUpdate</c> events back to the specific audiobook so a
+    /// failure's <c>error</c> string lands next to the right book in the
+    /// results UI.
+    /// </summary>
+    public class OrganizeQueuedJobDto
+    {
+        public string JobId { get; set; } = string.Empty;
+        public int AudiobookId { get; set; }
+        public string? AudiobookTitle { get; set; }
+        public string? TargetPath { get; set; }
+    }
+
+    /// <summary>
+    /// Body for the organize "flatten" action — collapse a single
+    /// nested-one-level-too-deep row into its canonical parent folder.
+    /// </summary>
+    public class OrganizeFlattenRequest
+    {
+        public int AudiobookId { get; set; }
+    }
+
+    public class OrganizeFlattenResultDto
+    {
+        public bool Success { get; set; }
+        public int FilesMoved { get; set; }
+        public string? NewPath { get; set; }
+        public string? Error { get; set; }
+    }
+
+    public class OrganizeLibraryApplyResultDto
+    {
+        public int Queued { get; set; }
+        public int Skipped { get; set; }
+        public int FailedToQueue { get; set; }
+        public List<OrganizeQueuedJobDto> QueuedJobs { get; set; } = new();
+        public List<OrganizeApplySkippedDto> SkippedDetails { get; set; } = new();
+        public List<string> Warnings { get; set; } = new();
+    }
+}

--- a/listenarr.api/Features/Library/LibraryOrganizeSweepWorkflow.Helpers.cs
+++ b/listenarr.api/Features/Library/LibraryOrganizeSweepWorkflow.Helpers.cs
@@ -1,0 +1,355 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Application.Audiobooks.Organizing;
+using Listenarr.Domain.Common;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Api.Features.Library
+{
+    public sealed partial class LibraryOrganizeSweepWorkflow
+    {
+        /// <summary>
+        /// Collapse a single "nested one level too deep" row (organize-preview
+        /// reason code <c>target_ancestor</c>) into its canonical parent folder.
+        /// These rows — a historical import artifact where the files sit in a
+        /// redundant subfolder beneath their canonical folder — can't go through
+        /// the normal move queue because the target is an ancestor of the source,
+        /// which the queue refuses. The flatten is strongly guarded (see
+        /// <see cref="OrganizeFilesystem.ExecuteFlatten"/>): it only collapses
+        /// empty wrapper directories and never touches a target that holds
+        /// foreign files. On success the audiobook's BasePath and file paths are
+        /// rebased in place so the DB matches the new on-disk layout.
+        /// </summary>
+        public async Task<IActionResult> FlattenAsync(OrganizeFlattenRequest? request, CancellationToken ct)
+        {
+            if (request == null || request.AudiobookId <= 0)
+            {
+                return new BadRequestObjectResult(new OrganizeFlattenResultDto { Success = false, Error = "No audiobook id provided" });
+            }
+
+            var audiobooks = await _repo.GetByIdsWithFilesAsync(new List<int> { request.AudiobookId }, ct);
+            var audiobook = audiobooks.FirstOrDefault();
+            if (audiobook == null)
+            {
+                return new NotFoundObjectResult(new OrganizeFlattenResultDto { Success = false, Error = $"Audiobook {request.AudiobookId} not found" });
+            }
+
+            var settings = await _configurationService.GetApplicationSettingsAsync();
+            var rootFolders = await _rootFolderService.GetAllAsync();
+
+            var currentPath = NormalizeOrganizePath(audiobook.BasePath);
+            if (string.IsNullOrEmpty(currentPath))
+            {
+                return new BadRequestObjectResult(new OrganizeFlattenResultDto { Success = false, Error = "Audiobook has no current folder path." });
+            }
+
+            var (target, invalidReason, _) = ComputeOrganizeTarget(audiobook, settings, rootFolders);
+            if (!string.IsNullOrEmpty(invalidReason))
+            {
+                return new BadRequestObjectResult(new OrganizeFlattenResultDto { Success = false, Error = invalidReason });
+            }
+
+            // Only the ancestor/nested case is a flatten. Re-validate against the
+            // live state rather than trusting the caller's snapshot.
+            if (!IsTargetAncestorOfSource(currentPath, target))
+            {
+                return new BadRequestObjectResult(new OrganizeFlattenResultDto
+                {
+                    Success = false,
+                    Error = "This row is not a 'nested one level too deep' case; flatten only applies to those.",
+                });
+            }
+
+            var outcome = _organizeFilesystem.ExecuteFlatten(currentPath, target, Guid.NewGuid());
+            if (!outcome.Success)
+            {
+                _logger.LogWarning("Organize flatten for audiobook {Id} ({Source} -> {Target}) refused: {Reason}",
+                    audiobook.Id, LogRedaction.SanitizeFilePath(currentPath), LogRedaction.SanitizeFilePath(target), outcome.ErrorMessage);
+                return new BadRequestObjectResult(new OrganizeFlattenResultDto { Success = false, Error = outcome.ErrorMessage });
+            }
+
+            // Files are on disk at the canonical path now — rebase the DB record
+            // so a re-scan isn't required.
+            var newBase = NormalizeOrganizePath(target);
+            audiobook.BasePath = newBase;
+            if (audiobook.Files != null)
+            {
+                foreach (var file in audiobook.Files.Where(f => !string.IsNullOrWhiteSpace(f.Path)))
+                {
+                    var fp = NormalizeOrganizePath(file.Path);
+                    if (string.Equals(fp, currentPath, StringComparison.OrdinalIgnoreCase) || FileUtils.IsPathInsideOf(fp, currentPath))
+                    {
+                        var rel = Path.GetRelativePath(currentPath, fp);
+                        file.Path = NormalizeOrganizePath(Path.Combine(newBase, rel));
+                    }
+                }
+            }
+            if (!string.IsNullOrWhiteSpace(audiobook.FilePath))
+            {
+                var fp = NormalizeOrganizePath(audiobook.FilePath);
+                if (string.Equals(fp, currentPath, StringComparison.OrdinalIgnoreCase) || FileUtils.IsPathInsideOf(fp, currentPath))
+                {
+                    var rel = Path.GetRelativePath(currentPath, fp);
+                    audiobook.FilePath = NormalizeOrganizePath(Path.Combine(newBase, rel));
+                }
+            }
+
+            try
+            {
+                await _repo.SaveChangesAsync(ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogError(ex,
+                    "Flatten moved audiobook {Id} files to {Target} on disk but persisting the new paths failed; a re-scan will recover.",
+                    audiobook.Id, LogRedaction.SanitizeFilePath(newBase));
+                return new OkObjectResult(new OrganizeFlattenResultDto
+                {
+                    Success = true,
+                    FilesMoved = outcome.FilesMoved,
+                    NewPath = newBase,
+                    Error = "Files were flattened on disk but the database update failed — re-scan the library to reconcile.",
+                });
+            }
+
+            try
+            {
+                await _historyRepository.AddAsync(new History
+                {
+                    AudiobookId = audiobook.Id,
+                    AudiobookTitle = audiobook.Title,
+                    EventType = "Organized",
+                    Message = $"Flattened nested folder into canonical path ({outcome.FilesMoved} file(s))",
+                    Source = "Organize",
+                    Timestamp = DateTime.UtcNow,
+                    NotificationSent = false,
+                }, ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogDebug(ex, "Non-fatal: failed to add history entry after flatten for audiobook {Id}", audiobook.Id);
+            }
+
+            _logger.LogInformation("Flattened audiobook {Id} from {Source} into {Target} ({Files} files)",
+                audiobook.Id, LogRedaction.SanitizeFilePath(currentPath), LogRedaction.SanitizeFilePath(newBase), outcome.FilesMoved);
+            return new OkObjectResult(new OrganizeFlattenResultDto { Success = true, FilesMoved = outcome.FilesMoved, NewPath = newBase });
+        }
+
+        /// <summary>
+        /// Build the canonical target folder path for <paramref name="audiobook"/>.
+        /// Delegates the pattern rendering to <see cref="LibraryPathPlanner"/> —
+        /// the same planner the add and move flows use — so the organize sweep
+        /// can never disagree with the paths the rest of the app computes.
+        /// Returns the <c>(target, invalidReason, invalidReasonCode)</c> triple;
+        /// a non-empty reason buckets the row as
+        /// <see cref="OrganizePreviewStatus.InvalidTarget"/>.
+        /// </summary>
+        private (string Target, string? InvalidReason, string? InvalidReasonCode) ComputeOrganizeTarget(
+            Audiobook audiobook,
+            ApplicationSettings settings,
+            List<RootFolder> rootFolders)
+        {
+            var firstAuthor = audiobook.Authors?.FirstOrDefault(a => !string.IsNullOrWhiteSpace(a));
+            if (string.IsNullOrWhiteSpace(audiobook.Title))
+            {
+                return (string.Empty, "Missing title", OrganizeInvalidReasonCode.MissingTitle);
+            }
+            if (string.IsNullOrWhiteSpace(firstAuthor))
+            {
+                return (string.Empty, "Missing author", OrganizeInvalidReasonCode.MissingAuthor);
+            }
+            if (string.IsNullOrWhiteSpace(settings?.FolderNamingPattern))
+            {
+                return (string.Empty, "FolderNamingPattern is not configured", OrganizeInvalidReasonCode.PatternNotConfigured);
+            }
+
+            var root = ResolveOrganizeRoot(audiobook.BasePath, settings, rootFolders);
+            if (string.IsNullOrEmpty(root))
+            {
+                return (string.Empty, "Audiobook is outside any configured library root", OrganizeInvalidReasonCode.OutsideRoot);
+            }
+
+            var combined = LibraryPathPlanner.ComputeAudiobookBaseDirectoryFromPattern(
+                audiobook, root, settings.FolderNamingPattern, _fileNamingService);
+            if (string.IsNullOrWhiteSpace(combined))
+            {
+                return (string.Empty, "Naming pattern produced an empty path", OrganizeInvalidReasonCode.EmptyPattern);
+            }
+
+            return (NormalizeOrganizePath(combined), null, null);
+        }
+
+        /// <summary>
+        /// Pick the canonical root for <paramref name="basePath"/>: the
+        /// longest configured root folder (or <c>OutputPath</c>) that contains
+        /// the current base path. Falls back to the default root, then to
+        /// <c>settings.OutputPath</c>, when the audiobook has no base path
+        /// yet. Returns empty when the audiobook lives outside every root.
+        /// </summary>
+        private static string ResolveOrganizeRoot(
+            string? basePath,
+            ApplicationSettings settings,
+            List<RootFolder> rootFolders)
+        {
+            var configuredRoots = rootFolders
+                .Where(r => !string.IsNullOrWhiteSpace(r.Path))
+                .Select(r => NormalizeOrganizePath(r.Path!))
+                .ToList();
+            if (!string.IsNullOrWhiteSpace(settings.OutputPath))
+            {
+                var outputNormalized = NormalizeOrganizePath(settings.OutputPath);
+                if (!configuredRoots.Any(r => string.Equals(r, outputNormalized, StringComparison.OrdinalIgnoreCase)))
+                {
+                    configuredRoots.Add(outputNormalized);
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(basePath))
+            {
+                var defaultRoot = rootFolders.FirstOrDefault(r => r.IsDefault)?.Path;
+                if (!string.IsNullOrWhiteSpace(defaultRoot)) return NormalizeOrganizePath(defaultRoot);
+                if (!string.IsNullOrWhiteSpace(settings.OutputPath)) return NormalizeOrganizePath(settings.OutputPath);
+                return configuredRoots.FirstOrDefault() ?? string.Empty;
+            }
+
+            var current = NormalizeOrganizePath(basePath);
+            return configuredRoots
+                .Where(r => string.Equals(r, current, StringComparison.OrdinalIgnoreCase) || FileUtils.IsPathInsideOf(current, r))
+                .OrderByDescending(r => r.Length)
+                .FirstOrDefault() ?? string.Empty;
+        }
+
+        private static string NormalizeOrganizePath(string? path)
+            => string.IsNullOrWhiteSpace(path) ? string.Empty : FileUtils.NormalizeStoredPath(path);
+
+        private static string NormalizeOrganizeKey(string path)
+        {
+            if (string.IsNullOrEmpty(path)) return string.Empty;
+            var trimmed = path.TrimEnd('/', '\\');
+            return trimmed.ToUpperInvariant();
+        }
+
+        /// <summary>
+        /// Returns true if the audiobook's current path matches a configured
+        /// root folder exactly. Rows in this state can't be moved by the
+        /// organize-library flow: the "source" would be the library root
+        /// itself, and the post-copy delete of the source would wipe every
+        /// other audiobook on the same root.
+        /// </summary>
+        private static bool IsSourceAtRootFolder(string? currentPath, IEnumerable<RootFolder> rootFolders)
+        {
+            if (string.IsNullOrWhiteSpace(currentPath)) return false;
+            var currentKey = NormalizeOrganizeKey(NormalizeOrganizePath(currentPath));
+            if (string.IsNullOrEmpty(currentKey)) return false;
+            foreach (var rf in rootFolders)
+            {
+                if (string.IsNullOrWhiteSpace(rf?.Path)) continue;
+                var rootKey = NormalizeOrganizeKey(NormalizeOrganizePath(rf.Path));
+                if (currentKey == rootKey) return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true when <paramref name="currentPath"/> and <paramref name="target"/>
+        /// normalize to the same key — the canonical-equality case used by the
+        /// already_canonical bucket. Bucketing the "target on disk exists with
+        /// content" case would otherwise misclassify these rows: the
+        /// audiobook's own files trivially make the target non-empty.
+        /// </summary>
+        private static bool IsCurrentPathEqualToTarget(string? currentPath, string target)
+        {
+            var currentKey = NormalizeOrganizeKey(NormalizeOrganizePath(currentPath));
+            var targetKey = NormalizeOrganizeKey(NormalizeOrganizePath(target));
+            return !string.IsNullOrEmpty(currentKey) && currentKey == targetKey;
+        }
+
+        /// <summary>
+        /// Returns true when the move would flatten the source into one of its
+        /// own ancestors — e.g. source <c>/audiobooks/Author/Title/Narrator</c>
+        /// targeting <c>/audiobooks/Author/Title</c> after a pattern change that
+        /// removed a directory level. The move queue refuses this ("Source and
+        /// target paths overlap"); mirroring the check here keeps these rows out
+        /// of will_move so the preview reflects what apply would actually do.
+        /// </summary>
+        private static bool IsTargetAncestorOfSource(string? source, string target)
+        {
+            if (string.IsNullOrWhiteSpace(source) || string.IsNullOrWhiteSpace(target)) return false;
+            string sourceFull;
+            string targetFull;
+            try
+            {
+                sourceFull = Path.GetFullPath(source);
+                targetFull = Path.GetFullPath(target);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                // Unparseable path — let the apply-time guard surface it instead.
+                return false;
+            }
+            if (string.Equals(sourceFull, targetFull, StringComparison.OrdinalIgnoreCase)) return false;
+            var sep = Path.DirectorySeparatorChar;
+            var sourceWithSep = sourceFull.TrimEnd(sep) + sep;
+            var targetWithSep = targetFull.TrimEnd(sep) + sep;
+            return sourceWithSep.StartsWith(targetWithSep, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Returns true when the target directory exists on disk and is not
+        /// empty. The move queue refuses moves into populated targets;
+        /// surfacing the same condition at preview time keeps these rows out
+        /// of will_move. Callers must rule out the canonical-equality case
+        /// (target == current) before invoking this.
+        /// </summary>
+        private bool TargetExistsWithContent(string target) => _organizeFilesystem.TargetExistsWithContent(target);
+
+        /// <summary>
+        /// True when an existing, populated organize target can be safely
+        /// replaced by the move: it holds no audio on disk (see
+        /// <see cref="OrganizeFilesystem.IsMetadataStubDirectory"/>), no tracked
+        /// file row lives at or under it, and no other audiobook's BasePath
+        /// points at or under it. The move processor re-checks the on-disk half
+        /// at execute time; the DB half is checked here because the processor is
+        /// pure file-system code.
+        /// </summary>
+        private bool IsReplaceableStubTarget(
+            string target,
+            int audiobookId,
+            IReadOnlyCollection<Audiobook> allAudiobooks,
+            IReadOnlyCollection<AudiobookFile> allFiles)
+        {
+            if (!_organizeFilesystem.IsMetadataStubDirectory(target)) return false;
+
+            var key = NormalizeOrganizeKey(NormalizeOrganizePath(target));
+            if (string.IsNullOrEmpty(key)) return false;
+            var prefix = key + "/";
+
+            bool AtOrUnderTarget(string? path)
+            {
+                if (string.IsNullOrWhiteSpace(path)) return false;
+                var k = NormalizeOrganizeKey(NormalizeOrganizePath(path));
+                return k == key || k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+            }
+
+            if (allFiles.Any(f => AtOrUnderTarget(f.Path))) return false;
+            if (allAudiobooks.Any(a => a.Id != audiobookId && AtOrUnderTarget(a.BasePath))) return false;
+            return true;
+        }
+    }
+}

--- a/listenarr.api/Features/Library/LibraryOrganizeSweepWorkflow.cs
+++ b/listenarr.api/Features/Library/LibraryOrganizeSweepWorkflow.cs
@@ -1,0 +1,414 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Application.Audiobooks.Organizing;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Api.Features.Library
+{
+    /// <summary>
+    /// Library-wide "Organize" sweep: bucket every audiobook against the
+    /// canonical path its metadata computes to (preview, read-only), then queue
+    /// per-book background moves for the rows the operator confirmed (apply).
+    /// A separate flatten action (see the Helpers partial) resolves the
+    /// "nested one level too deep" rows the move queue refuses.
+    /// </summary>
+    public sealed partial class LibraryOrganizeSweepWorkflow
+    {
+        private readonly IAudiobookRepository _repo;
+        private readonly IAudiobookFileRepository _audioFileRepository;
+        private readonly IHistoryRepository _historyRepository;
+        private readonly IRootFolderService _rootFolderService;
+        private readonly IConfigurationService _configurationService;
+        private readonly IFileNamingService _fileNamingService;
+        private readonly IMoveQueueService? _moveQueueService;
+        private readonly IOrganizeFilesystem _organizeFilesystem;
+        private readonly ILogger<LibraryOrganizeSweepWorkflow> _logger;
+
+        public LibraryOrganizeSweepWorkflow(
+            IAudiobookRepository repo,
+            IAudiobookFileRepository audioFileRepository,
+            IHistoryRepository historyRepository,
+            IRootFolderService rootFolderService,
+            IConfigurationService configurationService,
+            IFileNamingService fileNamingService,
+            IOrganizeFilesystem organizeFilesystem,
+            ILogger<LibraryOrganizeSweepWorkflow> logger,
+            IMoveQueueService? moveQueueService = null)
+        {
+            _repo = repo;
+            _audioFileRepository = audioFileRepository;
+            _historyRepository = historyRepository;
+            _rootFolderService = rootFolderService;
+            _configurationService = configurationService;
+            _fileNamingService = fileNamingService;
+            _moveQueueService = moveQueueService;
+            _organizeFilesystem = organizeFilesystem;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Walk every audiobook and bucket it into one of:
+        /// <c>already_canonical</c>, <c>will_move</c>, <c>collision</c>, or
+        /// <c>invalid_target</c>. Read-only — no DB or filesystem changes.
+        /// </summary>
+        public async Task<IActionResult> PreviewAsync(CancellationToken ct)
+        {
+            var settings = await _configurationService.GetApplicationSettingsAsync();
+            var rootFolders = await _rootFolderService.GetAllAsync();
+
+            var allAudiobooks = await _repo.GetAllAsync();
+            var allFiles = await _audioFileRepository.GetAllAsync(ct);
+            var filesByAudiobookId = allFiles
+                .GroupBy(f => f.AudiobookId)
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            // First pass: compute target per audiobook + initial bucket
+            // (invalid_target vs proposed). Collision detection happens after
+            // because it needs the full target map.
+            var rows = new List<OrganizePreviewRowDto>(allAudiobooks.Count);
+            var targetGroups = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var audiobook in allAudiobooks)
+            {
+                ct.ThrowIfCancellationRequested();
+                var files = filesByAudiobookId.TryGetValue(audiobook.Id, out var fs) ? fs : new List<AudiobookFile>();
+
+                // Rows with no tracked files have nothing to organize — whatever
+                // BasePath says, there's no on-disk content to move. Letting them
+                // through puts monitored-but-not-downloaded records in will_move,
+                // where each queued job then fails the source-path-exists check.
+                if (files.Count == 0)
+                {
+                    continue;
+                }
+
+                var currentPath = NormalizeOrganizePath(audiobook.BasePath);
+                var row = new OrganizePreviewRowDto
+                {
+                    Id = audiobook.Id,
+                    Title = audiobook.Title,
+                    Author = audiobook.Authors?.FirstOrDefault(a => !string.IsNullOrWhiteSpace(a)),
+                    CurrentPath = currentPath,
+                    FileCount = files.Count,
+                    TotalSize = files.Sum(f => f.Size ?? 0L),
+                };
+
+                // Source-at-root guard: rows whose BasePath equals a configured
+                // root folder (e.g. "/audiobooks") can't be moved — the post-
+                // copy delete of the source would obliterate every other
+                // audiobook on that root.
+                if (IsSourceAtRootFolder(currentPath, rootFolders))
+                {
+                    row.Status = OrganizePreviewStatus.InvalidTarget;
+                    row.ReasonCode = OrganizeInvalidReasonCode.SourceAtRoot;
+                    row.Reason = "Source path is the library root folder. Re-scan the library so this audiobook's BasePath points at its actual subfolder before organizing.";
+                    rows.Add(row);
+                    continue;
+                }
+
+                var (target, invalidReason, invalidReasonCode) = ComputeOrganizeTarget(audiobook, settings, rootFolders);
+                if (!string.IsNullOrEmpty(invalidReason))
+                {
+                    row.Status = OrganizePreviewStatus.InvalidTarget;
+                    row.Reason = invalidReason;
+                    row.ReasonCode = invalidReasonCode;
+                    rows.Add(row);
+                    continue;
+                }
+
+                // Apply-feasibility checks. The move queue refuses these at
+                // execute time; surfacing them here keeps un-moveable rows
+                // out of the will_move bucket so the user isn't told an
+                // operation is queued and then watches it fail one by one.
+                // Skip these for the canonical-equality case — if target
+                // equals current, target-exists-with-content is just the
+                // audiobook's own files, not a conflict.
+                if (!IsCurrentPathEqualToTarget(currentPath, target))
+                {
+                    if (IsTargetAncestorOfSource(currentPath, target))
+                    {
+                        row.Status = OrganizePreviewStatus.InvalidTarget;
+                        row.TargetPath = target;
+                        // Disk-check the flatten so the preview never offers a
+                        // one-click flatten the executor would refuse, and so an
+                        // orphaned record (folder gone from disk) is surfaced as
+                        // its own "files missing" case rather than a flatten-able
+                        // nested row.
+                        var (feasibility, _) = _organizeFilesystem.EvaluateFlatten(currentPath, target);
+                        if (feasibility == FlattenFeasibility.SourceMissing)
+                        {
+                            row.ReasonCode = OrganizeInvalidReasonCode.SourceMissing;
+                            row.Reason = "The record's folder no longer exists on disk — its files are gone. Re-scan the library to clear it, or remove the record.";
+                        }
+                        else
+                        {
+                            row.ReasonCode = OrganizeInvalidReasonCode.TargetAncestor;
+                            row.Reason = "Target is an ancestor of source; the move would flatten the source into one of its own parent directories. Adjust the Folder Naming Pattern or relocate the source manually.";
+                            row.CanFlatten = feasibility == FlattenFeasibility.Ok;
+                        }
+                        rows.Add(row);
+                        continue;
+                    }
+                    if (TargetExistsWithContent(target))
+                    {
+                        // A populated target is only a hard conflict when it
+                        // holds something worth protecting. A metadata-only husk
+                        // (covers, .opf, playlists — leftovers from a removed
+                        // release) that nothing in the DB references can be
+                        // replaced by the move; surface it as will_move with a
+                        // flag instead of making the operator delete it by hand.
+                        if (IsReplaceableStubTarget(target, audiobook.Id, allAudiobooks, allFiles))
+                        {
+                            row.ReplacesStubTarget = true;
+                        }
+                        else
+                        {
+                            row.Status = OrganizePreviewStatus.InvalidTarget;
+                            row.ReasonCode = OrganizeInvalidReasonCode.TargetExists;
+                            row.Reason = "Target directory already exists on disk and contains files. Resolve the existing content (move or delete) before organizing this row.";
+                            row.TargetPath = target;
+                            rows.Add(row);
+                            continue;
+                        }
+                    }
+                }
+
+                row.TargetPath = target;
+                var key = NormalizeOrganizeKey(target);
+                if (!targetGroups.TryGetValue(key, out var members))
+                {
+                    members = new List<int>();
+                    targetGroups[key] = members;
+                }
+                members.Add(audiobook.Id);
+                rows.Add(row);
+            }
+
+            // Second pass: assign bucket from target groups.
+            var collisionKeys = targetGroups
+                .Where(kv => kv.Value.Count > 1)
+                .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var row in rows)
+            {
+                if (row.Status == OrganizePreviewStatus.InvalidTarget) continue;
+                var key = NormalizeOrganizeKey(row.TargetPath ?? string.Empty);
+                if (collisionKeys.ContainsKey(key))
+                {
+                    row.Status = OrganizePreviewStatus.Collision;
+                    row.CollisionKey = key;
+                    continue;
+                }
+                row.Status = NormalizeOrganizeKey(row.CurrentPath ?? string.Empty) == key
+                    ? OrganizePreviewStatus.AlreadyCanonical
+                    : OrganizePreviewStatus.WillMove;
+            }
+
+            var preview = new OrganizeLibraryPreviewDto
+            {
+                Rows = rows.OrderBy(r => r.Status switch
+                    {
+                        OrganizePreviewStatus.WillMove => 0,
+                        OrganizePreviewStatus.Collision => 1,
+                        OrganizePreviewStatus.InvalidTarget => 2,
+                        _ => 3,
+                    }).ThenBy(r => r.Author ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(r => r.Title ?? string.Empty, StringComparer.OrdinalIgnoreCase)
+                    .ToList(),
+                AlreadyCanonicalCount = rows.Count(r => r.Status == OrganizePreviewStatus.AlreadyCanonical),
+                WillMoveCount = rows.Count(r => r.Status == OrganizePreviewStatus.WillMove),
+                CollisionCount = rows.Count(r => r.Status == OrganizePreviewStatus.Collision),
+                InvalidTargetCount = rows.Count(r => r.Status == OrganizePreviewStatus.InvalidTarget),
+            };
+            return new OkObjectResult(preview);
+        }
+
+        /// <summary>
+        /// Queue a per-book move for each id the user confirmed in the
+        /// preview. Each id is re-validated against the live DB state before
+        /// queuing: ids that no longer compute to <c>will_move</c>, or that
+        /// collide with another id in the same request, are skipped with a
+        /// warning rather than aborting the rest. Missing ids return
+        /// BadRequest without queuing anything.
+        /// </summary>
+        public async Task<IActionResult> ApplyAsync(OrganizeLibraryApplyRequest? request, CancellationToken ct)
+        {
+            if (request?.AudiobookIds == null || request.AudiobookIds.Count == 0)
+            {
+                return new BadRequestObjectResult(new { message = "No audiobook ids provided" });
+            }
+
+            if (_moveQueueService == null)
+            {
+                return new ObjectResult(new { message = "Move queue not available" })
+                {
+                    StatusCode = StatusCodes.Status503ServiceUnavailable
+                };
+            }
+
+            var requestedIds = request.AudiobookIds.Distinct().ToList();
+            var audiobooks = await _repo.GetByIdsWithFilesAsync(requestedIds, ct);
+            var foundIds = audiobooks.Select(a => a.Id).ToHashSet();
+            var missing = requestedIds.Where(id => !foundIds.Contains(id)).ToList();
+            if (missing.Count > 0)
+            {
+                return new BadRequestObjectResult(new
+                {
+                    message = $"Audiobook id(s) not found: {string.Join(", ", missing)}",
+                    missingIds = missing,
+                });
+            }
+
+            var settings = await _configurationService.GetApplicationSettingsAsync();
+            var rootFolders = await _rootFolderService.GetAllAsync();
+
+            // Re-compute targets for the selected set so the collision check
+            // reflects the live world, not the user's snapshot.
+            var targets = new Dictionary<int, string>();
+            var result = new OrganizeLibraryApplyResultDto();
+            var byKey = new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase);
+
+            // Full library state for the stub-target reference checks below —
+            // a target counts as a replaceable stub only if NOTHING in the DB
+            // points at it, which requires looking beyond the requested ids.
+            var allAudiobooksForStubCheck = await _repo.GetAllAsync();
+            var allFilesForStubCheck = await _audioFileRepository.GetAllAsync(ct);
+            var replaceStubIds = new HashSet<int>();
+
+            foreach (var audiobook in audiobooks)
+            {
+                // Defense in depth: even if the preview gate missed this or
+                // the operator's snapshot is stale, refuse to queue a move
+                // whose source is the library root (would wipe everything on
+                // delete-source).
+                if (IsSourceAtRootFolder(audiobook.BasePath, rootFolders))
+                {
+                    result.Skipped++;
+                    result.SkippedDetails.Add(new OrganizeApplySkippedDto
+                    {
+                        AudiobookId = audiobook.Id,
+                        Reason = "Source path is the library root folder; re-scan to correct BasePath before organizing.",
+                    });
+                    continue;
+                }
+
+                var (target, invalidReason, _) = ComputeOrganizeTarget(audiobook, settings, rootFolders);
+                if (!string.IsNullOrEmpty(invalidReason))
+                {
+                    result.Skipped++;
+                    result.SkippedDetails.Add(new OrganizeApplySkippedDto { AudiobookId = audiobook.Id, Reason = invalidReason });
+                    continue;
+                }
+
+                var currentKey = NormalizeOrganizeKey(NormalizeOrganizePath(audiobook.BasePath));
+                var targetKey = NormalizeOrganizeKey(target);
+                if (currentKey == targetKey)
+                {
+                    result.Skipped++;
+                    result.SkippedDetails.Add(new OrganizeApplySkippedDto
+                    {
+                        AudiobookId = audiobook.Id,
+                        Reason = "Already at canonical path",
+                    });
+                    continue;
+                }
+
+                // Mirror the preview's populated-target handling: replaceable
+                // metadata stubs get queued with the replace flag; anything
+                // else occupying the target is skipped here instead of failing
+                // one by one in the move queue.
+                if (!IsTargetAncestorOfSource(NormalizeOrganizePath(audiobook.BasePath), target)
+                    && TargetExistsWithContent(target))
+                {
+                    if (IsReplaceableStubTarget(target, audiobook.Id, allAudiobooksForStubCheck, allFilesForStubCheck))
+                    {
+                        replaceStubIds.Add(audiobook.Id);
+                    }
+                    else
+                    {
+                        result.Skipped++;
+                        result.SkippedDetails.Add(new OrganizeApplySkippedDto
+                        {
+                            AudiobookId = audiobook.Id,
+                            Reason = "Target directory already exists on disk and contains files",
+                        });
+                        continue;
+                    }
+                }
+
+                targets[audiobook.Id] = target;
+                if (!byKey.TryGetValue(targetKey, out var ids))
+                {
+                    ids = new List<int>();
+                    byKey[targetKey] = ids;
+                }
+                ids.Add(audiobook.Id);
+            }
+
+            // Drop ids that collide with another id in the same request.
+            foreach (var (key, ids) in byKey)
+            {
+                if (ids.Count <= 1) continue;
+                foreach (var id in ids)
+                {
+                    targets.Remove(id);
+                    result.Skipped++;
+                    result.SkippedDetails.Add(new OrganizeApplySkippedDto
+                    {
+                        AudiobookId = id,
+                        Reason = $"Collides with audiobook id(s) {string.Join(", ", ids.Where(i => i != id))} at the same target",
+                    });
+                }
+                result.Warnings.Add($"Skipped {ids.Count} audiobooks that compute to the same target path '{key}'");
+            }
+
+            foreach (var audiobook in audiobooks)
+            {
+                if (!targets.TryGetValue(audiobook.Id, out var target)) continue;
+                try
+                {
+                    var sourcePath = NormalizeOrganizePath(audiobook.BasePath);
+                    var jobId = await _moveQueueService.EnqueueMoveAsync(
+                        audiobook.Id, target, sourcePath,
+                        replaceStubTarget: replaceStubIds.Contains(audiobook.Id));
+                    result.Queued++;
+                    result.QueuedJobs.Add(new OrganizeQueuedJobDto
+                    {
+                        JobId = jobId.ToString(),
+                        AudiobookId = audiobook.Id,
+                        AudiobookTitle = audiobook.Title,
+                        TargetPath = target,
+                    });
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+                {
+                    _logger.LogError(ex, "Failed to enqueue organize move for audiobook {AudiobookId}", audiobook.Id);
+                    result.FailedToQueue++;
+                    result.SkippedDetails.Add(new OrganizeApplySkippedDto
+                    {
+                        AudiobookId = audiobook.Id,
+                        Reason = $"Failed to enqueue: {ex.Message}",
+                    });
+                }
+            }
+
+            return new OkObjectResult(result);
+        }
+    }
+}

--- a/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
+++ b/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
@@ -86,6 +86,8 @@ public static class ListenarrWorkflowRegistration
         services.AddScoped<LibraryPreviewPathWorkflow>();
         services.AddScoped<LibraryQueryWorkflow>();
         services.AddScoped<LibraryRenameWorkflow>();
+        services.AddScoped<LibraryOrganizeSweepWorkflow>();
+        services.AddScoped<LibraryMoveSummaryWorkflow>();
         services.AddScoped<SearchResponseMapper>();
         services.AddScoped<ImagePlaceholderResolver>();
         services.AddScoped<IndexerTestWorkflow>();

--- a/listenarr.application/Audiobooks/Contracts/IMoveQueueService.cs
+++ b/listenarr.application/Audiobooks/Contracts/IMoveQueueService.cs
@@ -20,7 +20,7 @@ namespace Listenarr.Application.Audiobooks.Contracts
 {
     public interface IMoveQueueService
     {
-        Task<Guid> EnqueueMoveAsync(int audiobookId, string requestedPath, string? sourcePath = null);
+        Task<Guid> EnqueueMoveAsync(int audiobookId, string requestedPath, string? sourcePath = null, bool replaceStubTarget = false);
         Task<Guid?> RequeueMoveAsync(Guid jobId);
         Task<MoveJob?> GetJobAsync(Guid id, CancellationToken cancellationToken = default);
         Task UpdateJobStatusAsync(Guid id, string status, string? error = null, CancellationToken cancellationToken = default);

--- a/listenarr.application/Audiobooks/Contracts/Repositories/IMoveJobRepository.cs
+++ b/listenarr.application/Audiobooks/Contracts/Repositories/IMoveJobRepository.cs
@@ -22,6 +22,7 @@ namespace Listenarr.Application.Audiobooks.Contracts.Repositories
     {
         Task<MoveJob?> GetByIdAsync(Guid id, CancellationToken ct = default);
         Task<List<MoveJob>> GetByStatusAsync(IEnumerable<string> statuses, CancellationToken ct = default);
+        Task<List<MoveJob>> GetAllAsync(CancellationToken ct = default);
         Task<MoveJob> AddAsync(MoveJob job, CancellationToken ct = default);
         Task UpdateAsync(MoveJob job, CancellationToken ct = default);
     }

--- a/listenarr.application/Audiobooks/Jobs/MoveQueueService.cs
+++ b/listenarr.application/Audiobooks/Jobs/MoveQueueService.cs
@@ -46,7 +46,7 @@ namespace Listenarr.Application.Audiobooks.Jobs
 
         public ChannelReader<MoveJob> Reader => _channel.Reader;
 
-        public async Task<Guid> EnqueueMoveAsync(int audiobookId, string requestedPath, string? sourcePath = null)
+        public async Task<Guid> EnqueueMoveAsync(int audiobookId, string requestedPath, string? sourcePath = null, bool replaceStubTarget = false)
         {
             var deduplicationKey = BuildDeduplicationKey(audiobookId, requestedPath);
             var existingDb = await _persistence.GetActiveByKeyAsync(deduplicationKey);
@@ -65,7 +65,8 @@ namespace Listenarr.Application.Audiobooks.Jobs
                 ActiveDeduplicationKey = deduplicationKey,
                 EnqueuedAt = _timeProvider.GetUtcNow().UtcDateTime,
                 Status = "Queued",
-                SourcePath = sourcePath
+                SourcePath = sourcePath,
+                ReplaceStubTarget = replaceStubTarget
             };
 
             try
@@ -190,7 +191,7 @@ namespace Listenarr.Application.Audiobooks.Jobs
                 return null;
             }
 
-            var newJobId = await EnqueueMoveAsync(job.AudiobookId, job.RequestedPath ?? string.Empty, job.SourcePath);
+            var newJobId = await EnqueueMoveAsync(job.AudiobookId, job.RequestedPath ?? string.Empty, job.SourcePath, job.ReplaceStubTarget);
             _logger.LogInformation("Requeueing move job {OldJobId} as job {NewJobId} for audiobook {AudiobookId}", jobId, newJobId, job.AudiobookId);
             return newJobId;
         }

--- a/listenarr.application/Audiobooks/Organizing/IOrganizeFilesystem.cs
+++ b/listenarr.application/Audiobooks/Organizing/IOrganizeFilesystem.cs
@@ -1,0 +1,94 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Listenarr.Application.Audiobooks.Organizing
+{
+    /// <summary>
+    /// Why a flatten would (or wouldn't) succeed.
+    /// <see cref="FlattenFeasibility.Ok"/> is the only value
+    /// <see cref="IOrganizeFilesystem.ExecuteFlatten"/> proceeds on.
+    /// </summary>
+    public enum FlattenFeasibility
+    {
+        Ok,
+        SourcePathEmpty,
+        TargetPathEmpty,
+        SourceMissing,
+        SamePath,
+        NotAncestor,
+        TargetMissing,
+        NoUsableParent,
+        TargetHasForeignFiles,
+        NoFiles,
+    }
+
+    public sealed class FlattenOutcome
+    {
+        public bool Success { get; init; }
+        public int FilesMoved { get; init; }
+        public string? ErrorMessage { get; init; }
+        public string? TempPathUsed { get; init; }
+    }
+
+    /// <summary>
+    /// Filesystem primitives for the organize-library flow: metadata-stub
+    /// detection, populated-target checks, and the strongly-guarded flatten
+    /// used for "nested one level too deep" rows. Implemented in the
+    /// infrastructure layer (the only layer allowed to touch the filesystem);
+    /// consumed by the organize preview/apply workflows and the move-job
+    /// processor's execute-time guards.
+    /// </summary>
+    public interface IOrganizeFilesystem
+    {
+        /// <summary>
+        /// True when <paramref name="path"/> is an existing directory that
+        /// contains no audio files at any depth — a metadata-only husk (covers,
+        /// .opf, playlists) left behind by a removed release. On any read error
+        /// it is NOT treated as a stub.
+        /// </summary>
+        bool IsMetadataStubDirectory(string path);
+
+        /// <summary>
+        /// True when the target directory exists on disk and is not empty.
+        /// </summary>
+        bool TargetExistsWithContent(string target);
+
+        /// <summary>
+        /// Read-only feasibility check for <see cref="ExecuteFlatten"/>: decides
+        /// whether collapsing <paramref name="source"/> into ancestor
+        /// <paramref name="dest"/> is safe, and returns the file count, without
+        /// mutating the filesystem. Shared by the organize preview (to bucket a
+        /// nested row and decide whether to offer the one-click flatten) and by
+        /// <see cref="ExecuteFlatten"/> so the preview's promise and the
+        /// executor's guard can never disagree.
+        /// </summary>
+        (FlattenFeasibility Feasibility, int FileCount) EvaluateFlatten(string source, string dest);
+
+        /// <summary>Human-readable explanation of a non-Ok <see cref="FlattenFeasibility"/>.</summary>
+        string DescribeFeasibility(FlattenFeasibility feasibility);
+
+        /// <summary>
+        /// Flatten a redundantly-nested folder: collapse everything under
+        /// <paramref name="source"/> up into strict ancestor <paramref name="dest"/>.
+        /// Strongly guarded via <see cref="EvaluateFlatten"/> — refuses unless
+        /// every file under dest already lives under source, so only empty
+        /// wrapper directories are ever collapsed.
+        /// </summary>
+        FlattenOutcome ExecuteFlatten(string source, string dest, Guid jobId);
+    }
+}

--- a/listenarr.domain/Audiobooks/MoveJob.cs
+++ b/listenarr.domain/Audiobooks/MoveJob.cs
@@ -34,5 +34,10 @@ namespace Listenarr.Domain.Audiobooks
         // Optional source path snapshot provided at enqueue time. Persist this so jobs
         // remain durable and can be inspected / resumed across restarts.
         public string? SourcePath { get; set; }
+        // When true, the processor may delete-and-replace a target directory that
+        // exists but contains no audio (leftover metadata from a removed release).
+        // Set only by the organize flow after verifying nothing in the DB
+        // references the target.
+        public bool ReplaceStubTarget { get; set; }
     }
 }

--- a/listenarr.infrastructure/DependencyInjection/Library/LibraryRegistrationExtensions.cs
+++ b/listenarr.infrastructure/DependencyInjection/Library/LibraryRegistrationExtensions.cs
@@ -9,6 +9,7 @@
  */
 using Listenarr.Infrastructure.Persistence.Repositories;
 using Microsoft.Extensions.DependencyInjection;
+using Listenarr.Application.Audiobooks.Organizing;
 
 namespace Listenarr.Infrastructure.DependencyInjection.Library;
 
@@ -17,6 +18,8 @@ internal static class LibraryRegistrationExtensions
     public static IServiceCollection AddLibraryServices(this IServiceCollection services)
     {
         services.AddScoped<IAudiobookFileService, AudiobookFileService>();
+        // Singleton: stateless filesystem primitives, consumed by the singleton MoveJobProcessor.
+        services.AddSingleton<IOrganizeFilesystem, Listenarr.Infrastructure.Library.Organizing.OrganizeFilesystem>();
         services.AddScoped<IAuthorCatalogService, AuthorCatalogService>();
         services.AddScoped<ISeriesCatalogService, SeriesCatalogService>();
         services.AddScoped<ILibraryAddService, LibraryAddService>();

--- a/listenarr.infrastructure/Library/Moving/MoveJobProcessor.TargetGate.cs
+++ b/listenarr.infrastructure/Library/Moving/MoveJobProcessor.TargetGate.cs
@@ -1,0 +1,79 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Domain.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Infrastructure.Library.Moving
+{
+    public partial class MoveJobProcessor
+    {
+        /// <summary>
+        /// Gate on an existing target directory. Returns true when the move may
+        /// proceed. An empty target is reclaimed as-is. A populated target fails
+        /// the job — unless the organize flow explicitly flagged it as a
+        /// replaceable metadata stub (no audio at any depth, nothing in the DB
+        /// referencing it), in which case the on-disk no-audio invariant is
+        /// re-verified here and the stub is deleted so the move can replace it.
+        /// The DB half of the stub check happened at enqueue time; if audio
+        /// landed in the target since, refuse rather than destroy it.
+        /// </summary>
+        private async Task<bool> TryReclaimTargetAsync(MoveJob job, string target, CancellationToken stoppingToken)
+        {
+            if (!Directory.Exists(target))
+            {
+                return true;
+            }
+
+            var targetHasContent = Directory.EnumerateFileSystemEntries(target).Any();
+            if (!targetHasContent)
+            {
+                // Target exists but is empty - safe to proceed (will use it instead of creating new)
+                logger.LogInformation("Target directory {Target} exists but is empty; proceeding with move", LogRedaction.SanitizeFilePath(target));
+                return true;
+            }
+
+            if (job.ReplaceStubTarget && organizeFilesystem.IsMetadataStubDirectory(target))
+            {
+                logger.LogInformation(
+                    "Move job {JobId}: target {Target} is a verified metadata-only stub; deleting it so the move can replace it",
+                    job.Id,
+                    LogRedaction.SanitizeFilePath(target));
+                Directory.Delete(target, true);
+                return true;
+            }
+
+            await moveQueueService.UpdateJobStatusAsync(job.Id, "Failed", "Target directory already exists and contains files", stoppingToken);
+            metrics.Increment("worker.move.job.failed");
+            return false;
+        }
+
+        private static bool IsFilesystemRoot(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return false;
+            }
+
+            var fullPath = Path.GetFullPath(path)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var root = Path.GetPathRoot(fullPath)?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return !string.IsNullOrWhiteSpace(root)
+                && string.Equals(fullPath, root, OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+        }
+    }
+}

--- a/listenarr.infrastructure/Library/Moving/MoveJobProcessor.cs
+++ b/listenarr.infrastructure/Library/Moving/MoveJobProcessor.cs
@@ -15,20 +15,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+using Listenarr.Application.Audiobooks.Organizing;
 using Listenarr.Application.Mapping;
 using Listenarr.Domain.Common;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 namespace Listenarr.Infrastructure.Library.Moving
 {
-    public class MoveJobProcessor(
+    public partial class MoveJobProcessor(
         IMoveQueueService moveQueueService,
         IToastService toastService,
         IScanQueueService scanQueueService,
         ILogger<MoveJobProcessor> logger,
         IServiceScopeFactory scopeFactory,
         IHubContext<DownloadHub> hubContext,
-        IAppMetricsService metrics) : IMoveJobProcessor
+        IAppMetricsService metrics,
+        IOrganizeFilesystem organizeFilesystem) : IMoveJobProcessor
     {
         public async Task ProcessJobAsync(MoveJob job, CancellationToken stoppingToken)
         {
@@ -130,18 +132,11 @@ namespace Listenarr.Infrastructure.Library.Moving
 
                 if (!Directory.Exists(targetParent)) Directory.CreateDirectory(targetParent);
 
-                // Check if target exists and has content - only fail if it has files/folders we'd overwrite
-                if (Directory.Exists(target))
+                // Populated targets fail unless the organize flow flagged a replaceable
+                // metadata stub (see the TargetGate partial for the reclaim rules).
+                if (!await TryReclaimTargetAsync(job, target, stoppingToken))
                 {
-                    var targetHasContent = Directory.EnumerateFileSystemEntries(target).Any();
-                    if (targetHasContent)
-                    {
-                        await moveQueueService.UpdateJobStatusAsync(job.Id, "Failed", "Target directory already exists and contains files", stoppingToken);
-                        metrics.Increment("worker.move.job.failed");
-                        return;
-                    }
-                    // Target exists but is empty - safe to proceed (will use it instead of creating new)
-                    logger.LogInformation("Target directory {Target} exists but is empty; proceeding with move", LogRedaction.SanitizeFilePath(target));
+                    return;
                 }
 
                 // Create a temporary directory under the target parent
@@ -481,20 +476,6 @@ namespace Listenarr.Infrastructure.Library.Moving
                 }
                 metrics.Increment("worker.move.job.failed");
             }
-        }
-
-        private static bool IsFilesystemRoot(string path)
-        {
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                return false;
-            }
-
-            var fullPath = Path.GetFullPath(path)
-                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            var root = Path.GetPathRoot(fullPath)?.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            return !string.IsNullOrWhiteSpace(root)
-                && string.Equals(fullPath, root, OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
         }
     }
 }

--- a/listenarr.infrastructure/Library/Organizing/OrganizeFilesystem.cs
+++ b/listenarr.infrastructure/Library/Organizing/OrganizeFilesystem.cs
@@ -1,0 +1,221 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Application.Audiobooks.Organizing;
+using Listenarr.Domain.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Infrastructure.Library.Organizing
+{
+    /// <summary>
+    /// Pure filesystem primitives shared by the organize-library flow (preview
+    /// classification in the API layer) and the move-job processor (execute-time
+    /// guards): metadata-stub detection and the strongly-guarded flatten used
+    /// for "nested one level too deep" rows.
+    /// </summary>
+    public sealed class OrganizeFilesystem(ILogger<OrganizeFilesystem> logger) : IOrganizeFilesystem
+    {
+        /// <summary>
+        /// True when <paramref name="path"/> is an existing directory that
+        /// contains no audio files at any depth — a metadata-only husk (covers,
+        /// .opf, playlists) left behind by a removed release. On any read error
+        /// we don't treat it as a stub.
+        /// </summary>
+        public bool IsMetadataStubDirectory(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return false;
+            try
+            {
+                if (!Directory.Exists(path)) return false;
+                return !Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories)
+                    .Any(FileUtils.IsAudioFile);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// True when the target directory exists on disk and is not empty. On a
+        /// permission or IO error reading the target, returns false — the
+        /// apply-time guard surfaces the real problem instead of a guess here.
+        /// </summary>
+        public bool TargetExistsWithContent(string target)
+        {
+            if (string.IsNullOrWhiteSpace(target)) return false;
+            try
+            {
+                if (!Directory.Exists(target)) return false;
+                return Directory.EnumerateFileSystemEntries(target).Any();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Read-only feasibility check for <see cref="ExecuteFlatten"/>: decides
+        /// whether collapsing <paramref name="source"/> into ancestor
+        /// <paramref name="dest"/> is safe, and returns the file count, without
+        /// touching the filesystem. Shared by the organize-preview (to bucket a
+        /// nested row and decide whether to offer the one-click flatten) and by
+        /// <see cref="ExecuteFlatten"/> (which refuses anything but
+        /// <see cref="FlattenFeasibility.Ok"/>) so the preview's promise and the
+        /// executor's guard can never disagree.
+        /// </summary>
+        public (FlattenFeasibility Feasibility, int FileCount) EvaluateFlatten(string source, string dest)
+        {
+            if (string.IsNullOrWhiteSpace(source)) return (FlattenFeasibility.SourcePathEmpty, 0);
+            if (string.IsNullOrWhiteSpace(dest)) return (FlattenFeasibility.TargetPathEmpty, 0);
+            if (!Directory.Exists(source)) return (FlattenFeasibility.SourceMissing, 0);
+
+            var sourceFull = TrimTrailingSeparator(Path.GetFullPath(source));
+            var destFull = TrimTrailingSeparator(Path.GetFullPath(dest));
+            var sep = Path.DirectorySeparatorChar;
+
+            if (string.Equals(sourceFull, destFull, StringComparison.OrdinalIgnoreCase))
+                return (FlattenFeasibility.SamePath, 0);
+            // dest must be a STRICT ancestor of source. If it isn't, this isn't a flatten.
+            if (!(sourceFull + sep).StartsWith(destFull + sep, StringComparison.OrdinalIgnoreCase))
+                return (FlattenFeasibility.NotAncestor, 0);
+            if (!Directory.Exists(destFull))
+                return (FlattenFeasibility.TargetMissing, 0);
+            var destParent = Path.GetDirectoryName(destFull);
+            if (string.IsNullOrEmpty(destParent) || IsFilesystemRoot(destParent))
+                return (FlattenFeasibility.NoUsableParent, 0);
+
+            // Guard: every FILE under dest must already live under source. If dest
+            // holds any file outside source's subtree, flattening would merge into
+            // populated content — refuse and leave it for manual resolution.
+            var sourceWithSep = sourceFull + sep;
+            try
+            {
+                var destFiles = Directory.EnumerateFiles(destFull, "*", SearchOption.AllDirectories)
+                    .Select(f => TrimTrailingSeparator(Path.GetFullPath(f)))
+                    .ToList();
+                if (destFiles.Any(f => !f.StartsWith(sourceWithSep, StringComparison.OrdinalIgnoreCase)))
+                    return (FlattenFeasibility.TargetHasForeignFiles, 0);
+                if (destFiles.Count == 0)
+                    return (FlattenFeasibility.NoFiles, 0);
+                return (FlattenFeasibility.Ok, destFiles.Count);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                // Can't read the target — treat as not-feasible so neither the
+                // preview nor the executor offers a flatten it can't safely do.
+                return (FlattenFeasibility.TargetHasForeignFiles, 0);
+            }
+        }
+
+        /// <summary>Human-readable explanation of a non-Ok <see cref="FlattenFeasibility"/>.</summary>
+        public string DescribeFeasibility(FlattenFeasibility f) => f switch
+        {
+            FlattenFeasibility.SourcePathEmpty => "Source path is empty",
+            FlattenFeasibility.TargetPathEmpty => "Target path is empty",
+            FlattenFeasibility.SourceMissing => "Source path does not exist",
+            FlattenFeasibility.SamePath => "Source and target are the same path",
+            FlattenFeasibility.NotAncestor => "Target is not an ancestor of source; not a flatten",
+            FlattenFeasibility.TargetMissing => "Target directory does not exist",
+            FlattenFeasibility.NoUsableParent => "Target has no usable parent directory (looks like a library root)",
+            FlattenFeasibility.TargetHasForeignFiles => "Target directory contains files outside the nested source folder; resolve manually",
+            FlattenFeasibility.NoFiles => "Nothing to flatten: no files under the source folder",
+            _ => "Flatten is not available for this row",
+        };
+
+        /// <summary>
+        /// Flatten a redundantly-nested folder: collapse everything under
+        /// <paramref name="source"/> up into <paramref name="dest"/>, where
+        /// <paramref name="dest"/> is a strict ancestor of <paramref name="source"/>
+        /// (e.g. source <c>/a/Title/Narrator/Title</c> → dest <c>/a/Title/Narrator</c>).
+        /// This is the exact case the normal move queue refuses ("Source and
+        /// target paths overlap"). It backs the organize-library "nested one
+        /// level too deep" rows, which a normal move can't resolve.
+        ///
+        /// Strongly guarded via <see cref="EvaluateFlatten"/> so no real file is
+        /// ever clobbered or lost: refuses unless dest is a strict ancestor of
+        /// source AND every file under dest already lives under source. That
+        /// guarantees dest holds nothing but source's subtree wrapped in redundant
+        /// (empty) directories, so the operation only collapses empty wrappers. The
+        /// move itself is two same-volume <see cref="Directory.Move(string,string)"/>
+        /// renames via a sibling staging dir, with the source extracted before the
+        /// redundant dest shell is removed — so an interruption leaves the files
+        /// recoverable at the staging path rather than destroyed.
+        /// </summary>
+        public FlattenOutcome ExecuteFlatten(string source, string dest, Guid jobId)
+        {
+            var (feasibility, fileCount) = EvaluateFlatten(source, dest);
+            if (feasibility != FlattenFeasibility.Ok)
+            {
+                return new FlattenOutcome { Success = false, ErrorMessage = DescribeFeasibility(feasibility) };
+            }
+
+            var sourceFull = TrimTrailingSeparator(Path.GetFullPath(source));
+            var destFull = TrimTrailingSeparator(Path.GetFullPath(dest));
+            var destParent = Path.GetDirectoryName(destFull)!;
+            var tempName = Path.Combine(destParent, $"flatten.tmp-{jobId:N}");
+            try
+            {
+                if (Directory.Exists(tempName)) Directory.Delete(tempName, true);
+
+                // 1. Extract source's subtree to a sibling staging dir (atomic
+                //    same-volume rename). dest now holds only empty wrappers.
+                Directory.Move(sourceFull, tempName);
+
+                // 2. Remove the redundant dest shell (guaranteed file-free by the
+                //    guard above), then promote the extracted subtree into dest.
+                Directory.Delete(destFull, true);
+                var finalParent = Path.GetDirectoryName(destFull);
+                if (!string.IsNullOrEmpty(finalParent) && !Directory.Exists(finalParent))
+                {
+                    Directory.CreateDirectory(finalParent);
+                }
+                Directory.Move(tempName, destFull);
+
+                return new FlattenOutcome { Success = true, FilesMoved = fileCount, TempPathUsed = tempName };
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                logger.LogError(ex,
+                    "Flatten failed collapsing {Source} into {Dest}. Files may be staged at {Temp} — recover manually if needed.",
+                    LogRedaction.SanitizeFilePath(sourceFull),
+                    LogRedaction.SanitizeFilePath(destFull),
+                    LogRedaction.SanitizeFilePath(tempName));
+                return new FlattenOutcome
+                {
+                    Success = false,
+                    ErrorMessage = $"Flatten failed: {ex.Message}",
+                    TempPathUsed = tempName,
+                };
+            }
+        }
+
+        private static string TrimTrailingSeparator(string path) =>
+            path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        private static bool IsFilesystemRoot(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return false;
+            var fullPath = TrimTrailingSeparator(Path.GetFullPath(path));
+            var root = Path.GetPathRoot(fullPath);
+            root = root == null ? null : TrimTrailingSeparator(root);
+            return !string.IsNullOrWhiteSpace(root)
+                && string.Equals(fullPath, root, OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+        }
+    }
+}

--- a/listenarr.infrastructure/Persistence/Migrations/20260702180000_AddReplaceStubTargetToMoveJobs.Designer.cs
+++ b/listenarr.infrastructure/Persistence/Migrations/20260702180000_AddReplaceStubTargetToMoveJobs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Listenarr.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Listenarr.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ListenArrDbContext))]
-    partial class ListenArrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702180000_AddReplaceStubTargetToMoveJobs")]
+    partial class AddReplaceStubTargetToMoveJobs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/listenarr.infrastructure/Persistence/Migrations/20260702180000_AddReplaceStubTargetToMoveJobs.cs
+++ b/listenarr.infrastructure/Persistence/Migrations/20260702180000_AddReplaceStubTargetToMoveJobs.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Listenarr.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReplaceStubTargetToMoveJobs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "ReplaceStubTarget",
+                table: "MoveJobs",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ReplaceStubTarget",
+                table: "MoveJobs");
+        }
+    }
+}

--- a/listenarr.infrastructure/Persistence/Repositories/EfMoveJobRepository.cs
+++ b/listenarr.infrastructure/Persistence/Repositories/EfMoveJobRepository.cs
@@ -41,6 +41,13 @@ namespace Listenarr.Infrastructure.Persistence.Repositories
                 .ToListAsync(ct);
         }
 
+        public async Task<List<MoveJob>> GetAllAsync(CancellationToken ct = default)
+        {
+            return await _db.MoveJobs
+                .AsNoTracking()
+                .ToListAsync(ct);
+        }
+
         public async Task<MoveJob> AddAsync(MoveJob job, CancellationToken ct = default)
         {
             _db.MoveJobs.Add(job);

--- a/tests/Builders/ServiceCollectionBuilder.cs
+++ b/tests/Builders/ServiceCollectionBuilder.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Listenarr.Application.Audiobooks.Organizing;
 
 namespace Listenarr.Tests.Builders
 {
@@ -201,6 +202,9 @@ namespace Listenarr.Tests.Builders
             services.AddSingleton<LibraryPreviewPathWorkflow>();
             services.AddSingleton<LibraryQueryWorkflow>();
             services.AddSingleton<LibraryRenameWorkflow>();
+            services.AddSingleton<LibraryOrganizeSweepWorkflow>();
+            services.AddSingleton<LibraryMoveSummaryWorkflow>();
+            services.AddSingleton<IOrganizeFilesystem, Listenarr.Infrastructure.Library.Organizing.OrganizeFilesystem>();
             services.AddSingleton<SearchResponseMapper>();
             services.AddSingleton<ImagePlaceholderResolver>();
             services.AddSingleton<IndexerTestWorkflow>();

--- a/tests/Features/Api/Features/Library/LibraryController_OrganizeTests.cs
+++ b/tests/Features/Api/Features/Library/LibraryController_OrganizeTests.cs
@@ -1,0 +1,744 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+using Listenarr.Api.Features.Library;
+using Listenarr.Tests.Common;
+using Listenarr.Tests.Builders;
+
+namespace Listenarr.Tests.Features.Api.Features.Library
+{
+    /// <summary>
+    /// Tests for the organize-library preview and apply endpoints. The
+    /// preview buckets every audiobook into already_canonical / will_move /
+    /// collision / invalid_target; apply queues a per-book move for each
+    /// confirmed id through MoveQueueService.
+    /// </summary>
+    public class LibraryController_OrganizeTests : BaseTests
+    {
+        private const string Root = "/audiobooks";
+        private readonly Mock<IImageCacheService> imageCacheServiceMock = new Mock<IImageCacheService>();
+
+        public override async Task InitializeAsync()
+        {
+            _services.AddSingleton(imageCacheServiceMock.Object);
+            Init();
+            await SeedSettingsAndRootAsync();
+        }
+
+        private async Task SeedSettingsAndRootAsync()
+        {
+            await _applicationSettingsRepository.SaveAsync(new ApplicationSettingsBuilder()
+                .WithFolderNamingPattern("{Author}/{Title}")
+                .WithOutputPath(Root)
+                .Build());
+            await _rootFolderRepository.AddAsync(new RootFolderBuilder()
+                .WithName("Library")
+                .WithPath(Root)
+                .WithIsDefault()
+                .Build());
+        }
+
+        /// <summary>
+        /// Attach a single tracked AudiobookFile to <paramref name="audiobook"/> so
+        /// it survives <c>GetOrganizePreview</c>'s fileless-row skip filter (rows
+        /// with zero tracked files are excluded from the preview entirely because
+        /// they have nothing on disk to move). Tests that exercise bucket
+        /// classification — already_canonical, will_move, collision,
+        /// invalid_target — call this so the row reaches the bucketing logic.
+        /// </summary>
+        private Task AttachFileAsync(Audiobook audiobook, string? path = null)
+        {
+            return _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(audiobook)
+                .WithPath(path ?? $"{audiobook.BasePath ?? Root}/dummy.m4b")
+                .Build());
+        }
+
+        [Fact]
+        public async Task Preview_NoLibrary_ReturnsEmptyBuckets()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var actionResult = await controller.GetOrganizePreview(CancellationToken.None) as OkObjectResult;
+            Assert.NotNull(actionResult);
+            var preview = Assert.IsType<OrganizeLibraryPreviewDto>(actionResult!.Value);
+            Assert.Empty(preview.Rows);
+            Assert.Equal(0, preview.WillMoveCount);
+            Assert.Equal(0, preview.CollisionCount);
+        }
+
+        [Fact]
+        public async Task Preview_RowAtCanonicalPath_IsAlreadyCanonical()
+        {
+            var canonicalPath = $"{Root}/Author A/Book One";
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Book One",
+                Authors = new List<string> { "Author A" },
+                BasePath = canonicalPath,
+            });
+            await AttachFileAsync(ab);
+
+            var preview = await GetPreviewAsync();
+            var row = Assert.Single(preview.Rows);
+            Assert.Equal(OrganizePreviewStatus.AlreadyCanonical, row.Status);
+            Assert.Equal(1, preview.AlreadyCanonicalCount);
+            Assert.Equal(0, preview.WillMoveCount);
+        }
+
+        [Fact]
+        public async Task Preview_RowWithDifferentPath_IsWillMove()
+        {
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Book Two",
+                Authors = new List<string> { "Author B" },
+                BasePath = $"{Root}/Misplaced",
+            });
+            await AttachFileAsync(ab);
+
+            var preview = await GetPreviewAsync();
+            var row = Assert.Single(preview.Rows);
+            Assert.Equal(OrganizePreviewStatus.WillMove, row.Status);
+            Assert.Equal($"{Root}/Author B/Book Two", row.TargetPath);
+            Assert.Equal(1, preview.WillMoveCount);
+        }
+
+        [Fact]
+        public async Task Preview_TwoRowsTargetingSameFolder_AreCollision()
+        {
+            // Same {Author}/{Title} → same target path; different ASINs so the
+            // existing dedup tool wouldn't catch them.
+            var ab1 = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Same Title",
+                Authors = new List<string> { "Same Author" },
+                Asin = "B00COLL0001",
+                BasePath = $"{Root}/Old Place A",
+            });
+            var ab2 = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Same Title",
+                Authors = new List<string> { "Same Author" },
+                Asin = "B00COLL0002",
+                BasePath = $"{Root}/Old Place B",
+            });
+            await AttachFileAsync(ab1);
+            await AttachFileAsync(ab2);
+
+            var preview = await GetPreviewAsync();
+            Assert.Equal(2, preview.Rows.Count);
+            Assert.All(preview.Rows, r => Assert.Equal(OrganizePreviewStatus.Collision, r.Status));
+            var key = preview.Rows[0].CollisionKey;
+            Assert.False(string.IsNullOrEmpty(key));
+            Assert.All(preview.Rows, r => Assert.Equal(key, r.CollisionKey));
+            Assert.Equal(2, preview.CollisionCount);
+            Assert.Equal(0, preview.WillMoveCount);
+        }
+
+        [Fact]
+        public async Task Preview_RowWithNoFilesAndNoBasePath_IsSkipped()
+        {
+            // Monitored-but-not-downloaded record: tracked in the library,
+            // but nothing on disk and no destination set. Including it in
+            // will_move would cause an "Source path does not exist" failure
+            // when the user applies the default selection.
+            await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Wishlisted Book",
+                Authors = new List<string> { "Author M" },
+                BasePath = null,
+            });
+
+            var preview = await GetPreviewAsync();
+            Assert.Empty(preview.Rows);
+            Assert.Equal(0, preview.WillMoveCount);
+            Assert.Equal(0, preview.AlreadyCanonicalCount);
+            Assert.Equal(0, preview.CollisionCount);
+            Assert.Equal(0, preview.InvalidTargetCount);
+        }
+
+        [Fact]
+        public async Task Preview_RowWithNoFilesButBasePathStamped_IsSkipped()
+        {
+            // Live-data variant: an earlier ingestion path stamped some
+            // wishlist records' BasePath at the library root ("/audiobooks")
+            // even though no files ever arrived. The narrow filter — empty
+            // BasePath AND zero files — let these through; they appeared in
+            // will_move, got default-selected, and each failed the move
+            // queue's source-path-exists check. The loosened filter drops
+            // every fileless row regardless of BasePath value.
+            await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Wishlisted Book",
+                Authors = new List<string> { "Author N" },
+                BasePath = Root, // i.e. "/audiobooks" — stamped, but no file ever landed
+            });
+
+            var preview = await GetPreviewAsync();
+            Assert.Empty(preview.Rows);
+            Assert.Equal(0, preview.WillMoveCount);
+        }
+
+        [Fact]
+        public async Task Preview_MissingAuthor_IsInvalidTarget()
+        {
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Orphan Book",
+                Authors = new List<string>(),
+                BasePath = $"{Root}/Somewhere",
+            });
+            await AttachFileAsync(ab);
+
+            var preview = await GetPreviewAsync();
+            var row = Assert.Single(preview.Rows);
+            Assert.Equal(OrganizePreviewStatus.InvalidTarget, row.Status);
+            Assert.Equal("Missing author", row.Reason);
+            Assert.Equal(OrganizeInvalidReasonCode.MissingAuthor, row.ReasonCode);
+            Assert.Null(row.TargetPath);
+            Assert.Equal(1, preview.InvalidTargetCount);
+        }
+
+        [Fact]
+        public async Task Preview_MissingTitle_IsInvalidTarget()
+        {
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = null,
+                Authors = new List<string> { "Author C" },
+                BasePath = $"{Root}/Somewhere",
+            });
+            await AttachFileAsync(ab);
+
+            var preview = await GetPreviewAsync();
+            var row = Assert.Single(preview.Rows);
+            Assert.Equal(OrganizePreviewStatus.InvalidTarget, row.Status);
+            Assert.Equal("Missing title", row.Reason);
+            Assert.Equal(OrganizeInvalidReasonCode.MissingTitle, row.ReasonCode);
+        }
+
+        [Fact]
+        public async Task Apply_EmptyBody_ReturnsBadRequest()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var result = await controller.ApplyOrganize(new OrganizeLibraryApplyRequest(), CancellationToken.None);
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task Apply_MissingIds_ReturnsBadRequestWithoutQueuing()
+        {
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Existing Book",
+                Authors = new List<string> { "Real Author" },
+                BasePath = $"{Root}/Somewhere",
+            });
+
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var result = await controller.ApplyOrganize(new OrganizeLibraryApplyRequest
+            {
+                AudiobookIds = new List<int> { ab.Id, 9999 },
+            }, CancellationToken.None);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            var jobs = await _moveJobRepository.GetByStatusAsync(new[] { "Queued", "Processing" });
+            Assert.Empty(jobs);
+        }
+
+        [Fact]
+        public async Task Apply_QueuesMovesForWillMoveRows()
+        {
+            var ab1 = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Move Me",
+                Authors = new List<string> { "Author X" },
+                BasePath = $"{Root}/Misplaced",
+            });
+            var ab2 = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Move Me Too",
+                Authors = new List<string> { "Author Y" },
+                BasePath = $"{Root}/Other",
+            });
+
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var actionResult = await controller.ApplyOrganize(new OrganizeLibraryApplyRequest
+            {
+                AudiobookIds = new List<int> { ab1.Id, ab2.Id },
+            }, CancellationToken.None) as OkObjectResult;
+
+            Assert.NotNull(actionResult);
+            var result = Assert.IsType<OrganizeLibraryApplyResultDto>(actionResult!.Value);
+            Assert.Equal(2, result.Queued);
+            Assert.Equal(0, result.Skipped);
+            Assert.Equal(0, result.FailedToQueue);
+            Assert.Equal(2, result.QueuedJobs.Count);
+            Assert.Contains(result.QueuedJobs, j => j.AudiobookId == ab1.Id && j.TargetPath == $"{Root}/Author X/Move Me");
+            Assert.Contains(result.QueuedJobs, j => j.AudiobookId == ab2.Id && j.TargetPath == $"{Root}/Author Y/Move Me Too");
+
+            var jobs = await _moveJobRepository.GetByStatusAsync(new[] { "Queued", "Processing" });
+            Assert.Equal(2, jobs.Count);
+            Assert.Contains(jobs, j => j.AudiobookId == ab1.Id && j.RequestedPath == $"{Root}/Author X/Move Me");
+            Assert.Contains(jobs, j => j.AudiobookId == ab2.Id && j.RequestedPath == $"{Root}/Author Y/Move Me Too");
+        }
+
+        [Fact]
+        public async Task Apply_SkipsRowsAlreadyAtCanonicalPath()
+        {
+            // User confirmed an id that — between preview and apply —
+            // got moved to its target by something else. Apply should
+            // skip with a warning, not enqueue a no-op.
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Already Done",
+                Authors = new List<string> { "Author Z" },
+                BasePath = $"{Root}/Author Z/Already Done",
+            });
+
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var actionResult = await controller.ApplyOrganize(new OrganizeLibraryApplyRequest
+            {
+                AudiobookIds = new List<int> { ab.Id },
+            }, CancellationToken.None) as OkObjectResult;
+
+            Assert.NotNull(actionResult);
+            var result = Assert.IsType<OrganizeLibraryApplyResultDto>(actionResult!.Value);
+            Assert.Equal(0, result.Queued);
+            Assert.Equal(1, result.Skipped);
+            Assert.Single(result.SkippedDetails, s => s.AudiobookId == ab.Id);
+
+            var jobs = await _moveJobRepository.GetByStatusAsync(new[] { "Queued", "Processing" });
+            Assert.Empty(jobs);
+        }
+
+        [Fact]
+        public async Task Apply_SkipsCollidingIdsInSameRequest()
+        {
+            var ab1 = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Conflict",
+                Authors = new List<string> { "Author Q" },
+                BasePath = $"{Root}/Old A",
+            });
+            var ab2 = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Conflict",
+                Authors = new List<string> { "Author Q" },
+                BasePath = $"{Root}/Old B",
+            });
+
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var actionResult = await controller.ApplyOrganize(new OrganizeLibraryApplyRequest
+            {
+                AudiobookIds = new List<int> { ab1.Id, ab2.Id },
+            }, CancellationToken.None) as OkObjectResult;
+
+            Assert.NotNull(actionResult);
+            var result = Assert.IsType<OrganizeLibraryApplyResultDto>(actionResult!.Value);
+            Assert.Equal(0, result.Queued);
+            Assert.Equal(2, result.Skipped);
+            Assert.NotEmpty(result.Warnings);
+
+            var jobs = await _moveJobRepository.GetByStatusAsync(new[] { "Queued", "Processing" });
+            Assert.Empty(jobs);
+        }
+
+        [Fact]
+        public async Task Preview_TargetDirectoryOccupied_IsInvalidTarget()
+        {
+            // Real temp directory tree so the preview can actually stat the target.
+            using var tmp = new TempDirectory();
+            var root = tmp.Path;
+            await _applicationSettingsRepository.SaveAsync(new ApplicationSettingsBuilder()
+                .WithFolderNamingPattern("{Author}/{Title}")
+                .WithOutputPath(root)
+                .Build());
+            // Replace the base-seed root (path = "/audiobooks") with one
+            // pointing at the temp directory so the preview's filesystem
+            // checks actually look at our test fixture.
+            foreach (var existing in await _rootFolderRepository.GetAllAsync())
+            {
+                await _rootFolderRepository.RemoveAsync(existing.Id);
+            }
+            await _rootFolderRepository.AddAsync(new RootFolderBuilder()
+                .WithName("Library")
+                .WithPath(root)
+                .WithIsDefault()
+                .Build());
+
+            // Audiobook's current path is /<tmp>/Misplaced; target computes to
+            // /<tmp>/Author X/Occupied. Pre-populate the target with a foreign
+            // AUDIO file so it exists and holds protected content — apply would
+            // refuse, so the preview must surface this row as invalid_target
+            // rather than will_move. (A non-audio occupant is the replaceable-
+            // stub case, covered separately below.)
+            var currentPath = Path.Combine(root, "Misplaced");
+            Directory.CreateDirectory(currentPath);
+            var targetPath = Path.Combine(root, "Author X", "Occupied");
+            Directory.CreateDirectory(targetPath);
+            await File.WriteAllTextAsync(Path.Combine(targetPath, "foreign.m4b"), "stranger danger");
+
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Occupied",
+                Authors = new List<string> { "Author X" },
+                BasePath = currentPath,
+            });
+            await AttachFileAsync(ab, $"{currentPath}/dummy.m4b");
+
+            var preview = await GetPreviewAsync();
+            var row = Assert.Single(preview.Rows);
+            Assert.Equal(OrganizePreviewStatus.InvalidTarget, row.Status);
+            Assert.Contains("already exists", row.Reason ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(OrganizeInvalidReasonCode.TargetExists, row.ReasonCode);
+            // TargetPath is surfaced on the invalid row so the UI can show the
+            // occupied canonical path the operator needs to resolve.
+            Assert.Contains("Occupied", row.TargetPath ?? string.Empty);
+            Assert.Equal(0, preview.WillMoveCount);
+            Assert.Equal(1, preview.InvalidTargetCount);
+        }
+
+        [Fact(DisplayName = "Preview: target occupied by metadata-only leftovers nothing references → will_move with replace flag")]
+        public async Task Preview_TargetOccupiedByUnreferencedStub_IsWillMoveWithReplaceFlag()
+        {
+            using var tmp = new TempDirectory();
+            var root = tmp.Path;
+            await UseTempRootAsync(root);
+
+            var currentPath = Path.Combine(root, "Misplaced");
+            Directory.CreateDirectory(currentPath);
+            var targetPath = Path.Combine(root, "Author X", "Occupied");
+            Directory.CreateDirectory(targetPath);
+            await File.WriteAllTextAsync(Path.Combine(targetPath, "Occupied - Author X.opf"), "stale metadata");
+            await File.WriteAllTextAsync(Path.Combine(targetPath, "cover.jpg"), "stale cover");
+
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Occupied",
+                Authors = new List<string> { "Author X" },
+                BasePath = currentPath,
+            });
+            await AttachFileAsync(ab, $"{currentPath}/dummy.m4b");
+
+            var preview = await GetPreviewAsync();
+            var row = Assert.Single(preview.Rows);
+            Assert.Equal(OrganizePreviewStatus.WillMove, row.Status);
+            Assert.True(row.ReplacesStubTarget);
+            Assert.Equal(1, preview.WillMoveCount);
+            Assert.Equal(0, preview.InvalidTargetCount);
+        }
+
+        [Fact(DisplayName = "Preview: stub target referenced by another record's BasePath → stays invalid_target")]
+        public async Task Preview_StubTargetReferencedByOtherBasePath_IsInvalidTarget()
+        {
+            using var tmp = new TempDirectory();
+            var root = tmp.Path;
+            await UseTempRootAsync(root);
+
+            var currentPath = Path.Combine(root, "Misplaced");
+            Directory.CreateDirectory(currentPath);
+            var targetPath = Path.Combine(root, "Author X", "Occupied");
+            Directory.CreateDirectory(targetPath);
+            await File.WriteAllTextAsync(Path.Combine(targetPath, "cover.jpg"), "stale cover");
+
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Occupied",
+                Authors = new List<string> { "Author X" },
+                BasePath = currentPath,
+            });
+            await AttachFileAsync(ab, $"{currentPath}/dummy.m4b");
+
+            // Another record claims the target folder as its BasePath — even
+            // though the folder holds no audio, replacing it would orphan that
+            // record's anchor, so the row must stay invalid.
+            var other = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Claimant",
+                Authors = new List<string> { "Author Y" },
+                BasePath = targetPath,
+            });
+            await AttachFileAsync(other, $"{targetPath}/claimant.m4b");
+            // The claimant's tracked file is DB-only (not on disk) so the
+            // target still LOOKS like a stub on disk — the DB check is what
+            // must catch it.
+
+            var preview = await GetPreviewAsync();
+            var row = Assert.Single(preview.Rows, r => r.Id == ab.Id);
+            Assert.Equal(OrganizePreviewStatus.InvalidTarget, row.Status);
+            Assert.Equal(OrganizeInvalidReasonCode.TargetExists, row.ReasonCode);
+        }
+
+        [Fact(DisplayName = "Apply: replaceable stub target queues the move (not skipped)")]
+        public async Task Apply_StubOccupiedTarget_QueuesMove()
+        {
+            using var tmp = new TempDirectory();
+            var root = tmp.Path;
+            await UseTempRootAsync(root);
+
+            var currentPath = Path.Combine(root, "Misplaced");
+            Directory.CreateDirectory(currentPath);
+            var targetPath = Path.Combine(root, "Author X", "Occupied");
+            Directory.CreateDirectory(targetPath);
+            await File.WriteAllTextAsync(Path.Combine(targetPath, "leftover.opf"), "stale");
+
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Occupied",
+                Authors = new List<string> { "Author X" },
+                BasePath = currentPath,
+            });
+            await AttachFileAsync(ab, $"{currentPath}/dummy.m4b");
+
+            var result = await ApplyAsync(new[] { ab.Id });
+            Assert.Equal(1, result.Queued);
+            Assert.Equal(0, result.Skipped);
+
+            var jobs = await _moveJobRepository.GetByStatusAsync(new[] { "Queued", "Processing" });
+            var job = Assert.Single(jobs, j => j.AudiobookId == ab.Id);
+            Assert.True(job.ReplaceStubTarget);
+        }
+
+        [Fact(DisplayName = "Apply: target occupied by audio is skipped with a reason instead of queuing a doomed job")]
+        public async Task Apply_AudioOccupiedTarget_SkipsWithReason()
+        {
+            using var tmp = new TempDirectory();
+            var root = tmp.Path;
+            await UseTempRootAsync(root);
+
+            var currentPath = Path.Combine(root, "Misplaced");
+            Directory.CreateDirectory(currentPath);
+            var targetPath = Path.Combine(root, "Author X", "Occupied");
+            Directory.CreateDirectory(targetPath);
+            await File.WriteAllTextAsync(Path.Combine(targetPath, "protected.m4b"), "real audio");
+
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Occupied",
+                Authors = new List<string> { "Author X" },
+                BasePath = currentPath,
+            });
+            await AttachFileAsync(ab, $"{currentPath}/dummy.m4b");
+
+            var result = await ApplyAsync(new[] { ab.Id });
+            Assert.Equal(0, result.Queued);
+            Assert.Equal(1, result.Skipped);
+            Assert.Contains(result.SkippedDetails, d => d.AudiobookId == ab.Id
+                && (d.Reason ?? string.Empty).Contains("already exists", StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Re-point the seeded root folder + settings at a real temp directory so
+        /// the preview's on-disk flatten-feasibility check (added with the
+        /// one-click flatten) actually stats the fixture.
+        /// </summary>
+        private async Task UseTempRootAsync(string root)
+        {
+            await _applicationSettingsRepository.SaveAsync(new ApplicationSettingsBuilder()
+                .WithFolderNamingPattern("{Author}/{Title}")
+                .WithOutputPath(root)
+                .Build());
+            foreach (var existing in await _rootFolderRepository.GetAllAsync())
+            {
+                await _rootFolderRepository.RemoveAsync(existing.Id);
+            }
+            await _rootFolderRepository.AddAsync(new RootFolderBuilder()
+                .WithName("Library")
+                .WithPath(root)
+                .WithIsDefault()
+                .Build());
+        }
+
+        [Fact]
+        public async Task Preview_TargetIsAncestorOfSource_OfferableFlatten()
+        {
+            // Source /<tmp>/Author Y/Title/Narrator nests one level below its
+            // canonical target /<tmp>/Author Y/Title. The target holds nothing
+            // but the Narrator subtree, so the flatten is feasible and the
+            // preview marks the row CanFlatten.
+            using var tmp = new TempDirectory();
+            var root = tmp.Path;
+            await UseTempRootAsync(root);
+
+            var source = Path.Combine(root, "Author Y", "Title", "Narrator");
+            Directory.CreateDirectory(source);
+            await File.WriteAllTextAsync(Path.Combine(source, "book.m4b"), "audio");
+
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Title",
+                Authors = new List<string> { "Author Y" },
+                BasePath = source,
+            });
+            await AttachFileAsync(ab, Path.Combine(source, "book.m4b"));
+
+            var preview = await GetPreviewAsync();
+            var row = Assert.Single(preview.Rows);
+            Assert.Equal(OrganizePreviewStatus.InvalidTarget, row.Status);
+            Assert.Equal(OrganizeInvalidReasonCode.TargetAncestor, row.ReasonCode);
+            Assert.Contains("ancestor", row.Reason ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(Path.Combine(root, "Author Y", "Title"), row.TargetPath);
+            Assert.True(row.CanFlatten);
+            Assert.Equal(1, preview.InvalidTargetCount);
+        }
+
+        [Fact]
+        public async Task Preview_TargetAncestor_TargetHasForeignFiles_NotFlattenable()
+        {
+            // Same nesting, but the canonical target also holds a foreign file
+            // directly — flattening would merge into populated content, so the
+            // executor would refuse. The preview must not offer the flatten.
+            using var tmp = new TempDirectory();
+            var root = tmp.Path;
+            await UseTempRootAsync(root);
+
+            var target = Path.Combine(root, "Author Y", "Title");
+            var source = Path.Combine(target, "Narrator");
+            Directory.CreateDirectory(source);
+            await File.WriteAllTextAsync(Path.Combine(source, "book.m4b"), "audio");
+            await File.WriteAllTextAsync(Path.Combine(target, "stray.txt"), "foreign");
+
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Title",
+                Authors = new List<string> { "Author Y" },
+                BasePath = source,
+            });
+            await AttachFileAsync(ab, Path.Combine(source, "book.m4b"));
+
+            var preview = await GetPreviewAsync();
+            var row = Assert.Single(preview.Rows);
+            Assert.Equal(OrganizeInvalidReasonCode.TargetAncestor, row.ReasonCode);
+            Assert.False(row.CanFlatten);
+            Assert.Equal(1, preview.InvalidTargetCount);
+        }
+
+        [Fact]
+        public async Task Preview_TargetAncestor_SourceMissingOnDisk_IsSourceMissing()
+        {
+            // The record points at a nested path that no longer exists on disk
+            // (an orphaned record). It must surface as its own source_missing
+            // case — not a flatten-able nested row — and never offer the flatten.
+            using var tmp = new TempDirectory();
+            var root = tmp.Path;
+            await UseTempRootAsync(root);
+
+            // Note: the nested source directory is deliberately NOT created.
+            var source = Path.Combine(root, "Author Y", "Title", "Narrator");
+
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Title",
+                Authors = new List<string> { "Author Y" },
+                BasePath = source,
+            });
+            await AttachFileAsync(ab, Path.Combine(source, "book.m4b"));
+
+            var preview = await GetPreviewAsync();
+            var row = Assert.Single(preview.Rows);
+            Assert.Equal(OrganizePreviewStatus.InvalidTarget, row.Status);
+            Assert.Equal(OrganizeInvalidReasonCode.SourceMissing, row.ReasonCode);
+            Assert.False(row.CanFlatten);
+            Assert.Equal(1, preview.InvalidTargetCount);
+        }
+
+        [Fact]
+        public async Task Preview_TargetEqualsCurrentAndExists_IsAlreadyCanonical()
+        {
+            // Regression guard: the new target-occupied check must NOT fire
+            // for the already_canonical case, where the target on disk is
+            // populated with the audiobook's OWN files.
+            using var tmp = new TempDirectory();
+            var root = tmp.Path;
+            await _applicationSettingsRepository.SaveAsync(new ApplicationSettingsBuilder()
+                .WithFolderNamingPattern("{Author}/{Title}")
+                .WithOutputPath(root)
+                .Build());
+            // Replace the base-seed root (path = "/audiobooks") with one
+            // pointing at the temp directory so the preview's filesystem
+            // checks actually look at our test fixture.
+            foreach (var existing in await _rootFolderRepository.GetAllAsync())
+            {
+                await _rootFolderRepository.RemoveAsync(existing.Id);
+            }
+            await _rootFolderRepository.AddAsync(new RootFolderBuilder()
+                .WithName("Library")
+                .WithPath(root)
+                .WithIsDefault()
+                .Build());
+
+            var canonical = Path.Combine(root, "Author Z", "Settled");
+            Directory.CreateDirectory(canonical);
+            await File.WriteAllTextAsync(Path.Combine(canonical, "book.m4b"), "real audiobook content");
+
+            var ab = await _audiobookRepository.AddAsync(new Audiobook
+            {
+                Title = "Settled",
+                Authors = new List<string> { "Author Z" },
+                BasePath = canonical,
+            });
+            await AttachFileAsync(ab, $"{canonical}/book.m4b");
+
+            var preview = await GetPreviewAsync();
+            var row = Assert.Single(preview.Rows);
+            Assert.Equal(OrganizePreviewStatus.AlreadyCanonical, row.Status);
+            Assert.Equal(1, preview.AlreadyCanonicalCount);
+            Assert.Equal(0, preview.InvalidTargetCount);
+        }
+
+        private async Task<OrganizeLibraryPreviewDto> GetPreviewAsync()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var actionResult = await controller.GetOrganizePreview(CancellationToken.None) as OkObjectResult;
+            Assert.NotNull(actionResult);
+            return Assert.IsType<OrganizeLibraryPreviewDto>(actionResult!.Value);
+        }
+
+        private async Task<OrganizeLibraryApplyResultDto> ApplyAsync(IEnumerable<int> ids)
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var actionResult = await controller.ApplyOrganize(new OrganizeLibraryApplyRequest
+            {
+                AudiobookIds = ids.ToList(),
+            }, CancellationToken.None) as OkObjectResult;
+            Assert.NotNull(actionResult);
+            return Assert.IsType<OrganizeLibraryApplyResultDto>(actionResult!.Value);
+        }
+
+        private sealed class TempDirectory : IDisposable
+        {
+            public string Path { get; }
+            public TempDirectory()
+            {
+                Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"listenarr-organize-tests-{Guid.NewGuid():N}");
+                Directory.CreateDirectory(Path);
+            }
+            public void Dispose()
+            {
+                try { Directory.Delete(Path, recursive: true); }
+                catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+                {
+                    /* Best effort — test cleanup. */
+                }
+            }
+        }
+    }
+}

--- a/tests/Features/Infrastructure/Library/Moving/MoveJobProcessorTests.cs
+++ b/tests/Features/Infrastructure/Library/Moving/MoveJobProcessorTests.cs
@@ -90,13 +90,82 @@ namespace Listenarr.Tests.Features.Infrastructure.Library.Moving
             Assert.True(File.Exists(Path.Join(src, "book.m4b")));
         }
 
+        [Fact]
+        public async Task ProcessJobAsync_StubTarget_ReplacedWhenFlagSet()
+        {
+            // Target holds only leftover metadata (no audio) and the organize
+            // flow queued the job with ReplaceStubTarget — the stub is deleted
+            // and replaced instead of failing the move.
+            var src = FileService.GetTempDirectory("move-stub-src");
+            await FileService.GetFileAsync(src, "book.m4b", "audio");
+            var dst = FileService.GetTempDirectory("move-stub-dst");
+            await FileService.GetFileAsync(dst, "Title - Author.opf", "stale-metadata");
+            await FileService.GetFileAsync(dst, "cover.jpg", "stale-cover");
+            var audiobook = await _audiobookRepository.AddAsync(new Audiobook { Title = "Stub Replace", BasePath = src });
+            var (queue, job) = await CreateQueuedMoveJobAsync(audiobook, dst, src, replaceStubTarget: true);
+
+            var processor = _provider.GetRequiredService<IMoveJobProcessor>();
+            await processor.ProcessJobAsync(job, CancellationToken.None);
+
+            var updatedJob = await queue.GetJobAsync(job.Id);
+            Assert.Equal("Completed", updatedJob!.Status);
+            Assert.True(File.Exists(Path.Join(dst, "book.m4b")));
+            Assert.False(File.Exists(Path.Join(dst, "Title - Author.opf")));
+            Assert.False(File.Exists(Path.Join(dst, "cover.jpg")));
+            Assert.False(Directory.Exists(src));
+        }
+
+        [Fact]
+        public async Task ProcessJobAsync_StubTarget_RefusedWithoutFlag()
+        {
+            var src = FileService.GetTempDirectory("move-stub-noflag-src");
+            await FileService.GetFileAsync(src, "book.m4b", "audio");
+            var dst = FileService.GetTempDirectory("move-stub-noflag-dst");
+            await FileService.GetFileAsync(dst, "Title - Author.opf", "stale-metadata");
+            var audiobook = await _audiobookRepository.AddAsync(new Audiobook { Title = "Stub No Flag", BasePath = src });
+            var (queue, job) = await CreateQueuedMoveJobAsync(audiobook, dst, src);
+
+            var processor = _provider.GetRequiredService<IMoveJobProcessor>();
+            await processor.ProcessJobAsync(job, CancellationToken.None);
+
+            var updatedJob = await queue.GetJobAsync(job.Id);
+            Assert.Equal("Failed", updatedJob!.Status);
+            Assert.True(File.Exists(Path.Join(src, "book.m4b")));
+            Assert.True(File.Exists(Path.Join(dst, "Title - Author.opf")));
+        }
+
+        [Fact]
+        public async Task ProcessJobAsync_AudioInTarget_RefusedDespiteFlag()
+        {
+            // Re-verification at execute time: if the target holds audio (even
+            // nested), the replace flag must not destroy it.
+            var src = FileService.GetTempDirectory("move-stub-audio-src");
+            await FileService.GetFileAsync(src, "book.m4b", "fresh-audio");
+            var dst = FileService.GetTempDirectory("move-stub-audio-dst");
+            await FileService.GetFileAsync(dst, "cover.jpg", "cover");
+            var nested = Path.Join(dst, "Sub");
+            Directory.CreateDirectory(nested);
+            await FileService.GetFileAsync(nested, "real-book.mp3", "protected-audio");
+            var audiobook = await _audiobookRepository.AddAsync(new Audiobook { Title = "Stub Audio Guard", BasePath = src });
+            var (queue, job) = await CreateQueuedMoveJobAsync(audiobook, dst, src, replaceStubTarget: true);
+
+            var processor = _provider.GetRequiredService<IMoveJobProcessor>();
+            await processor.ProcessJobAsync(job, CancellationToken.None);
+
+            var updatedJob = await queue.GetJobAsync(job.Id);
+            Assert.Equal("Failed", updatedJob!.Status);
+            Assert.True(File.Exists(Path.Join(src, "book.m4b")));
+            Assert.True(File.Exists(Path.Join(nested, "real-book.mp3")));
+        }
+
         private async Task<(IMoveQueueService Queue, MoveJob Job)> CreateQueuedMoveJobAsync(
             Audiobook audiobook,
             string requestedPath,
-            string sourcePath)
+            string sourcePath,
+            bool replaceStubTarget = false)
         {
             var queue = _provider.GetRequiredService<IMoveQueueService>();
-            var jobId = await queue.EnqueueMoveAsync(audiobook.Id, requestedPath, sourcePath);
+            var jobId = await queue.EnqueueMoveAsync(audiobook.Id, requestedPath, sourcePath, replaceStubTarget);
             var job = await queue.GetJobAsync(jobId);
             Assert.NotNull(job);
             return (queue, job!);

--- a/tests/Features/Infrastructure/Library/Organizing/OrganizeFilesystemTests.cs
+++ b/tests/Features/Infrastructure/Library/Organizing/OrganizeFilesystemTests.cs
@@ -1,0 +1,153 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Application.Audiobooks.Organizing;
+using Listenarr.Infrastructure.Library.Organizing;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Listenarr.Tests.Features.Infrastructure.Library.Organizing
+{
+    [Trait("Name", "OrganizeFilesystemTests")]
+    [Trait("Category", "Organize")]
+    public class OrganizeFilesystemTests : IDisposable
+    {
+        private readonly string _root;
+        private readonly OrganizeFilesystem _fs = new(NullLogger<OrganizeFilesystem>.Instance);
+
+        public OrganizeFilesystemTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "lna-organize-fs-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { if (Directory.Exists(_root)) Directory.Delete(_root, true); }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                System.Diagnostics.Debug.WriteLine("Suppressed non-fatal exception in catch block.");
+            }
+        }
+
+        private string MakeDir(params string[] segments)
+        {
+            var path = Path.Combine(new[] { _root }.Concat(segments).ToArray());
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        private static string WriteFile(string dir, string name, string content)
+        {
+            var path = Path.Combine(dir, name);
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        [Fact(DisplayName = "IsMetadataStubDirectory: metadata-only true (even nested), audio false, missing false, empty true")]
+        public void IsMetadataStubDirectory_Classification()
+        {
+            var stub = MakeDir("stub");
+            WriteFile(stub, "cover.jpg", "img");
+            WriteFile(MakeDir("stub", "nested"), "book.opf", "meta");
+            Assert.True(_fs.IsMetadataStubDirectory(stub));
+
+            var withAudio = MakeDir("with-audio");
+            WriteFile(withAudio, "cover.jpg", "img");
+            WriteFile(MakeDir("with-audio", "nested"), "book.mp3", "audio");
+            Assert.False(_fs.IsMetadataStubDirectory(withAudio));
+
+            Assert.False(_fs.IsMetadataStubDirectory(Path.Combine(_root, "does-not-exist")));
+
+            var empty = MakeDir("empty");
+            Assert.True(_fs.IsMetadataStubDirectory(empty));
+        }
+
+        [Fact(DisplayName = "EvaluateFlatten: nested wrapper with only source's files → Ok with file count")]
+        public void EvaluateFlatten_NestedWrapper_Ok()
+        {
+            // dest/Title holds nothing but the nested source subtree.
+            var dest = MakeDir("Author", "Title");
+            var source = MakeDir("Author", "Title", "Narrator", "Title");
+            WriteFile(source, "book.m4b", "audio");
+            WriteFile(source, "cover.jpg", "img");
+
+            var (feasibility, count) = _fs.EvaluateFlatten(source, dest);
+
+            Assert.Equal(FlattenFeasibility.Ok, feasibility);
+            Assert.Equal(2, count);
+        }
+
+        [Fact(DisplayName = "EvaluateFlatten: dest holds a foreign file → TargetHasForeignFiles")]
+        public void EvaluateFlatten_ForeignFile_Refused()
+        {
+            var dest = MakeDir("Author", "Title");
+            WriteFile(dest, "unrelated.mp3", "someone else's audio");
+            var source = MakeDir("Author", "Title", "Nested");
+            WriteFile(source, "book.m4b", "audio");
+
+            var (feasibility, _) = _fs.EvaluateFlatten(source, dest);
+
+            Assert.Equal(FlattenFeasibility.TargetHasForeignFiles, feasibility);
+        }
+
+        [Fact(DisplayName = "EvaluateFlatten: dest not an ancestor → NotAncestor; missing source → SourceMissing")]
+        public void EvaluateFlatten_NonFlattenShapes_Refused()
+        {
+            var a = MakeDir("A");
+            var b = MakeDir("B");
+            WriteFile(a, "book.m4b", "audio");
+            Assert.Equal(FlattenFeasibility.NotAncestor,
+                _fs.EvaluateFlatten(a, b).Feasibility);
+
+            Assert.Equal(FlattenFeasibility.SourceMissing,
+                _fs.EvaluateFlatten(Path.Combine(_root, "gone"), a).Feasibility);
+        }
+
+        [Fact(DisplayName = "ExecuteFlatten: collapses the wrapper; files land at dest, wrapper gone")]
+        public void ExecuteFlatten_CollapsesWrapper()
+        {
+            var dest = MakeDir("Author", "Title");
+            var source = MakeDir("Author", "Title", "Narrator", "Title");
+            WriteFile(source, "book.m4b", "audio");
+            var extras = MakeDir("Author", "Title", "Narrator", "Title", "extras");
+            WriteFile(extras, "notes.txt", "notes");
+
+            var outcome = _fs.ExecuteFlatten(source, dest, Guid.NewGuid());
+
+            Assert.True(outcome.Success, outcome.ErrorMessage);
+            Assert.Equal(2, outcome.FilesMoved);
+            Assert.True(File.Exists(Path.Combine(dest, "book.m4b")));
+            Assert.True(File.Exists(Path.Combine(dest, "extras", "notes.txt")));
+            Assert.False(Directory.Exists(Path.Combine(dest, "Narrator")));
+        }
+
+        [Fact(DisplayName = "ExecuteFlatten: refuses when dest holds foreign files — nothing moved or deleted")]
+        public void ExecuteFlatten_ForeignFiles_NothingTouched()
+        {
+            var dest = MakeDir("Author", "Title");
+            var foreign = WriteFile(dest, "keep-me.mp3", "protected");
+            var source = MakeDir("Author", "Title", "Nested");
+            var nestedFile = WriteFile(source, "book.m4b", "audio");
+
+            var outcome = _fs.ExecuteFlatten(source, dest, Guid.NewGuid());
+
+            Assert.False(outcome.Success);
+            Assert.True(File.Exists(foreign));
+            Assert.True(File.Exists(nestedFile));
+        }
+    }
+}


### PR DESCRIPTION
## What

A library-wide **Organize** flow (Settings → General): preview every book whose on-disk location disagrees with the configured naming pattern, then apply the moves as queued jobs.

- **Preview** (`LibraryOrganizeSweepWorkflow`): computes each book's expected path via the same `LibraryPathPlanner` that add/move use (so organize can never disagree with them), and groups results — `will_move`, `already_organized`, and per-reason invalid buckets (missing base path, unresolvable pattern, flatten-infeasible, target occupied…).
- **Apply**: enqueues standard move jobs (existing `IMoveQueueService` machinery — nothing new runs in-request), with progress via the existing MoveJob update channel. Returns 503 when the worker isn't available rather than silently dropping.
- **Metadata-stub replacement**: a `will_move` whose target folder exists but contains only metadata (cover/nfo — no audio at any depth, nothing in the DB referencing it) is flagged `ReplaceStubTarget` (new MoveJobs column, hand-written migration) instead of `invalid`. At execution time `MoveJobProcessor` re-verifies the no-audio invariant on disk and deletes the stub so the move can replace it; any audio found since enqueue → the job fails instead. Populated non-stub targets keep failing exactly as before.
- **UI**: `OrganizeLibraryModal` (grouped preview, per-group selection, apply progress) + a pending-moves banner, in a new maintenance section on the General settings tab.

## Notes for review

- Filesystem probing lives behind `IOrganizeFilesystem` (infrastructure); the workflow stays IO-free per the architecture tests.
- `MoveJobProcessor`'s target gate moved to a `TargetGate` partial (the main file was at the 500-line cap).
- Migration `AddReplaceStubTargetToMoveJobs` is hand-written (INTEGER, default false) with Designer + snapshot in agreement; boots and migrates clean in the e2e host.

## Tests

31 new: organize preview/apply workflow + controller tests (ported from the original suite), processor stub-gate tests, and pure filesystem-classifier tests. Full suite **1046/1046**; `vue-tsc` (pinned 3.3.4) + eslint + prettier + vitest clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)