### PR TITLE
feat(library): duplicate record + duplicate copy detection

### DIFF
--- a/fe/src/components/domain/audiobook/SplitCollectionModal.vue
+++ b/fe/src/components/domain/audiobook/SplitCollectionModal.vue
@@ -1,0 +1,497 @@
+<!--
+  Listenarr - Audiobook Management System
+  Copyright (C) 2024-2026 Listenarr Contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<!--
+  Break a multi-book record apart: server-side clustering (subdirectory /
+  embedded tag / filename stem) with a suggested existing library record per
+  group. Each group can be MOVED to a record (files relocate to its folder),
+  DELETED (a redundant duplicate copy — files removed from disk), or left
+  alone.
+-->
+<template>
+  <Modal :visible="visible" size="lg" title="Split collection" @close="onClose">
+    <ModalBody>
+      <div v-if="loading" class="split-empty">Analyzing files…</div>
+      <div v-else-if="error" class="split-error">{{ error }}</div>
+      <template v-else>
+        <p class="split-intro">
+          {{ clusters.length }} group{{ clusters.length === 1 ? '' : 's' }} detected. Move a group
+          to the record it belongs to (files relocate into its folder), delete a redundant copy, or
+          leave it alone.
+        </p>
+        <div class="split-clusters">
+          <div v-for="c in clusters" :key="c.key" class="split-cluster">
+            <div class="split-cluster-head">
+              <span class="split-cluster-name">
+                <strong>{{ c.displayName }}</strong>
+                <small
+                  >{{ c.fileIds.length }} file{{ c.fileIds.length === 1 ? '' : 's' }}
+                  <template v-if="c.fileNames.length">· e.g. {{ c.fileNames[0] }}</template></small
+                >
+              </span>
+              <div class="split-actions">
+                <label
+                  ><input type="radio" :name="`act-${c.key}`" value="none" v-model="c.action" />
+                  Leave</label
+                >
+                <label
+                  ><input
+                    type="radio"
+                    :name="`act-${c.key}`"
+                    value="move"
+                    v-model="c.action"
+                    :disabled="!c.targetId"
+                  />
+                  Move</label
+                >
+                <label class="split-delete-label"
+                  ><input type="radio" :name="`act-${c.key}`" value="delete" v-model="c.action" />
+                  Delete</label
+                >
+              </div>
+            </div>
+            <div class="split-cluster-dest">
+              <template v-if="c.editing">
+                <input
+                  v-model="c.query"
+                  type="text"
+                  class="split-search"
+                  placeholder="Search your library…"
+                />
+                <div class="split-candidates">
+                  <button
+                    v-for="cand in candidatesFor(c)"
+                    :key="cand.id"
+                    type="button"
+                    class="split-candidate"
+                    @click="pickTarget(c, cand)"
+                  >
+                    {{ cand.title }}
+                    <small>id {{ cand.id }}</small>
+                  </button>
+                  <div v-if="candidatesFor(c).length === 0" class="split-empty">No matches.</div>
+                </div>
+              </template>
+              <template v-else>
+                <span v-if="c.targetId" class="split-dest-label">
+                  → {{ c.targetTitle }}
+                  <small>id {{ c.targetId }}</small>
+                </span>
+                <span v-else class="split-dest-label split-dest-none">no destination</span>
+                <button type="button" class="split-change-btn" @click="c.editing = true">
+                  {{ c.targetId ? 'Change…' : 'Choose…' }}
+                </button>
+              </template>
+            </div>
+            <details class="split-files">
+              <summary>files</summary>
+              <div class="split-file" v-for="name in c.fileNames" :key="name">{{ name }}</div>
+            </details>
+          </div>
+        </div>
+        <div v-if="applying" class="split-progress">{{ progressText }}</div>
+      </template>
+    </ModalBody>
+    <div class="modal-footer">
+      <button type="button" class="btn" :disabled="applying" @click="onClose">Cancel</button>
+      <button
+        type="button"
+        class="btn btn-primary"
+        :disabled="applying || (moveCount === 0 && deleteCount === 0)"
+        @click="apply"
+      >
+        {{ applyLabel }}
+      </button>
+    </div>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, reactive } from 'vue'
+import { Modal, ModalBody } from '@/components/feedback'
+import { apiService } from '@/services/api'
+import { useToast } from '@/services/toastService'
+import { useLibraryStore } from '@/stores/library'
+import { showConfirm } from '@/composables/useConfirm'
+import type { Audiobook } from '@/types'
+
+type GroupAction = 'none' | 'move' | 'delete'
+
+interface ClusterRow {
+  key: string
+  displayName: string
+  fileIds: number[]
+  fileNames: string[]
+  targetId: number | null
+  targetTitle: string | null
+  action: GroupAction
+  editing: boolean
+  query: string
+}
+
+const props = defineProps<{
+  visible: boolean
+  audiobook: Audiobook | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'done', result: { groupsMoved: number; filesMoved: number; filesDeleted: number }): void
+}>()
+
+const toast = useToast()
+const libraryStore = useLibraryStore()
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+const clusters = ref<ClusterRow[]>([])
+const applying = ref(false)
+const progressText = ref('')
+
+const moveCount = computed(
+  () => clusters.value.filter((c) => c.action === 'move' && c.targetId).length,
+)
+const deleteCount = computed(() => clusters.value.filter((c) => c.action === 'delete').length)
+const applyLabel = computed(() => {
+  if (applying.value) return 'Working…'
+  const parts: string[] = []
+  if (moveCount.value > 0) parts.push(`move ${moveCount.value}`)
+  if (deleteCount.value > 0) parts.push(`delete ${deleteCount.value}`)
+  return parts.length ? `Apply (${parts.join(', ')})` : 'Apply'
+})
+
+watch(
+  () => props.visible,
+  async (visible) => {
+    if (!visible || !props.audiobook) return
+    loading.value = true
+    error.value = null
+    clusters.value = []
+    applying.value = false
+    if (libraryStore.audiobooks.length === 0) {
+      void libraryStore.fetchLibrary().catch(() => {})
+    }
+    try {
+      const preview = await apiService.getSplitPreview(props.audiobook.id)
+      clusters.value = preview.clusters.map((c) =>
+        reactive({
+          key: c.key,
+          displayName: c.displayName,
+          fileIds: c.fileIds,
+          fileNames: c.fileNames,
+          targetId: c.suggestedTargetId ?? null,
+          targetTitle: c.suggestedTargetTitle ?? null,
+          action: (c.suggestedTargetId ? 'move' : 'none') as GroupAction,
+          editing: false,
+          query: c.displayName,
+        }),
+      )
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Could not analyze this record.'
+    } finally {
+      loading.value = false
+    }
+  },
+)
+
+// Common words carry no signal — "The Rolling Stones" must not surface every
+// record containing "the".
+const STOPWORDS = new Set([
+  'the',
+  'a',
+  'an',
+  'of',
+  'and',
+  'or',
+  'in',
+  'on',
+  'to',
+  'for',
+  'by',
+  'at',
+  'is',
+  'it',
+  'vol',
+  'volume',
+  'book',
+  'part',
+  'unabridged',
+  'abridged',
+])
+
+function tokenize(text: string): string[] {
+  return (text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 1 && !STOPWORDS.has(t))
+}
+
+function candidatesFor(c: ClusterRow) {
+  const sourceId = props.audiobook?.id
+  const tokens = tokenize(c.query)
+  if (tokens.length === 0) return []
+  return libraryStore.audiobooks
+    .filter((b) => b.id !== sourceId)
+    .map((b) => {
+      const titleTokens = new Set(tokenize(b.title || ''))
+      const score = tokens.reduce((s, t) => s + (titleTokens.has(t) ? 1 : 0), 0)
+      return { id: b.id, title: b.title || '', score }
+    })
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title))
+    .slice(0, 8)
+}
+
+function pickTarget(c: ClusterRow, cand: { id: number; title: string }) {
+  c.targetId = cand.id
+  c.targetTitle = cand.title
+  c.action = 'move'
+  c.editing = false
+}
+
+async function apply() {
+  const book = props.audiobook
+  if (!book || applying.value) return
+  const moves = clusters.value.filter((c) => c.action === 'move' && c.targetId)
+  const deletes = clusters.value.filter((c) => c.action === 'delete')
+  if (moves.length === 0 && deletes.length === 0) return
+
+  if (deletes.length > 0) {
+    const fileCount = deletes.reduce((n, c) => n + c.fileIds.length, 0)
+    const names = deletes.map((c) => `"${c.displayName}"`).join(', ')
+    const ok = await showConfirm(
+      `Delete ${fileCount} file(s) from disk for group(s) ${names}? This cannot be undone.`,
+      'Confirm deletion',
+      { danger: true, confirmText: 'Delete files', cancelText: 'Cancel' },
+    )
+    if (!ok) return
+  }
+
+  applying.value = true
+  let groupsMoved = 0
+  let filesMoved = 0
+  let filesDeleted = 0
+  const failures: string[] = []
+
+  for (const [index, c] of moves.entries()) {
+    progressText.value = `Moving "${c.displayName}" (${index + 1}/${moves.length})…`
+    try {
+      const result = await apiService.transferAudiobookFiles(book.id, c.targetId!, c.fileIds)
+      groupsMoved++
+      filesMoved += result.transferred
+      if (result.warnings?.length) failures.push(`${c.displayName}: ${result.warnings.join(' ')}`)
+    } catch (err) {
+      failures.push(`${c.displayName}: ${err instanceof Error ? err.message : 'move failed'}`)
+    }
+  }
+
+  for (const c of deletes) {
+    progressText.value = `Deleting "${c.displayName}"…`
+    for (const fileId of c.fileIds) {
+      try {
+        await apiService.deleteAudiobookFile(book.id, fileId, { deleteFromDisk: true })
+        filesDeleted++
+      } catch (err) {
+        failures.push(`${c.displayName}: ${err instanceof Error ? err.message : 'delete failed'}`)
+        break
+      }
+    }
+  }
+  applying.value = false
+
+  const summary = [
+    filesMoved > 0 ? `moved ${filesMoved} file(s) across ${groupsMoved} book(s)` : null,
+    filesDeleted > 0 ? `deleted ${filesDeleted} file(s)` : null,
+  ]
+    .filter(Boolean)
+    .join('; ')
+  if (failures.length > 0) {
+    toast.warning(`Split finished with issues — ${summary}`, failures.slice(0, 3).join(' · '))
+  } else {
+    toast.success('Split collection complete', `${summary}.`)
+  }
+  emit('done', { groupsMoved, filesMoved, filesDeleted })
+}
+
+function onClose() {
+  if (!applying.value) emit('close')
+}
+</script>
+
+<style scoped>
+.split-intro {
+  color: #adb5bd;
+  font-size: 0.9rem;
+  margin: 0 0 1rem;
+}
+
+.split-clusters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.split-cluster {
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  padding: 0.6rem 0.75rem;
+}
+
+.split-cluster-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.split-cluster-name {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.split-cluster-name small {
+  color: #8a93a0;
+}
+
+.split-actions {
+  display: flex;
+  gap: 0.9rem;
+  font-size: 0.85rem;
+  color: #adb5bd;
+}
+
+.split-actions label {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  cursor: pointer;
+}
+
+.split-delete-label {
+  color: #e74c3c;
+}
+
+.split-cluster-dest {
+  margin: 0.4rem 0 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.split-dest-label {
+  color: #d8dee6;
+  font-size: 0.9rem;
+}
+
+.split-dest-label small {
+  color: #8a93a0;
+  margin-left: 0.35rem;
+}
+
+.split-dest-none {
+  color: #f39c12;
+  font-style: italic;
+}
+
+.split-change-btn {
+  align-self: flex-start;
+  background: none;
+  border: 1px solid var(--brand-500, #4dabf7);
+  color: var(--brand-500, #4dabf7);
+  border-radius: 5px;
+  padding: 2px 10px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.split-search {
+  width: 100%;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid #444;
+  border-radius: 6px;
+  background-color: #1a1a1a;
+  color: #fff;
+  font-size: 0.9rem;
+}
+
+.split-candidates {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.split-candidate {
+  text-align: left;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  color: #d8dee6;
+  border-radius: 5px;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+}
+
+.split-candidate:hover {
+  background: rgba(77, 171, 247, 0.12);
+}
+
+.split-candidate small {
+  color: #8a93a0;
+  margin-left: 0.4rem;
+}
+
+.split-files {
+  margin: 0.45rem 0 0 0;
+  font-size: 0.82rem;
+  color: #8a93a0;
+}
+
+.split-files summary {
+  cursor: pointer;
+}
+
+.split-file {
+  padding-left: 0.8rem;
+  overflow-wrap: anywhere;
+}
+
+.split-progress {
+  margin-top: 0.8rem;
+  color: #4dabf7;
+  font-size: 0.9rem;
+}
+
+.split-empty {
+  color: #8a93a0;
+  font-size: 0.9rem;
+  padding: 0.3rem 0;
+}
+
+.split-error {
+  color: #e74c3c;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+}
+</style>

--- a/fe/src/components/domain/audiobook/TransferFilesModal.vue
+++ b/fe/src/components/domain/audiobook/TransferFilesModal.vue
@@ -1,0 +1,355 @@
+<!--
+  Listenarr - Audiobook Management System
+  Copyright (C) 2024-2026 Listenarr Contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<!--
+  Move audio files from this record to ANOTHER EXISTING library record — the
+  remediation when files actually belong to a different book the library
+  already tracks (often still "wanted"): two books' tracks imported onto one
+  record, or a collection being split into its real books.
+-->
+<template>
+  <Modal :visible="visible" size="lg" title="Move files to another audiobook" @close="onClose">
+    <ModalBody>
+      <div v-if="!audiobook" class="transfer-empty">No audiobook selected.</div>
+      <template v-else>
+        <div class="transfer-section">
+          <div class="transfer-section-title">Files to move</div>
+          <label v-for="f in sourceFiles" :key="f.id" class="transfer-file-row">
+            <input
+              type="checkbox"
+              :checked="selectedFileIds.has(f.id)"
+              @change="toggleFile(f.id)"
+            />
+            <span class="transfer-file-name">{{ fileName(f.path) }}</span>
+          </label>
+          <div v-if="sourceFiles.length === 0" class="transfer-empty">
+            This audiobook has no tracked files.
+          </div>
+        </div>
+
+        <div class="transfer-section">
+          <div class="transfer-section-title">Destination record</div>
+          <input
+            v-model="query"
+            type="text"
+            class="transfer-search"
+            placeholder="Search your library by title…"
+            @input="chosenTargetId = null"
+          />
+          <div v-if="libraryLoading" class="transfer-empty">Loading library…</div>
+          <div v-else-if="candidates.length === 0" class="transfer-empty">
+            No library records match "{{ query }}".
+          </div>
+          <div v-else class="transfer-candidates">
+            <label v-for="c in candidates" :key="c.id" class="transfer-candidate">
+              <input type="radio" name="transfer-target" :value="c.id" v-model="chosenTargetId" />
+              <span class="transfer-candidate-text">
+                <strong>{{ c.title }}</strong>
+                <small>
+                  {{ (c.narrators || []).slice(0, 2).join(', ') || 'Unknown narrator' }}
+                  <template v-if="c.publishYear"> · {{ c.publishYear }}</template>
+                  · id {{ c.id }}
+                  <template v-if="(c.fileCount ?? 0) > 0">
+                    · <span class="transfer-has-files">{{ c.fileCount }} file(s)</span>
+                  </template>
+                </small>
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <div v-if="chosenTargetFileCount > 0" class="transfer-warning">
+          <strong>{{ chosenTarget?.title }}</strong> already has {{ chosenTargetFileCount }} audio
+          file(s). The moved files will be <strong>added alongside</strong> them — not replace them
+          — which can leave two books' tracks mixed in one record.
+        </div>
+
+        <div class="transfer-note">
+          Files keep their audio untouched: ownership moves to the destination record (and the file
+          relocates into its folder when possible).
+        </div>
+      </template>
+    </ModalBody>
+    <div class="modal-footer">
+      <button type="button" class="btn" @click="onClose">Cancel</button>
+      <button
+        type="button"
+        class="btn btn-primary"
+        :disabled="transferring || !chosenTargetId || selectedFileIds.size === 0"
+        @click="confirmTransfer"
+      >
+        {{ transferring ? 'Moving…' : `Move ${selectedFileIds.size} file(s)` }}
+      </button>
+    </div>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { Modal, ModalBody } from '@/components/feedback'
+import { apiService } from '@/services/api'
+import { useToast } from '@/services/toastService'
+import { showConfirm } from '@/composables/useConfirm'
+import { useLibraryStore } from '@/stores/library'
+import type { Audiobook } from '@/types'
+
+type SourceFile = { id: number; path?: string | null }
+
+const props = defineProps<{
+  visible: boolean
+  audiobook: Audiobook | null
+  // Seeds the destination search — e.g. the title the files' tags claim.
+  initialQuery?: string | null
+  // Pre-select a subset of files (e.g. a multi-select made in the file list).
+  // When omitted/empty, all of the source's files are selected as before.
+  initialFileIds?: number[] | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'done', result: { targetId: number; transferred: number }): void
+}>()
+
+const toast = useToast()
+const libraryStore = useLibraryStore()
+
+const query = ref('')
+const chosenTargetId = ref<number | null>(null)
+const selectedFileIds = ref<Set<number>>(new Set())
+const transferring = ref(false)
+const libraryLoading = ref(false)
+
+const sourceFiles = computed<SourceFile[]>(() => props.audiobook?.files ?? [])
+
+const chosenTarget = computed<Audiobook | null>(
+  () => libraryStore.audiobooks.find((b) => b.id === chosenTargetId.value) ?? null,
+)
+const chosenTargetFileCount = computed(() => chosenTarget.value?.fileCount ?? 0)
+
+watch(
+  () => props.visible,
+  (visible) => {
+    if (!visible) return
+    query.value = (props.initialQuery || '').trim()
+    chosenTargetId.value = null
+    selectedFileIds.value =
+      props.initialFileIds && props.initialFileIds.length
+        ? new Set(props.initialFileIds)
+        : new Set(sourceFiles.value.map((f) => f.id))
+    transferring.value = false
+    if (libraryStore.audiobooks.length === 0) {
+      libraryLoading.value = true
+      void libraryStore
+        .fetchLibrary()
+        .catch(() => {
+          /* candidates list shows empty; search still usable after retry */
+        })
+        .finally(() => {
+          libraryLoading.value = false
+        })
+    }
+  },
+)
+
+// Token-overlap ranking so a filename-ish query ("Warbreaker 2 of 3 Dramatized")
+// surfaces the matching record even when it isn't a substring of the title.
+const candidates = computed(() => {
+  const sourceId = props.audiobook?.id
+  const tokens = tokenize(query.value)
+  if (tokens.length === 0) return []
+  return libraryStore.audiobooks
+    .filter((b) => b.id !== sourceId)
+    .map((b) => ({ book: b, score: overlapScore(tokens, tokenize(b.title || '')) }))
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score || (a.book.title || '').localeCompare(b.book.title || ''))
+    .slice(0, 12)
+    .map((x) => x.book)
+})
+
+function tokenize(text: string): string[] {
+  return (text || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 1)
+}
+
+function overlapScore(queryTokens: string[], titleTokens: string[]): number {
+  const titleSet = new Set(titleTokens)
+  return queryTokens.reduce((score, t) => score + (titleSet.has(t) ? 1 : 0), 0)
+}
+
+function toggleFile(id: number) {
+  const next = new Set(selectedFileIds.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  selectedFileIds.value = next
+}
+
+function fileName(path?: string | null): string {
+  if (!path) return 'Unknown file'
+  const parts = path.split(/[\\/]/)
+  return parts[parts.length - 1] || path
+}
+
+async function confirmTransfer() {
+  const book = props.audiobook
+  const targetId = chosenTargetId.value
+  if (!book || !targetId || transferring.value) return
+
+  // Moving into a record that already has audio merges the two sets (it never
+  // overwrites) — confirm so a wrong destination doesn't silently end up with
+  // two books' tracks mixed together.
+  if (chosenTargetFileCount.value > 0) {
+    const ok = await showConfirm(
+      `${chosenTarget.value?.title || 'This record'} already has ${chosenTargetFileCount.value} audio ` +
+        `file(s). The ${selectedFileIds.value.size} moved file(s) will be added alongside the ` +
+        `existing ones, not replace them.\n\nMove them anyway?`,
+      'Destination already has files',
+    )
+    if (!ok) return
+  }
+
+  transferring.value = true
+  try {
+    const allSelected = selectedFileIds.value.size === sourceFiles.value.length
+    const result = await apiService.transferAudiobookFiles(
+      book.id,
+      targetId,
+      allSelected ? null : Array.from(selectedFileIds.value),
+    )
+    if (result.warnings?.length) {
+      toast.warning('Files moved with warnings', result.warnings.join(' '))
+    } else {
+      toast.success('Files moved', result.message)
+    }
+    emit('done', { targetId, transferred: result.transferred })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    toast.error('Could not move files', message)
+    transferring.value = false
+  }
+}
+
+function onClose() {
+  if (!transferring.value) emit('close')
+}
+</script>
+
+<style scoped>
+.transfer-section {
+  margin-bottom: 1.25rem;
+}
+
+.transfer-section-title {
+  font-weight: 500;
+  color: #fff;
+  margin-bottom: 0.5rem;
+}
+
+.transfer-file-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0;
+  cursor: pointer;
+}
+
+.transfer-file-name {
+  font-size: 0.9rem;
+  color: #d8dee6;
+  overflow-wrap: anywhere;
+}
+
+.transfer-search {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #444;
+  border-radius: 6px;
+  background-color: #1a1a1a;
+  color: #fff;
+  font-size: 0.95rem;
+  margin-bottom: 0.6rem;
+}
+
+.transfer-candidates {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.transfer-candidate {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.transfer-candidate:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.transfer-candidate-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.transfer-candidate-text small {
+  color: #8a93a0;
+}
+
+.transfer-has-files {
+  color: #e0a458;
+}
+
+.transfer-warning {
+  margin-bottom: 0.85rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: #f0c674;
+  background-color: rgba(224, 164, 88, 0.1);
+  border: 1px solid rgba(224, 164, 88, 0.3);
+}
+
+.transfer-warning strong {
+  color: #fff;
+}
+
+.transfer-note {
+  font-size: 0.85rem;
+  color: #adb5bd;
+}
+
+.transfer-empty {
+  color: #8a93a0;
+  font-size: 0.9rem;
+  padding: 0.4rem 0;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+}
+</style>

--- a/fe/src/components/settings/DuplicatesSection.vue
+++ b/fe/src/components/settings/DuplicatesSection.vue
@@ -1,0 +1,295 @@
+<!--
+  Listenarr - Audiobook Management System
+  Copyright (C) 2024-2026 Listenarr Contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<!--
+  Duplicate sweep results: duplicate RECORDS (same book tracked twice) with a
+  suggested keeper and per-record delete, and records holding duplicate COPIES
+  of their own audio (resolved on the book page via multi-select / split).
+-->
+<template>
+  <div class="settings-section duplicates-section">
+    <div class="dupes-header">
+      <h3>Duplicates</h3>
+      <button type="button" class="dupes-refresh-btn" :disabled="loading" @click="load">
+        {{ loading ? 'Scanning…' : hasLoaded ? 'Rescan' : 'Scan library' }}
+      </button>
+    </div>
+    <p class="dupes-help">
+      Finds books tracked twice (same ASIN, or same title and author without an edition signal) and
+      records holding two copies of their own audio.
+    </p>
+
+    <div v-if="error" class="dupes-error">{{ error }}</div>
+
+    <template v-if="hasLoaded && !loading && !error">
+      <div class="dupes-subhead">
+        Duplicate records
+        <small
+          >{{ groups.length }} group{{ groups.length === 1 ? '' : 's' }} — the suggested keeper is
+          marked; deleting removes the record only (files stay on disk).</small
+        >
+      </div>
+      <div v-if="groups.length === 0" class="dupes-empty">No duplicate records found.</div>
+      <div v-for="g in groups" :key="g.key" class="dupes-group">
+        <span class="dupes-reason" :class="`dupes-reason-${g.reason}`">{{
+          g.reason === 'asin' ? 'same ASIN' : 'same title + author'
+        }}</span>
+        <div v-for="b in g.books" :key="b.id" class="dupes-row">
+          <router-link :to="`/audiobooks/${b.id}`" class="dupes-title">{{ b.title }}</router-link>
+          <span v-if="b.id === g.suggestedKeeperId" class="dupes-keeper">keep</span>
+          <small class="dupes-meta">
+            {{ b.fileCount }} file{{ b.fileCount === 1 ? '' : 's' }}
+            <template v-if="b.fileSize > 0"> · {{ formatSize(b.fileSize) }}</template>
+            <template v-if="b.monitored"> · monitored</template>
+            · id {{ b.id }}
+          </small>
+          <button
+            v-if="b.id !== g.suggestedKeeperId"
+            type="button"
+            class="dupes-delete-btn"
+            :disabled="deletingId === b.id"
+            @click="deleteRecord(b)"
+          >
+            {{ deletingId === b.id ? 'Deleting…' : 'Delete record' }}
+          </button>
+        </div>
+      </div>
+
+      <div class="dupes-subhead">
+        Duplicate copies
+        <small
+          >{{ copies.length }} record{{ copies.length === 1 ? '' : 's' }} holding the same audio
+          twice — open the book and use file multi-select or Split Collection.</small
+        >
+      </div>
+      <div v-if="copies.length === 0" class="dupes-empty">No duplicate copies found.</div>
+      <div v-for="c in copies" :key="c.id" class="dupes-row">
+        <router-link :to="`/audiobooks/${c.id}`" class="dupes-title">{{ c.title }}</router-link>
+        <small class="dupes-meta"
+          >{{ c.fileCount }} files in {{ c.clusterCount }} groups · id {{ c.id }}</small
+        >
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { apiService } from '@/services/api'
+import { useToast } from '@/services/toastService'
+import { showConfirm } from '@/composables/useConfirm'
+import type { DuplicateBookSummary, DuplicateGroup, DuplicateCopyBook } from '@/types'
+
+const toast = useToast()
+
+const loading = ref(false)
+const hasLoaded = ref(false)
+const error = ref<string | null>(null)
+const groups = ref<DuplicateGroup[]>([])
+const copies = ref<DuplicateCopyBook[]>([])
+const deletingId = ref<number | null>(null)
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const resp = await apiService.getLibraryDuplicates()
+    groups.value = resp.duplicateGroups
+    copies.value = resp.duplicateCopyBooks
+    hasLoaded.value = true
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Duplicate scan failed.'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function deleteRecord(b: DuplicateBookSummary) {
+  const ok = await showConfirm(
+    `Delete the record "${b.title}" (id ${b.id})? Its ${b.fileCount} tracked file(s) stay on ` +
+      `disk; only the library record is removed.`,
+    'Delete duplicate record',
+    { danger: true, confirmText: 'Delete record', cancelText: 'Cancel' },
+  )
+  if (!ok) return
+
+  deletingId.value = b.id
+  try {
+    await apiService.removeFromLibrary(b.id)
+    toast.success('Record deleted', `Removed "${b.title}" (id ${b.id}).`)
+    await load()
+  } catch (err) {
+    toast.warning(
+      'Delete failed',
+      `Could not remove "${b.title}": ${err instanceof Error ? err.message : 'unknown error'}`,
+    )
+  } finally {
+    deletingId.value = null
+  }
+}
+
+function formatSize(bytes: number): string {
+  if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GB`
+  if (bytes >= 1024 ** 2) return `${(bytes / 1024 ** 2).toFixed(0)} MB`
+  return `${Math.max(1, Math.round(bytes / 1024))} KB`
+}
+</script>
+
+<style scoped>
+.duplicates-section {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.dupes-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.dupes-header h3 {
+  margin: 0;
+  color: #fff;
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.dupes-refresh-btn {
+  padding: 6px 12px;
+  background-color: rgba(var(--brand-rgb), 0.1);
+  border: 1px solid var(--brand-500);
+  border-radius: 4px;
+  color: var(--brand-500);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.dupes-refresh-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.dupes-help {
+  margin: 0.5rem 0 0;
+  color: #868e96;
+  font-size: 0.85rem;
+}
+
+.dupes-error {
+  margin-top: 0.75rem;
+  color: #e74c3c;
+  font-size: 0.9rem;
+}
+
+.dupes-subhead {
+  margin-top: 1.25rem;
+  color: #fff;
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.dupes-subhead small {
+  display: block;
+  color: #868e96;
+  font-weight: 400;
+  font-size: 0.8rem;
+}
+
+.dupes-empty {
+  color: #8a93a0;
+  font-size: 0.85rem;
+  padding: 0.4rem 0;
+}
+
+.dupes-group {
+  margin-top: 0.6rem;
+  padding: 0.5rem 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+}
+
+.dupes-reason {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 1px 8px;
+  border-radius: 999px;
+  margin-bottom: 0.3rem;
+}
+
+.dupes-reason-asin {
+  background: rgba(231, 76, 60, 0.12);
+  color: #e74c3c;
+  border: 1px solid rgba(231, 76, 60, 0.3);
+}
+
+.dupes-reason-title-author {
+  background: rgba(243, 156, 18, 0.12);
+  color: #f39c12;
+  border: 1px solid rgba(243, 156, 18, 0.3);
+}
+
+.dupes-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  padding: 0.25rem 0;
+  flex-wrap: wrap;
+}
+
+.dupes-title {
+  color: #4dabf7;
+  text-decoration: none;
+}
+
+.dupes-title:hover {
+  text-decoration: underline;
+}
+
+.dupes-keeper {
+  font-size: 0.7rem;
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: rgba(46, 204, 113, 0.12);
+  color: #2ecc71;
+  border: 1px solid rgba(46, 204, 113, 0.3);
+}
+
+.dupes-meta {
+  color: #8a93a0;
+  font-size: 0.78rem;
+}
+
+.dupes-delete-btn {
+  margin-left: auto;
+  padding: 2px 10px;
+  font-size: 0.78rem;
+  background-color: rgba(255, 107, 107, 0.1);
+  color: #ff6b6b;
+  border: 1px solid rgba(255, 107, 107, 0.3);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.dupes-delete-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+</style>

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -1256,6 +1256,26 @@ class ApiService {
     })
   }
 
+  async deleteAudiobookFile(
+    audiobookId: number,
+    fileId: number,
+    options?: { deleteFromDisk?: boolean },
+  ): Promise<{
+    message: string
+    fileId: number
+    deletedFromDisk: boolean
+    path: string | null
+    warnings: string[]
+  }> {
+    const params = new URLSearchParams()
+    if (options?.deleteFromDisk !== undefined)
+      params.set('deleteFromDisk', String(options.deleteFromDisk))
+    const suffix = params.toString() ? `?${params.toString()}` : ''
+    return this.request(`/library/${audiobookId}/files/${fileId}${suffix}`, {
+      method: 'DELETE',
+    })
+  }
+
   async removeFromLibrary(
     id: number,
     options?: { deleteFiles?: boolean; deleteFolder?: boolean },

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -1238,6 +1238,24 @@ class ApiService {
     })
   }
 
+  async transferAudiobookFiles(
+    sourceId: number,
+    targetAudiobookId: number,
+    fileIds: number[] | null,
+  ): Promise<{
+    message: string
+    sourceId: number
+    targetId: number
+    transferred: number
+    physicallyMoved: number
+    warnings: string[]
+  }> {
+    return this.request(`/library/${sourceId}/files/transfer`, {
+      method: 'POST',
+      body: JSON.stringify({ targetAudiobookId, fileIds }),
+    })
+  }
+
   async removeFromLibrary(
     id: number,
     options?: { deleteFiles?: boolean; deleteFolder?: boolean },

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -60,6 +60,7 @@ import type {
   RenamePreview,
   RenameOperation,
   RenameResult,
+  LibraryDuplicatesResponse,
 } from '@/types'
 import { getStartupConfigCached, resetCache as resetStartupConfigCache } from './startupConfigCache'
 import { sessionTokenManager } from '@/utils/sessionToken'
@@ -1288,6 +1289,10 @@ class ApiService {
     return this.request(`/library/${audiobookId}/files/${fileId}${suffix}`, {
       method: 'DELETE',
     })
+  }
+
+  async getLibraryDuplicates(): Promise<LibraryDuplicatesResponse> {
+    return this.request<LibraryDuplicatesResponse>(`/library/duplicates`)
   }
 
   async removeFromLibrary(

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -1238,6 +1238,20 @@ class ApiService {
     })
   }
 
+  async getSplitPreview(id: number): Promise<{
+    audiobookId: number
+    clusters: Array<{
+      key: string
+      displayName: string
+      fileIds: number[]
+      fileNames: string[]
+      suggestedTargetId?: number | null
+      suggestedTargetTitle?: string | null
+    }>
+  }> {
+    return this.request(`/library/${id}/split/preview`)
+  }
+
   async transferAudiobookFiles(
     sourceId: number,
     targetAudiobookId: number,

--- a/fe/src/services/toastService.ts
+++ b/fe/src/services/toastService.ts
@@ -80,9 +80,13 @@ export function useToast() {
       push('info', title, message, timeoutMs),
     success: (title: string, message: string, timeoutMs?: number) =>
       push('success', title, message, timeoutMs),
-    warning: (title: string, message: string, timeoutMs?: number) =>
+    // Warnings and errors are sticky by default (timeoutMs = 0): they carry
+    // information the user needs to act on — a 5s auto-dismiss too often vanishes
+    // before it can be read. They're dismissed via the toast's close button.
+    // Callers can still pass an explicit timeout to opt back into auto-dismiss.
+    warning: (title: string, message: string, timeoutMs = 0) =>
       push('warning', title, message, timeoutMs),
-    error: (title: string, message: string, timeoutMs?: number) =>
+    error: (title: string, message: string, timeoutMs = 0) =>
       push('error', title, message, timeoutMs),
   }
 }

--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -1109,3 +1109,35 @@ export interface RenameResult {
   error?: string
   renamedFiles: FileRenameResultItem[]
 }
+
+/** One book inside a duplicate-record group from GET /library/duplicates. */
+export interface DuplicateBookSummary {
+  id: number
+  title: string | null
+  subtitle?: string | null
+  publishYear?: string | null
+  asin?: string | null
+  fileCount: number
+  fileSize: number
+  monitored?: boolean
+}
+
+export interface DuplicateGroup {
+  key: string
+  reason: 'asin' | 'title-author'
+  books: DuplicateBookSummary[]
+  suggestedKeeperId: number
+}
+
+/** A record likely holding the same audio twice (two filename schemes). */
+export interface DuplicateCopyBook {
+  id: number
+  title: string | null
+  clusterCount: number
+  fileCount: number
+}
+
+export interface LibraryDuplicatesResponse {
+  duplicateGroups: DuplicateGroup[]
+  duplicateCopyBooks: DuplicateCopyBook[]
+}

--- a/fe/src/views/library/AudiobookDetailView.vue
+++ b/fe/src/views/library/AudiobookDetailView.vue
@@ -738,6 +738,15 @@
     @close="closeTransferModal"
     @done="onTransferDone"
   />
+
+  <!-- Break a multi-book record apart: server-side clustering with a suggested
+       destination per group; applying is transfers/deletes of each group. -->
+  <SplitCollectionModal
+    :visible="showSplitModal"
+    :audiobook="audiobook"
+    @close="showSplitModal = false"
+    @done="onSplitDone"
+  />
 </template>
 
 <script setup lang="ts">
@@ -768,6 +777,7 @@ import { useProtectedImages } from '@/composables/useProtectedImages'
 import { buildAudibleProductUrl } from '@/utils/marketDomains'
 import EditAudiobookModal from '@/components/domain/audiobook/EditAudiobookModal.vue'
 import TransferFilesModal from '@/components/domain/audiobook/TransferFilesModal.vue'
+import SplitCollectionModal from '@/components/domain/audiobook/SplitCollectionModal.vue'
 import ManualSearchModal from '@/components/domain/search/ManualSearchModal.vue'
 import RenamePreviewModal from '@/components/domain/organize/RenamePreviewModal.vue'
 import CustomSelect from '@/components/form/CustomSelect.vue'
@@ -808,6 +818,7 @@ import {
   PhCircle,
   PhDiscordLogo,
   PhArrowsLeftRight,
+  PhArrowsSplit,
 } from '@phosphor-icons/vue'
 
 const route = useRoute()
@@ -836,6 +847,7 @@ const scanJobId = ref<string | null>(null)
 const showEditModal = ref(false)
 const showOrganizeModal = ref(false)
 const showTransferModal = ref(false)
+const showSplitModal = ref(false)
 const showMoreActions = ref(false)
 
 // History state
@@ -946,6 +958,18 @@ const topActions = computed<DetailTopAction[]>(() => [
     },
   },
   {
+    key: 'split-collection',
+    label: 'Split Collection',
+    title: 'Break a multi-book record into its real books',
+    ariaLabel: 'Split Collection',
+    icon: PhArrowsSplit,
+    disabled: (audiobook.value?.files?.length ?? 0) < 2,
+    desktopGroup: 'secondary',
+    onClick: () => {
+      showSplitModal.value = true
+    },
+  },
+  {
     key: 'delete',
     label: 'Delete',
     title: 'Delete',
@@ -991,6 +1015,7 @@ type DetailTopAction = {
     | 'rescan-metadata'
     | 'organize'
     | 'transfer-files'
+    | 'split-collection'
     | 'delete'
   label: string
   title: string
@@ -1737,6 +1762,15 @@ async function handleOrganizeDone() {
 function closeTransferModal() {
   showTransferModal.value = false
   bulkMoveFileIds.value = []
+}
+
+function onSplitDone() {
+  showSplitModal.value = false
+  clearFileSelection()
+  // Groups left this record — reload it, and refresh the library list so the
+  // destinations' file counts are current too.
+  void loadAudiobook()
+  void libraryStore.fetchLibrary()
 }
 
 async function onTransferDone() {

--- a/fe/src/views/library/AudiobookDetailView.vue
+++ b/fe/src/views/library/AudiobookDetailView.vue
@@ -403,14 +403,56 @@
             </div>
           </div>
         </div>
+        <!-- Bulk-selection toolbar: pick a range of files (shift-click extends) and move
+             or delete them together, instead of one action at a time. -->
+        <div
+          v-if="(audiobook.files?.length ?? 0) > 1"
+          class="file-select-bar"
+          :class="{ active: selectionCount > 0 }"
+        >
+          <label class="checkbox-wrapper select-all-label">
+            <input
+              type="checkbox"
+              class="checkbox-input"
+              :checked="allFilesSelected"
+              :indeterminate.prop="selectionCount > 0 && !allFilesSelected"
+              aria-label="Select all files"
+              @change="toggleSelectAllFiles"
+            />
+            <span class="select-all-text">
+              {{ selectionCount > 0 ? `${selectionCount} selected` : 'Select files' }}
+            </span>
+          </label>
+          <div v-if="selectionCount > 0" class="file-select-actions">
+            <button type="button" class="bulk-move-btn" @click="openBulkMove">
+              Move selected…
+            </button>
+            <button type="button" class="bulk-delete-btn" @click="confirmBulkDelete">
+              <PhTrash />
+              Delete selected
+            </button>
+            <button type="button" class="clear-select-btn" @click="clearFileSelection">
+              Clear
+            </button>
+          </div>
+        </div>
         <div v-if="audiobook.files && audiobook.files.length" class="file-list">
           <div
             v-for="f in audiobook.files"
             :key="f.id"
             class="file-item"
-            :class="{ expanded: isFileAccordionExpanded(f.id) }"
+            :class="{ expanded: isFileAccordionExpanded(f.id), selected: isFileSelected(f.id) }"
           >
             <div class="file-header" @click="toggleFileAccordion(f.id)">
+              <label class="file-select-checkbox" @click.stop>
+                <input
+                  type="checkbox"
+                  class="checkbox-input"
+                  :checked="isFileSelected(f.id)"
+                  :aria-label="`Select ${getFileName(f.path)}`"
+                  @click="toggleFileSelection(f, $event)"
+                />
+              </label>
               <div class="file-info">
                 <PhFileAudio />
                 <span class="file-name">{{ getFileName(f.path) }}</span>
@@ -601,6 +643,49 @@
         </div>
       </template>
     </DeleteConfirmationModal>
+
+    <DeleteConfirmationModal
+      :visible="showBulkDeleteDialog"
+      title="Delete Files"
+      :confirmText="
+        bulkDeleting
+          ? 'Deleting...'
+          : `Delete ${selectionCount} file${selectionCount === 1 ? '' : 's'}`
+      "
+      @close="cancelBulkDelete"
+      @confirm="executeBulkDelete"
+    >
+      <template #default>
+        <p>
+          Remove <strong>{{ selectionCount }}</strong> selected file{{
+            selectionCount === 1 ? '' : 's'
+          }}
+          from this audiobook?
+        </p>
+        <ul class="bulk-delete-list">
+          <li v-for="f in selectedFiles" :key="f.id">{{ getFileName(f.path) }}</li>
+        </ul>
+        <div class="delete-options">
+          <div class="checkbox-row">
+            <label class="checkbox-wrapper checkbox-label">
+              <input
+                v-model="bulkDeleteFromDisk"
+                type="checkbox"
+                class="checkbox-input"
+                aria-label="Also delete the files from disk"
+              />
+              <div class="checkbox-content">
+                <span class="checkbox-title">Also delete the files from disk</span>
+                <small
+                  >Unchecked: only the database records are removed; the files stay on disk and a
+                  rescan will re-import them.</small
+                >
+              </div>
+            </label>
+          </div>
+        </div>
+      </template>
+    </DeleteConfirmationModal>
   </div>
 
   <!-- Loading State -->
@@ -649,7 +734,8 @@
     :visible="showTransferModal"
     :audiobook="audiobook"
     :initial-query="audiobook?.title || ''"
-    @close="showTransferModal = false"
+    :initial-file-ids="bulkMoveFileIds"
+    @close="closeTransferModal"
     @done="onTransferDone"
   />
 </template>
@@ -855,6 +941,7 @@ const topActions = computed<DetailTopAction[]>(() => [
     disabled: !audiobook.value?.files?.length,
     desktopGroup: 'secondary',
     onClick: () => {
+      bulkMoveFileIds.value = []
       showTransferModal.value = true
     },
   },
@@ -1291,6 +1378,7 @@ watch(
 async function loadAudiobook() {
   loading.value = true
   error.value = null
+  clearFileSelection()
 
   try {
     const id = parseInt(route.params.id as string)
@@ -1646,12 +1734,155 @@ async function handleOrganizeDone() {
   await loadAudiobook()
 }
 
+function closeTransferModal() {
+  showTransferModal.value = false
+  bulkMoveFileIds.value = []
+}
+
 async function onTransferDone() {
   showTransferModal.value = false
+  bulkMoveFileIds.value = []
+  clearFileSelection()
   // Files left this record — reload it, and refresh the library list so the
   // destination's file counts are current too.
   await loadAudiobook()
   void libraryStore.fetchLibrary()
+}
+
+// --- Multi-select in the Files list -------------------------------------------------
+// Lets the user tick a range of files (e.g. a duplicate copy of the book) and delete
+// or move them in one action instead of one at a time. Shift-click extends a range.
+type LibraryFile = NonNullable<Audiobook['files']>[number]
+
+const selectedFileIds = ref<Set<number>>(new Set())
+const lastClickedFileId = ref<number | null>(null)
+const selectionCount = computed(() => selectedFileIds.value.size)
+
+function isFileSelected(id: number): boolean {
+  return selectedFileIds.value.has(id)
+}
+
+function clearFileSelection(): void {
+  selectedFileIds.value = new Set()
+  lastClickedFileId.value = null
+}
+
+function toggleFileSelection(file: LibraryFile, event?: MouseEvent): void {
+  const ordered = audiobook.value?.files ?? []
+  const next = new Set(selectedFileIds.value)
+
+  // Shift-click selects the contiguous range from the last clicked row to this one.
+  if (event?.shiftKey && lastClickedFileId.value !== null) {
+    const from = ordered.findIndex((f) => f.id === lastClickedFileId.value)
+    const to = ordered.findIndex((f) => f.id === file.id)
+    if (from !== -1 && to !== -1) {
+      const [lo, hi] = from <= to ? [from, to] : [to, from]
+      for (let i = lo; i <= hi; i++) next.add(ordered[i].id)
+      selectedFileIds.value = next
+      lastClickedFileId.value = file.id
+      return
+    }
+  }
+
+  if (next.has(file.id)) next.delete(file.id)
+  else next.add(file.id)
+  selectedFileIds.value = next
+  lastClickedFileId.value = file.id
+}
+
+const allFilesSelected = computed(() => {
+  const total = audiobook.value?.files?.length ?? 0
+  return total > 0 && selectedFileIds.value.size === total
+})
+
+function toggleSelectAllFiles(): void {
+  if (allFilesSelected.value) {
+    clearFileSelection()
+  } else {
+    selectedFileIds.value = new Set((audiobook.value?.files ?? []).map((f) => f.id))
+  }
+}
+
+// Bulk move: hand the current selection to the transfer modal, which already knows how
+// to pick a destination record and relocate a subset of files.
+const bulkMoveFileIds = ref<number[]>([])
+
+function openBulkMove(): void {
+  if (selectedFileIds.value.size === 0) return
+  bulkMoveFileIds.value = Array.from(selectedFileIds.value)
+  showTransferModal.value = true
+}
+
+// Bulk delete: the per-file delete endpoint, looped over the selection, behind a
+// single confirm with a shared "also delete from disk" option.
+const showBulkDeleteDialog = ref(false)
+const bulkDeleteFromDisk = ref(true)
+const bulkDeleting = ref(false)
+
+const selectedFiles = computed<LibraryFile[]>(() =>
+  (audiobook.value?.files ?? []).filter((f) => selectedFileIds.value.has(f.id)),
+)
+
+function confirmBulkDelete(): void {
+  if (selectedFileIds.value.size === 0) return
+  bulkDeleteFromDisk.value = true
+  showBulkDeleteDialog.value = true
+}
+
+function cancelBulkDelete(): void {
+  showBulkDeleteDialog.value = false
+}
+
+async function executeBulkDelete(): Promise<void> {
+  if (!audiobook.value || selectedFileIds.value.size === 0) return
+  const audiobookId = audiobook.value.id
+  const targets = selectedFiles.value
+  const toast = useToast()
+  bulkDeleting.value = true
+
+  let deleted = 0
+  const failures: string[] = []
+  const warnings: string[] = []
+  try {
+    for (const file of targets) {
+      try {
+        const result = await apiService.deleteAudiobookFile(audiobookId, file.id, {
+          deleteFromDisk: bulkDeleteFromDisk.value,
+        })
+        deleted++
+        if (result.warnings && result.warnings.length > 0) {
+          warnings.push(...result.warnings)
+        }
+      } catch (err) {
+        failures.push(getFileName(file.path))
+        errorTracking.captureException(err as Error, {
+          component: 'AudiobookDetailView',
+          operation: 'executeBulkDelete',
+          metadata: { audiobookId, fileId: file.id },
+        })
+      }
+    }
+
+    const onDisk = bulkDeleteFromDisk.value ? ' and from disk' : ''
+    if (failures.length === 0) {
+      toast.success(
+        'Files removed',
+        `Removed ${deleted} file${deleted === 1 ? '' : 's'}${onDisk}.${
+          warnings.length ? ' ' + warnings.join(' ') : ''
+        }`,
+      )
+    } else {
+      toast.warning(
+        'Some files could not be deleted',
+        `Removed ${deleted} of ${targets.length}. Failed: ${failures.join(', ')}.`,
+      )
+    }
+  } finally {
+    bulkDeleting.value = false
+    showBulkDeleteDialog.value = false
+    clearFileSelection()
+    await loadAudiobook()
+  }
 }
 
 function formatRuntime(minutes: number): string {
@@ -3295,5 +3526,118 @@ a.identifier-link:hover {
 .secondary-actions .delete-btn {
   padding-left: 10px;
   padding-right: 10px;
+}
+
+/* Multi-select toolbar + per-row checkbox */
+.file-select-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 8px 12px;
+  margin-bottom: 12px;
+  background-color: #2b2b2b;
+  border: 1px solid #3a3a3a;
+  border-radius: 6px;
+}
+
+.file-select-bar.active {
+  border-color: var(--brand-500);
+  background-color: #313131;
+}
+
+.select-all-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  color: #ccc;
+  font-size: 14px;
+}
+
+.select-all-text {
+  user-select: none;
+}
+
+.file-select-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.bulk-move-btn {
+  padding: 6px 10px;
+  background-color: rgba(var(--brand-rgb), 0.1);
+  border: 1px solid var(--brand-500);
+  border-radius: 4px;
+  color: var(--brand-500);
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.bulk-move-btn:hover {
+  background-color: rgba(var(--brand-rgb), 0.2);
+}
+
+.bulk-delete-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: 14px;
+  background-color: rgba(255, 107, 107, 0.1);
+  color: #ff6b6b;
+  border: 1px solid rgba(255, 107, 107, 0.3);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.bulk-delete-btn:hover {
+  background-color: rgba(255, 107, 107, 0.2);
+  border-color: rgba(255, 107, 107, 0.5);
+}
+
+.clear-select-btn {
+  background: transparent;
+  border: none;
+  color: #999;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 6px 8px;
+  border-radius: 4px;
+}
+
+.clear-select-btn:hover {
+  color: #fff;
+  background-color: #3a3a3a;
+}
+
+.file-select-checkbox {
+  display: flex;
+  align-items: center;
+  margin-right: 12px;
+  cursor: pointer;
+}
+
+.file-item.selected {
+  background-color: #36404a;
+  box-shadow: inset 3px 0 0 var(--brand-500);
+}
+
+.bulk-delete-list {
+  margin: 8px 0;
+  padding-left: 20px;
+  max-height: 180px;
+  overflow-y: auto;
+  color: #ccc;
+  font-size: 13px;
+}
+
+.bulk-delete-list li {
+  margin: 2px 0;
+  word-break: break-all;
 }
 </style>

--- a/fe/src/views/library/AudiobookDetailView.vue
+++ b/fe/src/views/library/AudiobookDetailView.vue
@@ -642,6 +642,16 @@
     @close="showOrganizeModal = false"
     @done="handleOrganizeDone"
   />
+
+  <!-- Move files to another EXISTING library record (e.g. tracks imported onto
+       the wrong book, or a collection being split into its real books). -->
+  <TransferFilesModal
+    :visible="showTransferModal"
+    :audiobook="audiobook"
+    :initial-query="audiobook?.title || ''"
+    @close="showTransferModal = false"
+    @done="onTransferDone"
+  />
 </template>
 
 <script setup lang="ts">
@@ -671,6 +681,7 @@ import { errorTracking } from '@/services/errorTracking'
 import { useProtectedImages } from '@/composables/useProtectedImages'
 import { buildAudibleProductUrl } from '@/utils/marketDomains'
 import EditAudiobookModal from '@/components/domain/audiobook/EditAudiobookModal.vue'
+import TransferFilesModal from '@/components/domain/audiobook/TransferFilesModal.vue'
 import ManualSearchModal from '@/components/domain/search/ManualSearchModal.vue'
 import RenamePreviewModal from '@/components/domain/organize/RenamePreviewModal.vue'
 import CustomSelect from '@/components/form/CustomSelect.vue'
@@ -710,6 +721,7 @@ import {
   PhFileMinus,
   PhCircle,
   PhDiscordLogo,
+  PhArrowsLeftRight,
 } from '@phosphor-icons/vue'
 
 const route = useRoute()
@@ -737,6 +749,7 @@ const scanQueued = ref(false)
 const scanJobId = ref<string | null>(null)
 const showEditModal = ref(false)
 const showOrganizeModal = ref(false)
+const showTransferModal = ref(false)
 const showMoreActions = ref(false)
 
 // History state
@@ -834,6 +847,18 @@ const topActions = computed<DetailTopAction[]>(() => [
     },
   },
   {
+    key: 'transfer-files',
+    label: 'Move Files to Another Book',
+    title: 'Move files to the existing library record they actually belong to',
+    ariaLabel: 'Move Files to Another Book',
+    icon: PhArrowsLeftRight,
+    disabled: !audiobook.value?.files?.length,
+    desktopGroup: 'secondary',
+    onClick: () => {
+      showTransferModal.value = true
+    },
+  },
+  {
     key: 'delete',
     label: 'Delete',
     title: 'Delete',
@@ -878,6 +903,7 @@ type DetailTopAction = {
     | 'edit'
     | 'rescan-metadata'
     | 'organize'
+    | 'transfer-files'
     | 'delete'
   label: string
   title: string
@@ -1618,6 +1644,14 @@ async function handleEditSaved() {
 async function handleOrganizeDone() {
   showOrganizeModal.value = false
   await loadAudiobook()
+}
+
+async function onTransferDone() {
+  showTransferModal.value = false
+  // Files left this record — reload it, and refresh the library list so the
+  // destination's file counts are current too.
+  await loadAudiobook()
+  void libraryStore.fetchLibrary()
 }
 
 function formatRuntime(minutes: number): string {

--- a/fe/src/views/settings/GeneralSettingsTab.vue
+++ b/fe/src/views/settings/GeneralSettingsTab.vue
@@ -56,6 +56,8 @@
           @update:settings="(val) => Object.assign(localSettings, val)"
           @update:apiKey="(val) => emit('update:apiKey', val)"
         ></AuthenticationSection>
+
+        <DuplicatesSection />
       </div>
       <!-- settings-form -->
     </div>
@@ -74,6 +76,7 @@ import DownloadSettingsSection from '@/components/settings/DownloadSettingsSecti
 import FeaturesSection from '@/components/settings/FeaturesSection.vue'
 import SearchSettingsSection from '@/components/settings/SearchSettingsSection.vue'
 import AuthenticationSection from '@/components/settings/AuthenticationSection.vue'
+import DuplicatesSection from '@/components/settings/DuplicatesSection.vue'
 
 interface Props {
   settings: ApplicationSettings | null

--- a/listenarr.api/Features/Library/LibraryController.Models.cs
+++ b/listenarr.api/Features/Library/LibraryController.Models.cs
@@ -51,4 +51,12 @@ public partial class LibraryController
         public bool? MoveFiles { get; set; }
         public bool? DeleteEmptySource { get; set; }
     }
+
+    public class TransferFilesRequest
+    {
+        public int TargetAudiobookId { get; set; }
+
+        /// <summary>Files to move; null/empty transfers every file on the source.</summary>
+        public List<int>? FileIds { get; set; }
+    }
 }

--- a/listenarr.api/Features/Library/LibraryController.cs
+++ b/listenarr.api/Features/Library/LibraryController.cs
@@ -40,6 +40,7 @@ namespace Listenarr.Api.Features.Library
         private readonly LibraryPreviewPathWorkflow _previewPathWorkflow;
         private readonly LibraryQueryWorkflow _queryWorkflow;
         private readonly LibraryRenameWorkflow _renameWorkflow;
+        private readonly LibraryTransferFilesWorkflow _transferFilesWorkflow;
         /// <summary>Initializes the library transport façade.</summary>
         public LibraryController(
             ILibraryListService libraryListService,
@@ -55,7 +56,8 @@ namespace Listenarr.Api.Features.Library
             LibraryIdentifierWorkflow identifierWorkflow,
             LibraryPreviewPathWorkflow previewPathWorkflow,
             LibraryQueryWorkflow queryWorkflow,
-            LibraryRenameWorkflow renameWorkflow)
+            LibraryRenameWorkflow renameWorkflow,
+            LibraryTransferFilesWorkflow transferFilesWorkflow)
         {
             _libraryListService = libraryListService;
             _addWorkflow = addWorkflow;
@@ -71,6 +73,22 @@ namespace Listenarr.Api.Features.Library
             _previewPathWorkflow = previewPathWorkflow;
             _queryWorkflow = queryWorkflow;
             _renameWorkflow = renameWorkflow;
+            _transferFilesWorkflow = transferFilesWorkflow;
+        }
+
+        /// <summary>
+        /// Move audio files from this audiobook to another existing library record.
+        /// DB ownership is reassigned always; the physical file moves into the
+        /// target's folder best-effort (failures leave it in place with a warning).
+        /// Null/empty <see cref="TransferFilesRequest.FileIds"/> transfers every file.
+        /// </summary>
+        /// <param name="id">Source audiobook ID.</param>
+        /// <param name="request">Target audiobook and optional subset of file IDs to move.</param>
+        /// <param name="ct">Cancellation token bound to the request.</param>
+        [HttpPost("{id}/files/transfer")]
+        public async Task<IActionResult> TransferFiles(int id, [FromBody] TransferFilesRequest request, CancellationToken ct)
+        {
+            return await _transferFilesWorkflow.TransferAsync(id, request, ct);
         }
 
         /// <summary>

--- a/listenarr.api/Features/Library/LibraryController.cs
+++ b/listenarr.api/Features/Library/LibraryController.cs
@@ -41,6 +41,7 @@ namespace Listenarr.Api.Features.Library
         private readonly LibraryQueryWorkflow _queryWorkflow;
         private readonly LibraryRenameWorkflow _renameWorkflow;
         private readonly LibraryTransferFilesWorkflow _transferFilesWorkflow;
+        private readonly LibraryFileDeleteWorkflow _fileDeleteWorkflow;
         /// <summary>Initializes the library transport façade.</summary>
         public LibraryController(
             ILibraryListService libraryListService,
@@ -57,7 +58,8 @@ namespace Listenarr.Api.Features.Library
             LibraryPreviewPathWorkflow previewPathWorkflow,
             LibraryQueryWorkflow queryWorkflow,
             LibraryRenameWorkflow renameWorkflow,
-            LibraryTransferFilesWorkflow transferFilesWorkflow)
+            LibraryTransferFilesWorkflow transferFilesWorkflow,
+            LibraryFileDeleteWorkflow fileDeleteWorkflow)
         {
             _libraryListService = libraryListService;
             _addWorkflow = addWorkflow;
@@ -74,6 +76,20 @@ namespace Listenarr.Api.Features.Library
             _queryWorkflow = queryWorkflow;
             _renameWorkflow = renameWorkflow;
             _transferFilesWorkflow = transferFilesWorkflow;
+            _fileDeleteWorkflow = fileDeleteWorkflow;
+        }
+
+        /// <summary>
+        /// Delete a single tracked file from an audiobook. Optionally also remove the file from disk.
+        /// </summary>
+        /// <param name="id">Owning audiobook ID.</param>
+        /// <param name="fileId">AudiobookFile row ID to delete.</param>
+        /// <param name="deleteFromDisk">When true, attempt to delete the file from disk too. Disk-delete failures surface as warnings; the DB row is still removed.</param>
+        /// <param name="ct">Cancellation token bound to the request.</param>
+        [HttpDelete("{id}/files/{fileId}")]
+        public async Task<IActionResult> DeleteAudiobookFile(int id, int fileId, [FromQuery] bool deleteFromDisk = false, CancellationToken ct = default)
+        {
+            return await _fileDeleteWorkflow.DeleteFileAsync(id, fileId, deleteFromDisk, ct);
         }
 
         /// <summary>

--- a/listenarr.api/Features/Library/LibraryController.cs
+++ b/listenarr.api/Features/Library/LibraryController.cs
@@ -43,6 +43,7 @@ namespace Listenarr.Api.Features.Library
         private readonly LibraryTransferFilesWorkflow _transferFilesWorkflow;
         private readonly LibraryFileDeleteWorkflow _fileDeleteWorkflow;
         private readonly LibrarySplitPreviewWorkflow _splitPreviewWorkflow;
+        private readonly LibraryDuplicatesWorkflow _duplicatesWorkflow;
         /// <summary>Initializes the library transport façade.</summary>
         public LibraryController(
             ILibraryListService libraryListService,
@@ -61,7 +62,8 @@ namespace Listenarr.Api.Features.Library
             LibraryRenameWorkflow renameWorkflow,
             LibraryTransferFilesWorkflow transferFilesWorkflow,
             LibraryFileDeleteWorkflow fileDeleteWorkflow,
-            LibrarySplitPreviewWorkflow splitPreviewWorkflow)
+            LibrarySplitPreviewWorkflow splitPreviewWorkflow,
+            LibraryDuplicatesWorkflow duplicatesWorkflow)
         {
             _libraryListService = libraryListService;
             _addWorkflow = addWorkflow;
@@ -80,6 +82,20 @@ namespace Listenarr.Api.Features.Library
             _transferFilesWorkflow = transferFilesWorkflow;
             _fileDeleteWorkflow = fileDeleteWorkflow;
             _splitPreviewWorkflow = splitPreviewWorkflow;
+            _duplicatesWorkflow = duplicatesWorkflow;
+        }
+
+        /// <summary>
+        /// Read-only duplicate sweep: duplicate records (same ASIN, or same
+        /// normalized title+author without a conflicting ASIN/edition signal)
+        /// and records holding duplicate copies of their own audio (same file
+        /// set under two filename schemes).
+        /// </summary>
+        /// <param name="ct">Cancellation token bound to the request.</param>
+        [HttpGet("duplicates")]
+        public async Task<IActionResult> GetDuplicates(CancellationToken ct)
+        {
+            return await _duplicatesWorkflow.GetDuplicatesAsync(ct);
         }
 
         /// <summary>

--- a/listenarr.api/Features/Library/LibraryController.cs
+++ b/listenarr.api/Features/Library/LibraryController.cs
@@ -42,6 +42,7 @@ namespace Listenarr.Api.Features.Library
         private readonly LibraryRenameWorkflow _renameWorkflow;
         private readonly LibraryTransferFilesWorkflow _transferFilesWorkflow;
         private readonly LibraryFileDeleteWorkflow _fileDeleteWorkflow;
+        private readonly LibrarySplitPreviewWorkflow _splitPreviewWorkflow;
         /// <summary>Initializes the library transport façade.</summary>
         public LibraryController(
             ILibraryListService libraryListService,
@@ -59,7 +60,8 @@ namespace Listenarr.Api.Features.Library
             LibraryQueryWorkflow queryWorkflow,
             LibraryRenameWorkflow renameWorkflow,
             LibraryTransferFilesWorkflow transferFilesWorkflow,
-            LibraryFileDeleteWorkflow fileDeleteWorkflow)
+            LibraryFileDeleteWorkflow fileDeleteWorkflow,
+            LibrarySplitPreviewWorkflow splitPreviewWorkflow)
         {
             _libraryListService = libraryListService;
             _addWorkflow = addWorkflow;
@@ -77,6 +79,22 @@ namespace Listenarr.Api.Features.Library
             _renameWorkflow = renameWorkflow;
             _transferFilesWorkflow = transferFilesWorkflow;
             _fileDeleteWorkflow = fileDeleteWorkflow;
+            _splitPreviewWorkflow = splitPreviewWorkflow;
+        }
+
+        /// <summary>
+        /// Preview for the "Split collection" workflow: cluster this record's
+        /// files into per-book groups (subdirectory first, then embedded tag,
+        /// then filename stem) and suggest an existing library record for each
+        /// group. Read-only — applying is a sequence of file transfers/deletes
+        /// driven by the client.
+        /// </summary>
+        /// <param name="id">Audiobook whose files should be clustered.</param>
+        /// <param name="ct">Cancellation token bound to the request.</param>
+        [HttpGet("{id}/split/preview")]
+        public async Task<IActionResult> GetSplitPreview(int id, CancellationToken ct)
+        {
+            return await _splitPreviewWorkflow.PreviewAsync(id, ct);
         }
 
         /// <summary>

--- a/listenarr.api/Features/Library/LibraryDuplicatesWorkflow.cs
+++ b/listenarr.api/Features/Library/LibraryDuplicatesWorkflow.cs
@@ -1,0 +1,206 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Application.Audiobooks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Api.Features.Library
+{
+    /// <summary>
+    /// Read-only sweep for the two flavors of duplication a library accretes:
+    /// duplicate RECORDS (the same book tracked twice — same ASIN, or same
+    /// normalized title+author when neither carries a conflicting ASIN) and
+    /// duplicate COPIES (one record holding the same audio twice under two
+    /// filename schemes, detected via <see cref="FileClustering"/> signatures).
+    /// Conservative by design: same title with different subtitles AND
+    /// different years, or two distinct ASINs, are treated as different
+    /// editions, not duplicates — false positives erode trust in the list.
+    /// </summary>
+    public sealed class LibraryDuplicatesWorkflow
+    {
+        private readonly IAudiobookRepository _repo;
+        private readonly IAudiobookFileRepository _audioFileRepository;
+        private readonly ILogger<LibraryDuplicatesWorkflow> _logger;
+
+        public LibraryDuplicatesWorkflow(
+            IAudiobookRepository repo,
+            IAudiobookFileRepository audioFileRepository,
+            ILogger<LibraryDuplicatesWorkflow> logger)
+        {
+            _repo = repo;
+            _audioFileRepository = audioFileRepository;
+            _logger = logger;
+        }
+
+        public async Task<IActionResult> GetDuplicatesAsync(CancellationToken ct)
+        {
+            var books = await _repo.GetAllAsync();
+            var files = await _audioFileRepository.GetAllAsync(ct);
+            var filesByBook = files
+                .GroupBy(f => f.AudiobookId)
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            object Summarize(Audiobook b)
+            {
+                filesByBook.TryGetValue(b.Id, out var bf);
+                return new
+                {
+                    id = b.Id,
+                    title = b.Title,
+                    subtitle = b.Subtitle,
+                    publishYear = b.PublishYear,
+                    asin = b.Asin,
+                    fileCount = bf?.Count ?? 0,
+                    fileSize = bf?.Sum(f => f.Size ?? 0) ?? 0,
+                    monitored = b.Monitored
+                };
+            }
+
+            int SuggestKeeper(List<Audiobook> group) => group
+                .OrderByDescending(b => filesByBook.TryGetValue(b.Id, out var bf) ? bf.Count : 0)
+                .ThenBy(b => b.Id)
+                .First().Id;
+
+            var duplicateGroups = new List<object>();
+            var groupedIds = new HashSet<int>();
+
+            // Pass (a): identical non-empty ASIN — the strongest duplicate signal.
+            foreach (var g in books
+                .Where(b => !string.IsNullOrWhiteSpace(b.Asin))
+                .GroupBy(b => b.Asin!.Trim(), StringComparer.OrdinalIgnoreCase)
+                .Where(g => g.Count() > 1))
+            {
+                var members = g.ToList();
+                foreach (var b in members) groupedIds.Add(b.Id);
+                duplicateGroups.Add(new
+                {
+                    key = $"asin:{g.Key}",
+                    reason = "asin",
+                    books = members.Select(Summarize).ToList(),
+                    suggestedKeeperId = SuggestKeeper(members)
+                });
+            }
+
+            // Pass (b): normalized title + primary author for everything not
+            // already grouped by ASIN.
+            foreach (var g in books
+                .Where(b => !groupedIds.Contains(b.Id) && !string.IsNullOrWhiteSpace(b.Title))
+                .GroupBy(b =>
+                    TitleMatcher.Normalize(b.Title) + "|" + TitleMatcher.Normalize(b.Authors?.FirstOrDefault()))
+                .Where(g => g.Count() > 1))
+            {
+                var members = g.ToList();
+
+                // Two distinct non-empty ASINs = two catalog editions, not a dupe.
+                var distinctAsins = members
+                    .Select(b => b.Asin?.Trim())
+                    .Where(a => !string.IsNullOrWhiteSpace(a))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Count();
+                if (distinctAsins >= 2) continue;
+
+                // Different subtitles AND different years = probably different
+                // editions/volumes sharing a series-ish title. Leave them alone.
+                var distinctSubtitles = members
+                    .Select(b => TitleMatcher.Normalize(b.Subtitle))
+                    .Where(s => s.Length > 0)
+                    .Distinct()
+                    .Count();
+                var distinctYears = members
+                    .Select(b => b.PublishYear?.Trim())
+                    .Where(y => !string.IsNullOrWhiteSpace(y))
+                    .Distinct()
+                    .Count();
+                if (distinctSubtitles >= 2 && distinctYears >= 2) continue;
+
+                duplicateGroups.Add(new
+                {
+                    key = $"title-author:{g.Key}",
+                    reason = "title-author",
+                    books = members.Select(Summarize).ToList(),
+                    suggestedKeeperId = SuggestKeeper(members)
+                });
+            }
+
+            // Duplicate COPIES: one record, the same book's audio twice. Flat
+            // files only (stem clusters) — disc/part subfolders of a single copy
+            // ("CD1"/"CD2") are legitimate multi-cluster layouts, so dir clusters
+            // never count toward this signal.
+            var duplicateCopyBooks = new List<object>();
+            foreach (var b in books)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (!filesByBook.TryGetValue(b.Id, out var bf) || bf.Count < 2) continue;
+
+                var clusters = FileClustering.Cluster(bf, b.BasePath);
+                if (clusters.Count < 2) continue;
+
+                var stemClusters = clusters
+                    .Select(c => (cluster: c, key: c.Key))
+                    .Where(x => x.key.StartsWith("stem:", StringComparison.Ordinal))
+                    .Select(x =>
+                    {
+                        // Key shape: "stem:<lower-stem>|<signature>" — signatures
+                        // never contain '|', so the last one is the separator.
+                        var sep = x.key.LastIndexOf('|');
+                        return (x.cluster, stem: x.key[5..sep]);
+                    })
+                    .ToList();
+
+                // (i) Same stem rendered with two numbering styles — the
+                // signature-identity case the Split workflow can't separate.
+                var hit = stemClusters
+                    .GroupBy(x => x.stem, StringComparer.OrdinalIgnoreCase)
+                    .Any(g => g.Count() > 1);
+
+                // (ii) Two multi-file flat clusters covering near-identical total
+                // runtime — same book under two unrelated filename schemes.
+                if (!hit)
+                {
+                    var totals = stemClusters
+                        .Where(x => x.cluster.Files.Count > 1)
+                        .Select(x => x.cluster.Files.Sum(f => f.DurationSeconds ?? 0))
+                        .Where(t => t > 0)
+                        .OrderBy(t => t)
+                        .ToList();
+                    for (var i = 1; i < totals.Count && !hit; i++)
+                    {
+                        if (totals[i - 1] / totals[i] >= 0.75) hit = true;
+                    }
+                }
+
+                if (hit)
+                {
+                    duplicateCopyBooks.Add(new
+                    {
+                        id = b.Id,
+                        title = b.Title,
+                        clusterCount = clusters.Count,
+                        fileCount = bf.Count
+                    });
+                }
+            }
+
+            _logger.LogInformation(
+                "Duplicate sweep: {Groups} duplicate-record group(s), {Copies} record(s) with duplicate copies across {Books} books",
+                duplicateGroups.Count, duplicateCopyBooks.Count, books.Count);
+
+            return new OkObjectResult(new { duplicateGroups, duplicateCopyBooks });
+        }
+    }
+}

--- a/listenarr.api/Features/Library/LibraryFileDeleteWorkflow.cs
+++ b/listenarr.api/Features/Library/LibraryFileDeleteWorkflow.cs
@@ -1,0 +1,91 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Api.Features.Library
+{
+    /// <summary>
+    /// Delete a single tracked file from an audiobook, optionally removing it
+    /// from disk too. Disk-delete failures surface as warnings; the DB row is
+    /// still removed.
+    /// </summary>
+    public sealed class LibraryFileDeleteWorkflow
+    {
+        private readonly IAudiobookRepository _repo;
+        private readonly IAudiobookFileService _audiobookFileService;
+        private readonly ILogger<LibraryFileDeleteWorkflow> _logger;
+
+        public LibraryFileDeleteWorkflow(
+            IAudiobookRepository repo,
+            IAudiobookFileService audiobookFileService,
+            ILogger<LibraryFileDeleteWorkflow> logger)
+        {
+            _repo = repo;
+            _audiobookFileService = audiobookFileService;
+            _logger = logger;
+        }
+
+        public async Task<IActionResult> DeleteFileAsync(int id, int fileId, bool deleteFromDisk, CancellationToken ct)
+        {
+            var audiobook = await _repo.GetByIdAsync(id);
+            if (audiobook == null)
+            {
+                return new NotFoundObjectResult(new { message = "Audiobook not found" });
+            }
+
+            DeleteAudiobookFileResult result;
+            try
+            {
+                result = await _audiobookFileService.DeleteAudiobookFileAsync(audiobook, fileId, deleteFromDisk, source: "manual", ct: ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogError(ex, "Failed to delete AudiobookFile {FileId} for audiobook {AudiobookId}", fileId, id);
+                return new ObjectResult(new { message = "Failed to delete file" })
+                {
+                    StatusCode = StatusCodes.Status500InternalServerError
+                };
+            }
+
+            return result.Outcome switch
+            {
+                DeleteAudiobookFileOutcome.NotFound =>
+                    new NotFoundObjectResult(new { message = "File not found" }),
+
+                DeleteAudiobookFileOutcome.DoesNotBelongToAudiobook =>
+                    new BadRequestObjectResult(new { message = "File does not belong to this audiobook" }),
+
+                DeleteAudiobookFileOutcome.Deleted =>
+                    new OkObjectResult(new
+                    {
+                        message = "File removed",
+                        fileId,
+                        deletedFromDisk = result.DeletedFromDisk,
+                        path = result.Path,
+                        warnings = result.Warnings
+                    }),
+
+                _ => new ObjectResult(new { message = "Unknown delete outcome" })
+                {
+                    StatusCode = StatusCodes.Status500InternalServerError
+                }
+            };
+        }
+    }
+}

--- a/listenarr.api/Features/Library/LibrarySplitPreviewWorkflow.cs
+++ b/listenarr.api/Features/Library/LibrarySplitPreviewWorkflow.cs
@@ -1,0 +1,151 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Application.Audiobooks;
+using Listenarr.Domain.Common;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Api.Features.Library
+{
+    /// <summary>
+    /// Preview for the "Split collection" workflow: cluster a record's files
+    /// into per-book groups (subdirectory first, then embedded tag, then
+    /// filename stem) and suggest an existing library record for each group.
+    /// Read-only — applying is a sequence of file transfers/deletes driven by
+    /// the client.
+    /// </summary>
+    public sealed class LibrarySplitPreviewWorkflow
+    {
+        private readonly IAudiobookRepository _repo;
+        private readonly IAudiobookFileRepository _audioFileRepository;
+        private readonly IFfmpegService _ffmpegService;
+        private readonly IFileSystem _fileSystem;
+        private readonly ILogger<LibrarySplitPreviewWorkflow> _logger;
+
+        public LibrarySplitPreviewWorkflow(
+            IAudiobookRepository repo,
+            IAudiobookFileRepository audioFileRepository,
+            IFfmpegService ffmpegService,
+            IFileSystem fileSystem,
+            ILogger<LibrarySplitPreviewWorkflow> logger)
+        {
+            _repo = repo;
+            _audioFileRepository = audioFileRepository;
+            _ffmpegService = ffmpegService;
+            _fileSystem = fileSystem;
+            _logger = logger;
+        }
+
+        public async Task<IActionResult> PreviewAsync(int id, CancellationToken ct)
+        {
+            var audiobook = await _repo.GetByIdAsync(id);
+            if (audiobook == null)
+            {
+                return new NotFoundObjectResult(new { message = "Audiobook not found" });
+            }
+
+            var files = await _audioFileRepository.GetByAudiobookIdAsync(id, ct);
+
+            // Read each file's embedded book title (Album/Title tag) so a collection bulk-renamed
+            // to the parent record's name still splits by the real book each file belongs to —
+            // filenames are useless there, but the tags name the actual book.
+            //
+            // CRITICAL: parallelize ONLY the raw ffprobe (RunFfprobeAsync spawns a process and
+            // touches no DbContext). Higher-level metadata reads hit the request-scoped,
+            // non-thread-safe EF DbContext per call; probing those concurrently corrupted
+            // results, so the same file read its tag on one run and blank on the next — making
+            // the clusters (and therefore the moves) non-deterministic.
+            var embeddedTitles = new System.Collections.Concurrent.ConcurrentDictionary<int, string>();
+            try
+            {
+                // Resolve/install ffprobe once up front so the parallel probes don't race on it.
+                await _ffmpegService.GetFfprobePathAsync();
+
+                var targets = files
+                    .Select(f => (f.Id, path: FileUtils.CombineWithOptionalBase(audiobook.BasePath, f.Path ?? string.Empty)))
+                    .Where(x => !string.IsNullOrWhiteSpace(x.path) && _fileSystem.FileExists(x.path))
+                    .ToList();
+
+                await Parallel.ForEachAsync(
+                    targets,
+                    new ParallelOptions { MaxDegreeOfParallelism = 4, CancellationToken = ct },
+                    async (target, token) =>
+                    {
+                        try
+                        {
+                            var meta = await _ffmpegService.RunFfprobeAsync(target.path);
+                            var bookTitle = !string.IsNullOrWhiteSpace(meta?.Album) ? meta!.Album : meta?.Title;
+                            if (!string.IsNullOrWhiteSpace(bookTitle))
+                            {
+                                embeddedTitles[target.Id] = bookTitle!;
+                            }
+                        }
+                        catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+                        {
+                            _logger.LogDebug(ex, "ffprobe failed for split clustering (file {FileId})", target.Id);
+                        }
+                    });
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                // Tag reads are an enhancement to clustering, not a requirement —
+                // fall back to path/stem clustering when ffprobe is unavailable.
+                _logger.LogDebug(ex, "Embedded-tag read skipped for split preview of audiobook {AudiobookId}", id);
+            }
+
+            var clusters = FileClustering.Cluster(files, audiobook.BasePath, embeddedTitles);
+
+            // Suggestion candidates: same-author records first (a collection
+            // dump is almost always one author's shelf), then the whole library
+            // as fallback. The suggester prefers the longest matching title, so
+            // ordering only matters for the fallback breadth.
+            var all = await _repo.GetAllAsync();
+            var sourceAuthors = new HashSet<string>(
+                audiobook.Authors ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
+            var sameAuthor = new List<(int, string)>();
+            var others = new List<(int, string)>();
+            foreach (var candidate in all)
+            {
+                if (candidate.Id == id || string.IsNullOrWhiteSpace(candidate.Title)) continue;
+                var isSameAuthor = (candidate.Authors ?? new List<string>()).Any(sourceAuthors.Contains);
+                (isSameAuthor ? sameAuthor : others).Add((candidate.Id, candidate.Title!));
+            }
+            var titleById = all.Where(a => a.Id != id).ToDictionary(a => a.Id, a => a.Title ?? string.Empty);
+
+            var response = clusters.Select(cluster =>
+            {
+                var suggested = SplitDestinationSuggester.Suggest(cluster.DisplayName, sameAuthor)
+                                ?? SplitDestinationSuggester.Suggest(cluster.DisplayName, others);
+                return new
+                {
+                    key = cluster.Key,
+                    displayName = cluster.DisplayName,
+                    fileIds = cluster.Files.Select(f => f.Id).ToList(),
+                    fileNames = cluster.Files
+                        .Select(f => Path.GetFileName(f.Path ?? string.Empty))
+                        .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+                        .ToList(),
+                    suggestedTargetId = suggested,
+                    suggestedTargetTitle = suggested.HasValue && titleById.TryGetValue(suggested.Value, out var t) ? t : null
+                };
+            }).ToList();
+
+            return new OkObjectResult(new { audiobookId = id, clusters = response });
+        }
+    }
+}

--- a/listenarr.api/Features/Library/LibraryTransferFilesWorkflow.cs
+++ b/listenarr.api/Features/Library/LibraryTransferFilesWorkflow.cs
@@ -1,0 +1,240 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Api.Features.Library
+{
+    /// <summary>
+    /// Move audio files from one audiobook to another existing library record —
+    /// the remediation for "these files are actually a different book I track"
+    /// (e.g. two books' tracks imported onto one record, or a collection being
+    /// split into its real books). DB ownership is reassigned always; the
+    /// physical file is moved into the target's folder best-effort (failures
+    /// leave it in place with a warning — the Organize tool can relocate it
+    /// later).
+    /// </summary>
+    public sealed class LibraryTransferFilesWorkflow
+    {
+        private readonly IAudiobookRepository _repo;
+        private readonly IAudiobookFileRepository _audioFileRepository;
+        private readonly IHistoryRepository _historyRepository;
+        private readonly IFileMover _fileMover;
+        private readonly IFileSystem _fileSystem;
+        private readonly ILogger<LibraryTransferFilesWorkflow> _logger;
+
+        public LibraryTransferFilesWorkflow(
+            IAudiobookRepository repo,
+            IAudiobookFileRepository audioFileRepository,
+            IHistoryRepository historyRepository,
+            IFileMover fileMover,
+            IFileSystem fileSystem,
+            ILogger<LibraryTransferFilesWorkflow> logger)
+        {
+            _repo = repo;
+            _audioFileRepository = audioFileRepository;
+            _historyRepository = historyRepository;
+            _fileMover = fileMover;
+            _fileSystem = fileSystem;
+            _logger = logger;
+        }
+
+        public async Task<IActionResult> TransferAsync(int id, LibraryController.TransferFilesRequest? request, CancellationToken ct)
+        {
+            if (request == null)
+            {
+                return new BadRequestObjectResult(new { message = "Request body required" });
+            }
+
+            if (request.TargetAudiobookId == id)
+            {
+                return new BadRequestObjectResult(new { message = "Target audiobook must be different from the source" });
+            }
+
+            var source = await _repo.GetByIdAsync(id);
+            if (source == null)
+            {
+                return new NotFoundObjectResult(new { message = "Source audiobook not found" });
+            }
+
+            var target = await _repo.GetByIdAsync(request.TargetAudiobookId);
+            if (target == null)
+            {
+                return new NotFoundObjectResult(new { message = "Target audiobook not found" });
+            }
+
+            var sourceFiles = await _audioFileRepository.GetByAudiobookIdAsync(id, ct);
+            var toMove = request.FileIds is { Count: > 0 }
+                ? sourceFiles.Where(f => request.FileIds.Contains(f.Id)).ToList()
+                : sourceFiles.ToList();
+            if (toMove.Count == 0)
+            {
+                return new BadRequestObjectResult(new { message = "No matching files to transfer" });
+            }
+
+            if (request.FileIds is { Count: > 0 } && toMove.Count != request.FileIds.Distinct().Count())
+            {
+                return new BadRequestObjectResult(new { message = "One or more file ids do not belong to this audiobook" });
+            }
+
+            var targetFiles = await _audioFileRepository.GetByAudiobookIdAsync(target.Id, ct);
+
+            var warnings = new List<string>();
+            var physicallyMoved = 0;
+            var reassigned = 0;
+
+            foreach (var file in toMove)
+            {
+                // Determine the path this file would occupy under the target, and bail BEFORE
+                // touching disk if the target already owns a row there — a duplicate from a prior
+                // (partial) transfer, or the same physical file dual-referenced by both records.
+                // Reassigning would violate the (AudiobookId, Path) unique key; moving first and
+                // only then discovering the collision relocates the file on disk but orphans the
+                // source's DB row (the file leaves but never reassigns). Skip it entirely so the
+                // rest of the transfer still goes through; the user can delete the redundant copy
+                // from the source if it's a true duplicate.
+                var candidatePath = (!string.IsNullOrWhiteSpace(target.BasePath) && !string.IsNullOrWhiteSpace(file.Path))
+                    ? Path.Join(target.BasePath, Path.GetFileName(file.Path))
+                    : file.Path;
+                if (!string.IsNullOrWhiteSpace(candidatePath)
+                    && targetFiles.Any(tf => tf.Id != file.Id && string.Equals(tf.Path, candidatePath, StringComparison.OrdinalIgnoreCase)))
+                {
+                    warnings.Add($"{Path.GetFileName(candidatePath)} already exists under the target — left in place (delete the redundant copy if it's a duplicate)");
+                    continue;
+                }
+
+                // Physical relocation is best-effort: ownership (the DB row) is the
+                // core semantic, and a file left in the old folder is fixable via
+                // the Organize tool. A failed disk move must not abort the transfer.
+                var newPath = file.Path;
+                if (!string.IsNullOrWhiteSpace(target.BasePath) && !string.IsNullOrWhiteSpace(file.Path))
+                {
+                    try
+                    {
+                        var destination = Path.Join(target.BasePath, Path.GetFileName(file.Path));
+                        if (!_fileSystem.FileExists(file.Path))
+                        {
+                            warnings.Add($"File missing on disk, reassigned in place: {Path.GetFileName(file.Path)}");
+                        }
+                        else if (string.Equals(Path.GetFullPath(destination), Path.GetFullPath(file.Path), StringComparison.OrdinalIgnoreCase))
+                        {
+                            // Already where it belongs.
+                        }
+                        else if (_fileSystem.FileExists(destination))
+                        {
+                            warnings.Add($"Target folder already has {Path.GetFileName(file.Path)} — file left in place");
+                        }
+                        else
+                        {
+                            if (!_fileSystem.DirectoryExists(target.BasePath))
+                            {
+                                _fileSystem.CreateDirectory(target.BasePath);
+                            }
+
+                            if (await _fileMover.PerformActionOn(FileAction.Move, file.Path, destination))
+                            {
+                                newPath = destination;
+                                physicallyMoved++;
+                            }
+                            else
+                            {
+                                warnings.Add($"Could not move {Path.GetFileName(file.Path)} on disk — file left in place");
+                            }
+                        }
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+                    {
+                        warnings.Add($"Could not move {Path.GetFileName(file.Path)} on disk — file left in place");
+                        _logger.LogWarning(ex, "transfer-files: disk move failed for file {FileId}", file.Id);
+                    }
+                }
+
+                try
+                {
+                    await _audioFileRepository.ReassignAsync(file.Id, target.Id, newPath, ct);
+                    // Mutate the in-memory row only after the DB update succeeds, so a caught
+                    // failure can't leave a stale path in the collision checks below.
+                    file.AudiobookId = target.Id;
+                    file.Path = newPath;
+                    reassigned++;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+                {
+                    // Last-resort guard: any per-file DB failure (e.g. a same-name collision within
+                    // this batch) becomes a warning, never a 500 that aborts the whole transfer.
+                    warnings.Add($"Could not reassign {Path.GetFileName(newPath)} — left in place");
+                    _logger.LogWarning(ex, "transfer-files: DB reassign failed for file {FileId}", file.Id);
+                }
+            }
+
+            // Source bookkeeping: when its audio is gone, the legacy single-file
+            // columns describe content it no longer owns. Gate on what actually
+            // reassigned — a skipped/collided file means the source still holds audio.
+            if (reassigned > 0 && reassigned == sourceFiles.Count)
+            {
+                source.FilePath = null;
+                source.FileSize = null;
+                await _repo.UpdateAsync(source);
+            }
+
+            try
+            {
+                await _historyRepository.AddAsync(new History
+                {
+                    AudiobookId = source.Id,
+                    AudiobookTitle = source.Title ?? "Unknown Title",
+                    EventType = "Files Transferred",
+                    Message = $"Moved {reassigned} file(s) to '{target.Title}' (id {target.Id}).",
+                    Source = "transfer-files",
+                    Timestamp = DateTime.UtcNow
+                }, ct);
+                await _historyRepository.AddAsync(new History
+                {
+                    AudiobookId = target.Id,
+                    AudiobookTitle = target.Title ?? "Unknown Title",
+                    EventType = "Files Received",
+                    Message = $"Received {reassigned} file(s) from '{source.Title}' (id {source.Id}).",
+                    Source = "transfer-files",
+                    Timestamp = DateTime.UtcNow
+                }, ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogWarning(ex, "transfer-files: failed to record history (non-critical)");
+            }
+
+            // Post-transfer hook point: when content verification lands, this is where
+            // the target gets re-verified against its new audio (and stale verdicts on
+            // both records get reset).
+
+            _logger.LogInformation(
+                "Transferred {Count} file(s) ({Physical} moved on disk) from audiobook {SourceId} to {TargetId}",
+                reassigned, physicallyMoved, source.Id, target.Id);
+
+            return new OkObjectResult(new
+            {
+                message = $"Transferred {reassigned} file(s) to '{target.Title}'",
+                sourceId = source.Id,
+                targetId = target.Id,
+                transferred = reassigned,
+                physicallyMoved,
+                warnings
+            });
+        }
+    }
+}

--- a/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
+++ b/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
@@ -87,6 +87,7 @@ public static class ListenarrWorkflowRegistration
         services.AddScoped<LibraryQueryWorkflow>();
         services.AddScoped<LibraryRenameWorkflow>();
         services.AddScoped<LibraryTransferFilesWorkflow>();
+        services.AddScoped<LibraryFileDeleteWorkflow>();
         services.AddScoped<SearchResponseMapper>();
         services.AddScoped<ImagePlaceholderResolver>();
         services.AddScoped<IndexerTestWorkflow>();

--- a/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
+++ b/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
@@ -89,6 +89,7 @@ public static class ListenarrWorkflowRegistration
         services.AddScoped<LibraryTransferFilesWorkflow>();
         services.AddScoped<LibraryFileDeleteWorkflow>();
         services.AddScoped<LibrarySplitPreviewWorkflow>();
+        services.AddScoped<LibraryDuplicatesWorkflow>();
         services.AddScoped<SearchResponseMapper>();
         services.AddScoped<ImagePlaceholderResolver>();
         services.AddScoped<IndexerTestWorkflow>();

--- a/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
+++ b/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
@@ -86,6 +86,7 @@ public static class ListenarrWorkflowRegistration
         services.AddScoped<LibraryPreviewPathWorkflow>();
         services.AddScoped<LibraryQueryWorkflow>();
         services.AddScoped<LibraryRenameWorkflow>();
+        services.AddScoped<LibraryTransferFilesWorkflow>();
         services.AddScoped<SearchResponseMapper>();
         services.AddScoped<ImagePlaceholderResolver>();
         services.AddScoped<IndexerTestWorkflow>();

--- a/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
+++ b/listenarr.api/Startup/ListenarrWorkflowRegistration.cs
@@ -88,6 +88,7 @@ public static class ListenarrWorkflowRegistration
         services.AddScoped<LibraryRenameWorkflow>();
         services.AddScoped<LibraryTransferFilesWorkflow>();
         services.AddScoped<LibraryFileDeleteWorkflow>();
+        services.AddScoped<LibrarySplitPreviewWorkflow>();
         services.AddScoped<SearchResponseMapper>();
         services.AddScoped<ImagePlaceholderResolver>();
         services.AddScoped<IndexerTestWorkflow>();

--- a/listenarr.application/Audiobooks/Contracts/IAudiobookFileService.cs
+++ b/listenarr.application/Audiobooks/Contracts/IAudiobookFileService.cs
@@ -14,5 +14,16 @@ namespace Listenarr.Application.Audiobooks.Contracts
         /// <param name="source">Optional source identifier (e.g., "scan", "import")</param>
         /// <returns>True if the audiobook is associated with an audiobook file, false otherwise</returns>
         Task<bool> EnsureAudiobookFileAsync(Audiobook audiobook, string filePath, string? source = "scan");
+
+        /// <summary>
+        /// Delete a single tracked file from an audiobook. Disk-delete failures surface
+        /// as warnings; the DB row is still removed. A history entry records the removal.
+        /// </summary>
+        /// <param name="audiobook">The owning audiobook. The file must belong to this audiobook or the call returns <see cref="Files.DeleteAudiobookFileOutcome.DoesNotBelongToAudiobook"/>.</param>
+        /// <param name="fileId">The AudiobookFile row ID to delete.</param>
+        /// <param name="deleteFromDisk">When true, also attempt to delete the file from disk.</param>
+        /// <param name="source">Optional source identifier for the history entry (e.g., "manual").</param>
+        /// <param name="ct">Cancellation token.</param>
+        Task<Files.DeleteAudiobookFileResult> DeleteAudiobookFileAsync(Audiobook audiobook, int fileId, bool deleteFromDisk, string? source = "manual", CancellationToken ct = default);
     }
 }

--- a/listenarr.application/Audiobooks/Contracts/Repositories/IAudiobookFileRepository.cs
+++ b/listenarr.application/Audiobooks/Contracts/Repositories/IAudiobookFileRepository.cs
@@ -25,6 +25,13 @@ namespace Listenarr.Application.Audiobooks.Contracts.Repositories
         Task<List<AudiobookFile>> GetMissingMetadataAsync(int max, CancellationToken ct = default);
         Task<AudiobookFile> AddAsync(AudiobookFile file, CancellationToken ct = default);
         Task UpdateAsync(AudiobookFile file, CancellationToken ct = default);
+
+        /// <summary>
+        /// Reassign a file row to another audiobook (optionally with a new path)
+        /// via a targeted column update — no entity tracking, so bulk transfers
+        /// can't trip EF identity-map conflicts on overlapping navigation graphs.
+        /// </summary>
+        Task ReassignAsync(int fileId, int newAudiobookId, string? newPath, CancellationToken ct = default);
         Task DeleteByAudiobookIdAsync(int audiobookId, CancellationToken ct = default);
         Task DeleteAsync(int id, CancellationToken ct = default);
         Task<bool> ExistsAtPathAsync(int audiobookId, string path, CancellationToken ct = default);

--- a/listenarr.application/Audiobooks/FileClustering.cs
+++ b/listenarr.application/Audiobooks/FileClustering.cs
@@ -1,0 +1,289 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Text.RegularExpressions;
+
+namespace Listenarr.Application.Audiobooks
+{
+    /// <summary>
+    /// Groups a record's files into per-book clusters for the "Split
+    /// collection" workflow (a multi-book dump imported onto one record —
+    /// live case: 773 files spanning 34 books). Subdirectory is the strongest
+    /// grouping signal; root-level files cluster by their filename with track
+    /// numbering and noise stripped, so "friday-01_77.mp3" … "friday-44_77.mp3"
+    /// form one "friday" cluster. Pure and deterministic for unit testing.
+    /// </summary>
+    public static class FileClustering
+    {
+        public sealed record FileCluster(string Key, string DisplayName, List<AudiobookFile> Files);
+
+        // Trailing track/part markers: "-01_77", " Part 03 of 26", "_42",
+        // " - 7 - 7", "(2 of 3)", and bare parenthesized/bracketed track
+        // numbers "(10)" / "[07]" (live case: "The Rolling Stones (1)" …
+        // "(50)" exploded into 50 singleton groups without it).
+        private static readonly Regex TrailingNumberingRegex = new(
+            @"(\s*[-_ ]\s*(part|pt|cd|disc|disk|track|chapter|ch)?\s*\d+(\s*(of|/)\s*\d+)?|\s*[(\[]\d+(\s*(of|/)\s*\d+)?[)\]]|[-_ ]\d+([_-]\d+)*)\s*$",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Leading list numbering: "1 The Year of the Jackpot".
+        private static readonly Regex LeadingNumberRegex = new(@"^\d{1,3}[\s.\-_]+", RegexOptions.Compiled);
+
+        // A trailing volume/book designator ("…, Vol. 2", "Book 3") whose own
+        // number must NOT be mistaken for track numbering — otherwise
+        // "Expanded Universe, Vol. 1-001" and "…Vol. 2-001" both reduce to
+        // "…, Vol." with the same signature and collapse into one cluster, so a
+        // multi-volume set dumped onto one record can't be split apart.
+        private static readonly Regex DanglingVolumeRegex = new(
+            @"\b(vol|volume|book|bk)\.?\s*$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // Leading number of a matched trailing run ("  1" of "  1-001").
+        private static readonly Regex LeadingRunNumberRegex = new(@"^\s*\d+", RegexOptions.Compiled);
+
+        public static List<FileCluster> Cluster(
+            IEnumerable<AudiobookFile> files,
+            string? basePath,
+            IReadOnlyDictionary<int, string>? embeddedTitles = null)
+        {
+            var groups = new Dictionary<string, FileCluster>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var file in files.Where(f => !string.IsNullOrWhiteSpace(f.Path)))
+            {
+                var relative = MakeRelative(file.Path!, basePath);
+                var slash = relative.IndexOf('/');
+
+                string key;
+                string display;
+                if (slash > 0)
+                {
+                    // Subdirectory wins — even over the embedded tag. A per-book subfolder is the
+                    // strongest grouping signal, and trusting the tag over it merged genuinely
+                    // different books that shared a (mis-)tag across folders — e.g. a
+                    // "[Dramatized Adaptation]" subfolder lumped with a novel because both carried
+                    // the series album "Throne of Glass bk 2", and a two-file book split apart
+                    // because its files were tagged inconsistently.
+                    key = "dir:" + relative[..slash];
+                    display = relative[..slash];
+                }
+                else if (embeddedTitles != null
+                    && embeddedTitles.TryGetValue(file.Id, out var embeddedTitle)
+                    && TryEmbeddedTitleKey(embeddedTitle, out var embedKey, out var embedDisplay))
+                {
+                    // Flat files only: when a collection was bulk-renamed to the parent record's
+                    // name, every filename is identical and useless for splitting — but each
+                    // file's embedded Album/Title tag still names the real book (e.g. files all
+                    // named "Old Man's War-NNN.mp3" whose tags say "The Ghost Brigades" /
+                    // "The Sagan Diary"). Track noise is stripped the same way as filenames; the
+                    // numbering *style* is intentionally ignored (a tag is a book identity).
+                    key = embedKey;
+                    display = embedDisplay;
+                }
+                else
+                {
+                    var (stem, signature) = CleanStemWithSignature(Path.GetFileNameWithoutExtension(relative));
+                    // The numbering STYLE is part of the identity: a record
+                    // holding two copies of one book ("Title-NN.mp3" and
+                    // "Title (N).mp3") must yield two groups, or the
+                    // delete-the-duplicate-copy workflow can't target one.
+                    key = "stem:" + stem.ToLowerInvariant() + "|" + signature;
+                    display = stem;
+                }
+
+                if (!groups.TryGetValue(key, out var cluster))
+                {
+                    cluster = new FileCluster(key, display, new List<AudiobookFile>());
+                    groups[key] = cluster;
+                }
+                cluster.Files.Add(file);
+            }
+
+            MergeUnnumberedSiblings(groups);
+
+            return groups.Values
+                .OrderByDescending(c => c.Files.Count)
+                .ThenBy(c => c.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Builds a cluster key/display from a file's embedded book title, stripping the same
+        /// track/list numbering noise as filenames ("The Ghost Brigades 10-41" → "The Ghost
+        /// Brigades"; "1 - The Sagan Diary" → "The Sagan Diary"). Returns false when the tag
+        /// carries no usable signal (empty, or cleans down to nothing/bare digits) so the caller
+        /// falls back to path-based clustering for that file.
+        /// </summary>
+        private static bool TryEmbeddedTitleKey(string? embeddedTitle, out string key, out string display)
+        {
+            key = string.Empty;
+            display = string.Empty;
+            if (string.IsNullOrWhiteSpace(embeddedTitle))
+            {
+                return false;
+            }
+
+            var (stem, _) = CleanStemWithSignature(embeddedTitle);
+            if (string.IsNullOrWhiteSpace(stem) || stem.All(char.IsDigit))
+            {
+                return false;
+            }
+
+            key = "embed:" + stem.ToLowerInvariant();
+            display = stem;
+            return true;
+        }
+
+        /// <summary>
+        /// An unnumbered file alongside a numbered set ("Title.mp3" next to
+        /// "Title (1).mp3"…) is usually that set's FIRST track — numbering
+        /// often starts at the unmarked file (users have resorted to renaming
+        /// it "Title (0).mp3" by hand). Merge it into the same-stem numbered
+        /// group when it plausibly IS one track (duration/size comparable to
+        /// the group's median); a same-stem whole-book file is many times
+        /// larger and stays its own group, as does anything ambiguous
+        /// (multiple same-stem numbered groups to choose from).
+        /// </summary>
+        private static void MergeUnnumberedSiblings(Dictionary<string, FileCluster> groups)
+        {
+            var markerless = groups
+                .Where(kv => kv.Key.StartsWith("stem:", StringComparison.Ordinal)
+                             && kv.Key.EndsWith("|", StringComparison.Ordinal)
+                             && kv.Value.Files.Count == 1)
+                .ToList();
+
+            foreach (var (key, cluster) in markerless)
+            {
+                // The markerless key "stem:<stem>|" is itself the shared prefix
+                // of every same-stem numbered group ("stem:<stem>|<signature>").
+                var candidates = groups
+                    .Where(kv => kv.Key != key
+                                 && kv.Key.StartsWith(key, StringComparison.Ordinal)
+                                 && kv.Value.Files.Count > 0)
+                    .Select(kv => kv.Value)
+                    .ToList();
+                if (candidates.Count != 1) continue; // none, or ambiguous (two copies)
+
+                var target = candidates[0];
+                if (!LooksLikeOneTrackOf(cluster.Files[0], target.Files)) continue;
+
+                target.Files.Insert(0, cluster.Files[0]);
+                groups.Remove(key);
+            }
+        }
+
+        private static bool LooksLikeOneTrackOf(AudiobookFile file, List<AudiobookFile> groupFiles)
+        {
+            const double MaxRatio = 3.0;
+
+            var fileDuration = file.DurationSeconds ?? 0;
+            var durations = groupFiles.Select(f => f.DurationSeconds ?? 0).Where(d => d > 0).OrderBy(d => d).ToList();
+            if (fileDuration > 0 && durations.Count > 0)
+            {
+                return fileDuration <= durations[durations.Count / 2] * MaxRatio;
+            }
+
+            var fileSize = file.Size ?? 0;
+            var sizes = groupFiles.Select(f => f.Size ?? 0).Where(s => s > 0).OrderBy(s => s).ToList();
+            if (fileSize > 0 && sizes.Count > 0)
+            {
+                return fileSize <= sizes[sizes.Count / 2] * MaxRatio;
+            }
+
+            // No comparable signal — stay conservative, keep it separate.
+            return false;
+        }
+
+        /// <summary>
+        /// Strips track numbering and list prefixes so sibling files share a
+        /// stem: "(heinlein_robert)-friday-01_77" → "(heinlein_robert)-friday".
+        /// Applied repeatedly because markers stack ("Part 01 of 26" + "_77").
+        /// </summary>
+        public static string CleanStem(string fileName) => CleanStemWithSignature(fileName).Stem;
+
+        /// <summary>
+        /// As <see cref="CleanStem"/>, plus the digit-normalized template of
+        /// what was stripped ("-#_#", " (#)", " part # of #") — the marker
+        /// STYLE that distinguishes two copies of the same book.
+        /// </summary>
+        public static (string Stem, string Signature) CleanStemWithSignature(string fileName)
+        {
+            var stem = fileName.Trim();
+            var signatureParts = new List<string>();
+
+            var leading = LeadingNumberRegex.Match(stem);
+            if (leading.Success)
+            {
+                signatureParts.Add(NormalizeDigits(leading.Value));
+                stem = stem[leading.Length..];
+            }
+
+            string previous;
+            do
+            {
+                previous = stem;
+                var trailing = TrailingNumberingRegex.Match(stem);
+                if (!trailing.Success) break;
+
+                var stripIndex = trailing.Index;
+                var markerValue = trailing.Value;
+
+                // Volume/book guard: when "<title>, Vol. N" is followed by a
+                // track marker, the matched run is " N-001"; keep "Vol. N" on
+                // the stem (strip only the track part) so different volumes of
+                // one title don't collapse into a single cluster.
+                var runNumber = LeadingRunNumberRegex.Match(markerValue);
+                if (runNumber.Success && DanglingVolumeRegex.IsMatch(stem[..stripIndex]))
+                {
+                    // The run is only the volume's own number ("…, Vol. 2") —
+                    // keep it whole as part of the identity, strip nothing more.
+                    if (runNumber.Length >= markerValue.Length) break;
+
+                    // Keep "<keyword> N"; the remainder is the real track marker.
+                    stripIndex += runNumber.Length;
+                    markerValue = stem[stripIndex..];
+                }
+
+                // Outermost marker first so stacked markers serialize stably.
+                signatureParts.Insert(leading.Success ? 1 : 0, NormalizeDigits(markerValue));
+                stem = stem[..stripIndex].Trim();
+            } while (stem != previous && stem.Length > 0);
+
+            // A stem that stripped down to nothing or to bare digits carries no
+            // grouping signal — keep the original name (conservative: such
+            // files stay singleton clusters instead of merging on noise).
+            if (stem.Length == 0 || stem.All(char.IsDigit)) return (fileName.Trim(), string.Empty);
+            return (stem, string.Join("", signatureParts));
+        }
+
+        private static string NormalizeDigits(string marker) =>
+            Regex.Replace(marker.Trim().ToLowerInvariant(), @"\d+", "#");
+
+        private static string MakeRelative(string path, string? basePath)
+        {
+            var normalized = path.Replace('\\', '/');
+            if (!string.IsNullOrWhiteSpace(basePath))
+            {
+                var root = basePath.Replace('\\', '/').TrimEnd('/') + "/";
+                if (normalized.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+                {
+                    return normalized[root.Length..];
+                }
+            }
+            // Fall back to the file name so an unanchored path can't smuggle in
+            // its whole directory chain as a "subdirectory" cluster.
+            return Path.GetFileName(normalized);
+        }
+    }
+}

--- a/listenarr.application/Audiobooks/Files/AudiobookFileService.cs
+++ b/listenarr.application/Audiobooks/Files/AudiobookFileService.cs
@@ -260,5 +260,99 @@ namespace Listenarr.Application.Audiobooks.Files
                 return false;
             }
         }
+
+        public async Task<DeleteAudiobookFileResult> DeleteAudiobookFileAsync(
+            Audiobook audiobook,
+            int fileId,
+            bool deleteFromDisk,
+            string? source = "manual",
+            CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(audiobook);
+
+            var file = await audiobookFileRepository.GetByIdAsync(fileId, ct);
+            if (file == null)
+            {
+                return DeleteAudiobookFileResult.NotFound();
+            }
+
+            if (file.AudiobookId != audiobook.Id)
+            {
+                logger.LogWarning(
+                    "Refusing to delete AudiobookFile {FileId}: belongs to audiobook {OwnerId}, not {RequestedId}",
+                    fileId, file.AudiobookId, audiobook.Id);
+                return DeleteAudiobookFileResult.WrongAudiobook(file.Path);
+            }
+
+            var warnings = new List<string>();
+            var deletedFromDisk = false;
+
+            if (deleteFromDisk && !string.IsNullOrWhiteSpace(file.Path))
+            {
+                try
+                {
+                    if (fileSystem.FileExists(file.Path))
+                    {
+                        fileSystem.DeleteFile(file.Path);
+                        deletedFromDisk = true;
+                        logger.LogInformation(
+                            "Deleted audiobook file from disk for audiobook {AudiobookId}: {Path}",
+                            audiobook.Id, LogRedaction.SanitizeFilePath(file.Path));
+                    }
+                    else
+                    {
+                        logger.LogInformation(
+                            "Skipping disk delete — file not present for audiobook {AudiobookId}: {Path}",
+                            audiobook.Id, LogRedaction.SanitizeFilePath(file.Path));
+                    }
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                    warnings.Add($"Could not delete file '{Path.GetFileName(file.Path)}' from disk.");
+                    logger.LogWarning(ex, "Failed to delete audiobook file from disk for audiobook {AudiobookId}: {Path}",
+                        audiobook.Id, LogRedaction.SanitizeFilePath(file.Path));
+                }
+            }
+
+            await audiobookFileRepository.DeleteAsync(fileId, ct);
+            logger.LogInformation(
+                "Deleted AudiobookFile {FileId} for audiobook {AudiobookId}: {Path}",
+                fileId, audiobook.Id, LogRedaction.SanitizeFilePath(file.Path));
+
+            try
+            {
+                var historyEntry = new History
+                {
+                    AudiobookId = audiobook.Id,
+                    AudiobookTitle = audiobook.Title ?? "Unknown",
+                    EventType = "File Removed",
+                    Message = $"File removed: {Path.GetFileName(file.Path)}",
+                    Source = source ?? "manual",
+                    Data = JsonSerializer.Serialize(new
+                    {
+                        FileId = fileId,
+                        FilePath = file.Path,
+                        FileSize = file.Size,
+                        Format = file.Format,
+                        DeletedFromDisk = deletedFromDisk,
+                        Warnings = warnings
+                    }),
+                    Timestamp = DateTime.UtcNow
+                };
+                await historyRepository.AddAsync(historyEntry, ct);
+            }
+            catch (Exception hx) when (hx is not OperationCanceledException && hx is not OutOfMemoryException && hx is not StackOverflowException)
+            {
+                logger.LogDebug(hx, "Failed to create history entry for removed audiobook file {Path}", LogRedaction.SanitizeFilePath(file.Path));
+            }
+
+            return new DeleteAudiobookFileResult
+            {
+                Outcome = DeleteAudiobookFileOutcome.Deleted,
+                DeletedFromDisk = deletedFromDisk,
+                Path = file.Path,
+                Warnings = warnings
+            };
+        }
     }
 }

--- a/listenarr.application/Audiobooks/Files/DeleteAudiobookFileResult.cs
+++ b/listenarr.application/Audiobooks/Files/DeleteAudiobookFileResult.cs
@@ -1,0 +1,40 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace Listenarr.Application.Audiobooks.Files
+{
+    public enum DeleteAudiobookFileOutcome
+    {
+        Deleted,
+        NotFound,
+        DoesNotBelongToAudiobook
+    }
+
+    public sealed class DeleteAudiobookFileResult
+    {
+        public DeleteAudiobookFileOutcome Outcome { get; init; }
+        public bool DeletedFromDisk { get; init; }
+        public string? Path { get; init; }
+        public IReadOnlyList<string> Warnings { get; init; } = Array.Empty<string>();
+
+        public static DeleteAudiobookFileResult NotFound() =>
+            new() { Outcome = DeleteAudiobookFileOutcome.NotFound };
+
+        public static DeleteAudiobookFileResult WrongAudiobook(string? path) =>
+            new() { Outcome = DeleteAudiobookFileOutcome.DoesNotBelongToAudiobook, Path = path };
+    }
+}

--- a/listenarr.application/Audiobooks/SplitDestinationSuggester.cs
+++ b/listenarr.application/Audiobooks/SplitDestinationSuggester.cs
@@ -1,0 +1,58 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Application.Search;
+
+namespace Listenarr.Application.Audiobooks
+{
+    /// <summary>
+    /// Suggests the library record a file cluster belongs to: the candidate
+    /// whose normalized title is contained in the cluster's name, preferring
+    /// the longest title ("Expanded Universe, Vol. 2" beats "Expanded
+    /// Universe") and tolerating missing spaces ("TunnelintheSky" matches
+    /// "Tunnel in the Sky"). Conservative: no containment, no suggestion —
+    /// validated against a live 773-file, 34-book split.
+    /// </summary>
+    public static class SplitDestinationSuggester
+    {
+        public static int? Suggest(string clusterDisplayName, IReadOnlyList<(int Id, string Title)> candidates)
+        {
+            if (string.IsNullOrWhiteSpace(clusterDisplayName) || candidates.Count == 0) return null;
+
+            var name = TitleMatcher.Normalize(clusterDisplayName);
+            if (name.Length == 0) return null;
+            var nameNoSpace = name.Replace(" ", "");
+
+            int? best = null;
+            var bestLength = 0;
+            foreach (var (id, title) in candidates)
+            {
+                var normalized = TitleMatcher.Normalize(title);
+                // Very short titles ("Job", "D") match everything; demand 4+ chars.
+                if (normalized.Length < 4 || normalized.Length <= bestLength) continue;
+
+                if (name.Contains(normalized, StringComparison.Ordinal)
+                    || nameNoSpace.Contains(normalized.Replace(" ", ""), StringComparison.Ordinal))
+                {
+                    best = id;
+                    bestLength = normalized.Length;
+                }
+            }
+            return best;
+        }
+    }
+}

--- a/listenarr.application/Search/TitleMatcher.cs
+++ b/listenarr.application/Search/TitleMatcher.cs
@@ -1,0 +1,59 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Text;
+
+namespace Listenarr.Application.Search
+{
+    /// <summary>
+    /// Punctuation-tolerant title matching. A naive case-insensitive
+    /// comparison fails on common punctuation mismatches between user-entered
+    /// or filename-derived titles and canonical catalog titles (hyphen vs.
+    /// colon, en/em dashes, smart quotes, doubled whitespace), causing
+    /// legitimate matches to be silently dropped.
+    /// </summary>
+    public static class TitleMatcher
+    {
+        /// <summary>
+        /// Lowercases the input and replaces any character that is not a
+        /// letter or digit with a single space, collapsing consecutive
+        /// whitespace. Strips characters that commonly differ between
+        /// user input and indexer titles: -, –, —, :, ;, ,, ., (), [], etc.
+        /// </summary>
+        public static string Normalize(string? input)
+        {
+            if (string.IsNullOrWhiteSpace(input)) return string.Empty;
+            var sb = new StringBuilder(input.Length);
+            bool lastWasSpace = true;
+            foreach (var ch in input)
+            {
+                if (char.IsLetterOrDigit(ch))
+                {
+                    sb.Append(char.ToLowerInvariant(ch));
+                    lastWasSpace = false;
+                }
+                else if (!lastWasSpace)
+                {
+                    sb.Append(' ');
+                    lastWasSpace = true;
+                }
+            }
+            if (sb.Length > 0 && sb[sb.Length - 1] == ' ') sb.Length--;
+            return sb.ToString();
+        }
+    }
+}

--- a/listenarr.infrastructure/Persistence/Repositories/EfAudiobookFileRepository.cs
+++ b/listenarr.infrastructure/Persistence/Repositories/EfAudiobookFileRepository.cs
@@ -64,6 +64,40 @@ namespace Listenarr.Infrastructure.Persistence.Repositories
             await _db.SaveChangesAsync(ct);
         }
 
+        public async Task ReassignAsync(int fileId, int newAudiobookId, string? newPath, CancellationToken ct = default)
+        {
+            // Targeted column update via a detached stub: Update(entity) on rows
+            // loaded with their navigation graphs trips EF's identity map on the
+            // second file of a bulk transfer ("instance with the same key is
+            // already being tracked"). Marking only the reassigned columns
+            // modified loads and tracks no graphs. (ExecuteUpdate would also
+            // work, but isn't supported by the InMemory test provider.)
+            var tracked = _db.AudiobookFiles.Local.FirstOrDefault(f => f.Id == fileId);
+            if (tracked != null)
+            {
+                _db.Entry(tracked).State = EntityState.Detached;
+            }
+
+            var stub = new AudiobookFile { Id = fileId, AudiobookId = newAudiobookId, Path = newPath };
+            var entry = _db.Entry(stub);
+            entry.Property(f => f.AudiobookId).IsModified = true;
+            if (newPath != null)
+            {
+                entry.Property(f => f.Path).IsModified = true;
+            }
+
+            try
+            {
+                await _db.SaveChangesAsync(ct);
+            }
+            finally
+            {
+                // Always detach: a failed save (e.g. unique-key collision) must not
+                // leave a dirty stub behind for an unrelated later SaveChanges.
+                entry.State = EntityState.Detached;
+            }
+        }
+
         public async Task DeleteByAudiobookIdAsync(int audiobookId, CancellationToken ct = default)
         {
             var files = await _db.AudiobookFiles.Where(f => f.AudiobookId == audiobookId).ToListAsync(ct);

--- a/tests/Builders/ServiceCollectionBuilder.cs
+++ b/tests/Builders/ServiceCollectionBuilder.cs
@@ -202,6 +202,7 @@ namespace Listenarr.Tests.Builders
             services.AddSingleton<LibraryQueryWorkflow>();
             services.AddSingleton<LibraryRenameWorkflow>();
             services.AddSingleton<LibraryTransferFilesWorkflow>();
+            services.AddSingleton<LibraryFileDeleteWorkflow>();
             services.AddSingleton<SearchResponseMapper>();
             services.AddSingleton<ImagePlaceholderResolver>();
             services.AddSingleton<IndexerTestWorkflow>();

--- a/tests/Builders/ServiceCollectionBuilder.cs
+++ b/tests/Builders/ServiceCollectionBuilder.cs
@@ -203,6 +203,7 @@ namespace Listenarr.Tests.Builders
             services.AddSingleton<LibraryRenameWorkflow>();
             services.AddSingleton<LibraryTransferFilesWorkflow>();
             services.AddSingleton<LibraryFileDeleteWorkflow>();
+            services.AddSingleton<LibrarySplitPreviewWorkflow>();
             services.AddSingleton<SearchResponseMapper>();
             services.AddSingleton<ImagePlaceholderResolver>();
             services.AddSingleton<IndexerTestWorkflow>();

--- a/tests/Builders/ServiceCollectionBuilder.cs
+++ b/tests/Builders/ServiceCollectionBuilder.cs
@@ -204,6 +204,7 @@ namespace Listenarr.Tests.Builders
             services.AddSingleton<LibraryTransferFilesWorkflow>();
             services.AddSingleton<LibraryFileDeleteWorkflow>();
             services.AddSingleton<LibrarySplitPreviewWorkflow>();
+            services.AddSingleton<LibraryDuplicatesWorkflow>();
             services.AddSingleton<SearchResponseMapper>();
             services.AddSingleton<ImagePlaceholderResolver>();
             services.AddSingleton<IndexerTestWorkflow>();

--- a/tests/Builders/ServiceCollectionBuilder.cs
+++ b/tests/Builders/ServiceCollectionBuilder.cs
@@ -201,6 +201,7 @@ namespace Listenarr.Tests.Builders
             services.AddSingleton<LibraryPreviewPathWorkflow>();
             services.AddSingleton<LibraryQueryWorkflow>();
             services.AddSingleton<LibraryRenameWorkflow>();
+            services.AddSingleton<LibraryTransferFilesWorkflow>();
             services.AddSingleton<SearchResponseMapper>();
             services.AddSingleton<ImagePlaceholderResolver>();
             services.AddSingleton<IndexerTestWorkflow>();

--- a/tests/Features/Api/Features/Library/LibraryController_DuplicatesTests.cs
+++ b/tests/Features/Api/Features/Library/LibraryController_DuplicatesTests.cs
@@ -1,0 +1,179 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Listenarr.Tests.Builders;
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Api.Features.Library
+{
+    [Trait("Area", "LibraryApi")]
+    [Trait("Name", "LibraryController_DuplicatesTests")]
+    [Trait("Category", "LibraryController")]
+    public class LibraryController_DuplicatesTests : BaseTests
+    {
+        private static JsonElement ToJson(object? value) => JsonSerializer.SerializeToElement(value);
+
+        private async Task<Audiobook> AddBookAsync(
+            string title,
+            string? author = null,
+            string? asin = null,
+            string? subtitle = null,
+            string? year = null,
+            string? folder = null)
+        {
+            var builder = new AudiobookBuilder().WithTitle(title);
+            if (author != null) builder = builder.WithAuthor(author);
+            if (subtitle != null) builder = builder.WithSubtitle(subtitle);
+            if (year != null) builder = builder.WithYear(year);
+            builder = builder.WithBasePath(FileService.GetTempDirectory(folder ?? $"dupes-{Guid.NewGuid():N}"));
+            var book = builder.Build();
+            book.Asin = asin;
+            return await _audiobookRepository.AddAsync(book);
+        }
+
+        private async Task AddFileAsync(Audiobook owner, string fileName)
+        {
+            await _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(owner)
+                .WithPath(Path.Join(owner.BasePath, fileName))
+                .Build());
+        }
+
+        private async Task<JsonElement> SweepAsync()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var result = await controller.GetDuplicates(CancellationToken.None);
+            var ok = Assert.IsType<OkObjectResult>(result);
+            return ToJson(ok.Value);
+        }
+
+        [Fact]
+        [Trait("Method", "GetDuplicates")]
+        [Trait("Scenario", "SameAsin_FormsGroup")]
+        public async Task GetDuplicates_SameAsin_FormsGroup()
+        {
+            var a = await AddBookAsync("Warbreaker", "Brandon Sanderson", asin: "B002UZZ7Y2");
+            var b = await AddBookAsync("Warbreaker (Unabridged)", "Brandon Sanderson", asin: "b002uzz7y2");
+
+            var payload = await SweepAsync();
+            var groups = payload.GetProperty("duplicateGroups").EnumerateArray().ToList();
+            var group = Assert.Single(groups);
+            Assert.Equal("asin", group.GetProperty("reason").GetString());
+            var ids = group.GetProperty("books").EnumerateArray()
+                .Select(x => x.GetProperty("id").GetInt32()).OrderBy(x => x).ToList();
+            Assert.Equal(new[] { a.Id, b.Id }.OrderBy(x => x).ToList(), ids);
+        }
+
+        [Fact]
+        [Trait("Method", "GetDuplicates")]
+        [Trait("Scenario", "SameTitleAuthor_NoAsins_FormsGroup")]
+        public async Task GetDuplicates_SameTitleAuthor_NoAsins_FormsGroup()
+        {
+            await AddBookAsync("The Ghost Brigades", "John Scalzi");
+            await AddBookAsync("The Ghost  Brigades!", "John Scalzi");
+
+            var payload = await SweepAsync();
+            var groups = payload.GetProperty("duplicateGroups").EnumerateArray().ToList();
+            var group = Assert.Single(groups);
+            Assert.Equal("title-author", group.GetProperty("reason").GetString());
+            Assert.Equal(2, group.GetProperty("books").GetArrayLength());
+        }
+
+        [Fact]
+        [Trait("Method", "GetDuplicates")]
+        [Trait("Scenario", "DistinctAsins_AreNotDuplicates")]
+        public async Task GetDuplicates_DistinctAsins_AreNotDuplicates()
+        {
+            await AddBookAsync("Dune", "Frank Herbert", asin: "B0011UGNDG");
+            await AddBookAsync("Dune", "Frank Herbert", asin: "B08G9PRS1K");
+
+            var payload = await SweepAsync();
+            Assert.Empty(payload.GetProperty("duplicateGroups").EnumerateArray());
+        }
+
+        [Fact]
+        [Trait("Method", "GetDuplicates")]
+        [Trait("Scenario", "DifferentSubtitleAndYear_AreNotDuplicates")]
+        public async Task GetDuplicates_DifferentSubtitleAndYear_AreNotDuplicates()
+        {
+            await AddBookAsync("Foundation", "Isaac Asimov", subtitle: "Book One", year: "1951");
+            await AddBookAsync("Foundation", "Isaac Asimov", subtitle: "The Radio Dramatization", year: "1973");
+
+            var payload = await SweepAsync();
+            Assert.Empty(payload.GetProperty("duplicateGroups").EnumerateArray());
+        }
+
+        [Fact]
+        [Trait("Method", "GetDuplicates")]
+        [Trait("Scenario", "SuggestedKeeper_PrefersMostFiles_ThenOldestId")]
+        public async Task GetDuplicates_SuggestedKeeper_PrefersMostFiles_ThenOldestId()
+        {
+            var empty = await AddBookAsync("Old Man's War", "John Scalzi");
+            var withFiles = await AddBookAsync("Old Man's War.", "John Scalzi");
+            await AddFileAsync(withFiles, "part1.mp3");
+            await AddFileAsync(withFiles, "part2.mp3");
+
+            var payload = await SweepAsync();
+            var group = Assert.Single(payload.GetProperty("duplicateGroups").EnumerateArray().ToList());
+            Assert.Equal(withFiles.Id, group.GetProperty("suggestedKeeperId").GetInt32());
+            Assert.True(empty.Id < withFiles.Id); // keeper won on files, not id
+
+            // Tie on files (none anywhere) → oldest id wins.
+            var first = await AddBookAsync("Agent to the Stars", "John Scalzi");
+            await AddBookAsync("Agent to the Stars!", "John Scalzi");
+            var payload2 = await SweepAsync();
+            var tieGroup = payload2.GetProperty("duplicateGroups").EnumerateArray()
+                .Single(g => g.GetProperty("key").GetString()!.Contains("agent"));
+            Assert.Equal(first.Id, tieGroup.GetProperty("suggestedKeeperId").GetInt32());
+        }
+
+        [Fact]
+        [Trait("Method", "GetDuplicates")]
+        [Trait("Scenario", "TwoFilenameSchemes_FlagDuplicateCopies")]
+        public async Task GetDuplicates_TwoFilenameSchemes_FlagDuplicateCopies()
+        {
+            var book = await AddBookAsync("Shadow of the Giant", "Orson Scott Card", folder: "dupes-copies");
+            // Same stem, two numbering styles — the signature-identity case.
+            await AddFileAsync(book, "Shadow of the Giant-01.mp3");
+            await AddFileAsync(book, "Shadow of the Giant-02.mp3");
+            await AddFileAsync(book, "Shadow of the Giant (1).mp3");
+            await AddFileAsync(book, "Shadow of the Giant (2).mp3");
+
+            var payload = await SweepAsync();
+            var hits = payload.GetProperty("duplicateCopyBooks").EnumerateArray().ToList();
+            var hit = Assert.Single(hits);
+            Assert.Equal(book.Id, hit.GetProperty("id").GetInt32());
+            Assert.Equal(4, hit.GetProperty("fileCount").GetInt32());
+        }
+
+        [Fact]
+        [Trait("Method", "GetDuplicates")]
+        [Trait("Scenario", "SingleScheme_NotFlagged")]
+        public async Task GetDuplicates_SingleScheme_NotFlagged()
+        {
+            var book = await AddBookAsync("Friday", "Robert A. Heinlein", folder: "dupes-single");
+            await AddFileAsync(book, "friday-01_77.mp3");
+            await AddFileAsync(book, "friday-02_77.mp3");
+            await AddFileAsync(book, "friday-03_77.mp3");
+
+            var payload = await SweepAsync();
+            Assert.Empty(payload.GetProperty("duplicateCopyBooks").EnumerateArray());
+        }
+    }
+}

--- a/tests/Features/Api/Features/Library/LibraryController_FileDeleteTests.cs
+++ b/tests/Features/Api/Features/Library/LibraryController_FileDeleteTests.cs
@@ -1,0 +1,165 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Listenarr.Tests.Builders;
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Api.Features.Library
+{
+    [Trait("Area", "LibraryApi")]
+    [Trait("Name", "LibraryController_FileDeleteTests")]
+    [Trait("Category", "LibraryController")]
+    public class LibraryController_FileDeleteTests : BaseTests
+    {
+        private static JsonElement ToJson(object? value)
+        {
+            return JsonSerializer.SerializeToElement(value);
+        }
+
+        private async Task<Audiobook> CreateAudiobookWithFolderAsync(string folderName = "file-delete")
+        {
+            return await _audiobookRepository.AddAsync(new AudiobookBuilder()
+                .WithTitle("Test Book")
+                .WithBasePath(FileService.GetTempDirectory(folderName))
+                .Build());
+        }
+
+        private async Task<AudiobookFile> AddFileOnDiskAsync(Audiobook owner, string fileName)
+        {
+            var path = Path.Join(owner.BasePath, fileName);
+            Directory.CreateDirectory(owner.BasePath!);
+            await File.WriteAllTextAsync(path, "audio");
+            return await _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(owner)
+                .WithPath(path)
+                .Build());
+        }
+
+        [Fact]
+        [Trait("Method", "DeleteAudiobookFile")]
+        [Trait("Scenario", "ReturnsNotFound_WhenAudiobookMissing")]
+        public async Task DeleteAudiobookFile_ReturnsNotFound_WhenAudiobookMissing()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+
+            var result = await controller.DeleteAudiobookFile(999_101, 1, deleteFromDisk: false, CancellationToken.None);
+
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        [Trait("Method", "DeleteAudiobookFile")]
+        [Trait("Scenario", "ReturnsNotFound_WhenFileMissing")]
+        public async Task DeleteAudiobookFile_ReturnsNotFound_WhenFileMissing()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var ab = await CreateAudiobookWithFolderAsync();
+
+            var result = await controller.DeleteAudiobookFile(ab.Id, 999_102, deleteFromDisk: false, CancellationToken.None);
+
+            Assert.IsType<NotFoundObjectResult>(result);
+        }
+
+        [Fact]
+        [Trait("Method", "DeleteAudiobookFile")]
+        [Trait("Scenario", "ReturnsBadRequest_WhenFileBelongsToAnotherAudiobook")]
+        public async Task DeleteAudiobookFile_ReturnsBadRequest_WhenFileBelongsToAnotherAudiobook()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var owner = await CreateAudiobookWithFolderAsync("file-delete-owner");
+            var other = await CreateAudiobookWithFolderAsync("file-delete-other");
+            var file = await AddFileOnDiskAsync(owner, "part1.m4b");
+
+            var result = await controller.DeleteAudiobookFile(other.Id, file.Id, deleteFromDisk: false, CancellationToken.None);
+
+            var bad = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Contains("does not belong", bad.Value?.ToString() ?? string.Empty);
+
+            // File untouched.
+            Assert.NotNull(await _audiobookFileRepository.GetByIdAsync(file.Id));
+            Assert.True(File.Exists(file.Path));
+        }
+
+        [Fact]
+        [Trait("Method", "DeleteAudiobookFile")]
+        [Trait("Scenario", "DbOnlyDelete_RemovesRow_KeepsFileOnDisk")]
+        public async Task DeleteAudiobookFile_DbOnlyDelete_RemovesRow_KeepsFileOnDisk()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var ab = await CreateAudiobookWithFolderAsync();
+            var file = await AddFileOnDiskAsync(ab, "part1.m4b");
+
+            var result = await controller.DeleteAudiobookFile(ab.Id, file.Id, deleteFromDisk: false, CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.False(payload.GetProperty("deletedFromDisk").GetBoolean());
+
+            Assert.Null(await _audiobookFileRepository.GetByIdAsync(file.Id));
+            Assert.True(File.Exists(file.Path));
+
+            var history = await _historyRepository.GetByAudiobookIdAsync(ab.Id);
+            Assert.Contains(history, h => h.EventType == "File Removed");
+        }
+
+        [Fact]
+        [Trait("Method", "DeleteAudiobookFile")]
+        [Trait("Scenario", "DiskDelete_RemovesRowAndFile")]
+        public async Task DeleteAudiobookFile_DiskDelete_RemovesRowAndFile()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var ab = await CreateAudiobookWithFolderAsync();
+            var file = await AddFileOnDiskAsync(ab, "part1.m4b");
+
+            var result = await controller.DeleteAudiobookFile(ab.Id, file.Id, deleteFromDisk: true, CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.True(payload.GetProperty("deletedFromDisk").GetBoolean());
+            Assert.Empty(payload.GetProperty("warnings").EnumerateArray());
+
+            Assert.Null(await _audiobookFileRepository.GetByIdAsync(file.Id));
+            Assert.False(File.Exists(file.Path));
+        }
+
+        [Fact]
+        [Trait("Method", "DeleteAudiobookFile")]
+        [Trait("Scenario", "DiskDelete_FileAlreadyGone_StillRemovesRow")]
+        public async Task DeleteAudiobookFile_DiskDelete_FileAlreadyGone_StillRemovesRow()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var ab = await CreateAudiobookWithFolderAsync();
+
+            // Row whose physical file does not exist.
+            var ghostPath = Path.Join(ab.BasePath, "ghost.m4b");
+            var ghost = await _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(ab)
+                .WithPath(ghostPath)
+                .Build());
+
+            var result = await controller.DeleteAudiobookFile(ab.Id, ghost.Id, deleteFromDisk: true, CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.False(payload.GetProperty("deletedFromDisk").GetBoolean());
+
+            Assert.Null(await _audiobookFileRepository.GetByIdAsync(ghost.Id));
+        }
+    }
+}

--- a/tests/Features/Api/Features/Library/LibraryController_TransferFilesTests.cs
+++ b/tests/Features/Api/Features/Library/LibraryController_TransferFilesTests.cs
@@ -1,0 +1,342 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Listenarr.Tests.Builders;
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Api.Features.Library
+{
+    [Trait("Area", "LibraryApi")]
+    [Trait("Name", "LibraryController_TransferFilesTests")]
+    [Trait("Category", "LibraryController")]
+    public class LibraryController_TransferFilesTests : BaseTests
+    {
+        private static JsonElement ToJson(object? value)
+        {
+            return JsonSerializer.SerializeToElement(value);
+        }
+
+        private async Task<(Audiobook source, Audiobook target)> CreateSourceAndTargetAsync(
+            string sourceFolderName = "transfer-src",
+            string targetFolderName = "transfer-dst")
+        {
+            var sourceFolder = FileService.GetTempDirectory(sourceFolderName);
+            var targetFolder = Path.Join(FileService.GetTempPath(), targetFolderName);
+
+            var source = await _audiobookRepository.AddAsync(new AudiobookBuilder()
+                .WithTitle("Arcanum Unbounded")
+                .WithBasePath(sourceFolder)
+                .Build());
+
+            var target = await _audiobookRepository.AddAsync(new AudiobookBuilder()
+                .WithTitle("Warbreaker")
+                .WithBasePath(targetFolder)
+                .Build());
+
+            return (source, target);
+        }
+
+        private async Task<AudiobookFile> AddFileOnDiskAsync(Audiobook owner, string fileName)
+        {
+            var path = Path.Join(owner.BasePath, fileName);
+            Directory.CreateDirectory(owner.BasePath!);
+            await File.WriteAllTextAsync(path, "audio");
+            return await _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(owner)
+                .WithPath(path)
+                .Build());
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "ReturnsBadRequest_WhenTargetIsSource")]
+        public async Task TransferFiles_ReturnsBadRequest_WhenTargetIsSource()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, _) = await CreateSourceAndTargetAsync();
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = source.Id },
+                CancellationToken.None);
+
+            var bad = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Contains("different", bad.Value?.ToString() ?? string.Empty);
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "ReturnsNotFound_WhenSourceOrTargetMissing")]
+        public async Task TransferFiles_ReturnsNotFound_WhenSourceOrTargetMissing()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, _) = await CreateSourceAndTargetAsync();
+
+            var missingSource = await controller.TransferFiles(
+                999_001,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = source.Id },
+                CancellationToken.None);
+            Assert.IsType<NotFoundObjectResult>(missingSource);
+
+            var missingTarget = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = 999_002 },
+                CancellationToken.None);
+            Assert.IsType<NotFoundObjectResult>(missingTarget);
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "ReturnsBadRequest_WhenFileIdsDoNotBelongToSource")]
+        public async Task TransferFiles_ReturnsBadRequest_WhenFileIdsDoNotBelongToSource()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+            var file = await AddFileOnDiskAsync(source, "part1.m4b");
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest
+                {
+                    TargetAudiobookId = target.Id,
+                    FileIds = [file.Id, 999_003]
+                },
+                CancellationToken.None);
+
+            var bad = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Contains("do not belong", bad.Value?.ToString() ?? string.Empty);
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "ReturnsBadRequest_WhenSourceHasNoFiles")]
+        public async Task TransferFiles_ReturnsBadRequest_WhenSourceHasNoFiles()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = target.Id },
+                CancellationToken.None);
+
+            var bad = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Contains("No matching files", bad.Value?.ToString() ?? string.Empty);
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "MovesAllFiles_ReassignsOwnership_AndClearsLegacyColumns")]
+        public async Task TransferFiles_MovesAllFiles_ReassignsOwnership_AndClearsLegacyColumns()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+            var file1 = await AddFileOnDiskAsync(source, "part1.m4b");
+            var file2 = await AddFileOnDiskAsync(source, "part2.m4b");
+
+            // Legacy single-file columns describe the audio the source is about to lose.
+            source.FilePath = file1.Path;
+            source.FileSize = 5;
+            await _audiobookRepository.UpdateAsync(source);
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = target.Id },
+                CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.Equal(2, payload.GetProperty("transferred").GetInt32());
+            Assert.Equal(2, payload.GetProperty("physicallyMoved").GetInt32());
+            Assert.Empty(payload.GetProperty("warnings").EnumerateArray());
+
+            // DB ownership moved to the target, paths point into its folder.
+            var sourceFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(source.Id);
+            var targetFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(target.Id);
+            Assert.Empty(sourceFiles);
+            Assert.Equal(2, targetFiles.Count);
+            Assert.All(targetFiles, f => Assert.StartsWith(target.BasePath!, f.Path!));
+
+            // Physically relocated.
+            Assert.True(File.Exists(Path.Join(target.BasePath, "part1.m4b")));
+            Assert.True(File.Exists(Path.Join(target.BasePath, "part2.m4b")));
+            Assert.False(File.Exists(Path.Join(source.BasePath, "part1.m4b")));
+
+            // Legacy columns cleared: the source no longer owns any audio.
+            var reloadedSource = await _audiobookRepository.GetByIdAsync(source.Id);
+            Assert.Null(reloadedSource!.FilePath);
+            Assert.Null(reloadedSource.FileSize);
+
+            // History recorded on both records.
+            var sourceHistory = await _historyRepository.GetByAudiobookIdAsync(source.Id);
+            var targetHistory = await _historyRepository.GetByAudiobookIdAsync(target.Id);
+            Assert.Contains(sourceHistory, h => h.EventType == "Files Transferred");
+            Assert.Contains(targetHistory, h => h.EventType == "Files Received");
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "SubsetTransfer_KeepsSourceLegacyColumns")]
+        public async Task TransferFiles_SubsetTransfer_KeepsSourceLegacyColumns()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+            var file1 = await AddFileOnDiskAsync(source, "part1.m4b");
+            var file2 = await AddFileOnDiskAsync(source, "part2.m4b");
+
+            source.FilePath = file2.Path;
+            source.FileSize = 5;
+            await _audiobookRepository.UpdateAsync(source);
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest
+                {
+                    TargetAudiobookId = target.Id,
+                    FileIds = [file1.Id]
+                },
+                CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.Equal(1, payload.GetProperty("transferred").GetInt32());
+
+            var sourceFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(source.Id);
+            var targetFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(target.Id);
+            Assert.Single(sourceFiles);
+            Assert.Equal(file2.Id, sourceFiles[0].Id);
+            Assert.Single(targetFiles);
+
+            // Source still holds audio — legacy columns must survive.
+            var reloadedSource = await _audiobookRepository.GetByIdAsync(source.Id);
+            Assert.Equal(file2.Path, reloadedSource!.FilePath);
+            Assert.Equal(5, reloadedSource.FileSize);
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "FileMissingOnDisk_ReassignsInPlace_WithWarning")]
+        public async Task TransferFiles_FileMissingOnDisk_ReassignsInPlace_WithWarning()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+
+            // DB row whose physical file does not exist.
+            var ghostPath = Path.Join(source.BasePath, "ghost.m4b");
+            var ghost = await _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(source)
+                .WithPath(ghostPath)
+                .Build());
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = target.Id },
+                CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.Equal(1, payload.GetProperty("transferred").GetInt32());
+            Assert.Equal(0, payload.GetProperty("physicallyMoved").GetInt32());
+            Assert.Contains(
+                payload.GetProperty("warnings").EnumerateArray(),
+                w => w.GetString()!.Contains("missing on disk"));
+
+            // Ownership reassigned; path unchanged (nothing to move).
+            var targetFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(target.Id);
+            var moved = Assert.Single(targetFiles);
+            Assert.Equal(ghost.Id, moved.Id);
+            Assert.Equal(ghostPath, moved.Path);
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "TargetAlreadyOwnsRowAtPath_SkipsFile_NoDiskMove")]
+        public async Task TransferFiles_TargetAlreadyOwnsRowAtPath_SkipsFile_NoDiskMove()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+            var sourceFile = await AddFileOnDiskAsync(source, "part1.m4b");
+
+            // The target already owns a row at the exact path the file would occupy —
+            // a duplicate from a prior partial transfer. Reassigning would violate the
+            // (AudiobookId, Path) unique key; moving first would orphan the source row.
+            Directory.CreateDirectory(target.BasePath!);
+            await _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(target)
+                .WithPath(Path.Join(target.BasePath, "part1.m4b"))
+                .Build());
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = target.Id },
+                CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.Equal(0, payload.GetProperty("transferred").GetInt32());
+            Assert.Equal(0, payload.GetProperty("physicallyMoved").GetInt32());
+            Assert.Contains(
+                payload.GetProperty("warnings").EnumerateArray(),
+                w => w.GetString()!.Contains("already exists under the target"));
+
+            // File stayed with the source, on disk and in the DB.
+            Assert.True(File.Exists(sourceFile.Path));
+            var sourceFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(source.Id);
+            Assert.Single(sourceFiles);
+
+            // A skipped file means the source still holds audio — no history spam either.
+            var sourceHistory = await _historyRepository.GetByAudiobookIdAsync(source.Id);
+            Assert.Contains(sourceHistory, h => h.EventType == "Files Transferred" && h.Message!.Contains("0 file(s)"));
+        }
+
+        [Fact]
+        [Trait("Method", "TransferFiles")]
+        [Trait("Scenario", "DestinationFileOnDiskWithoutRow_LeavesInPlace_ButReassigns")]
+        public async Task TransferFiles_DestinationFileOnDiskWithoutRow_LeavesInPlace_ButReassigns()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+            var (source, target) = await CreateSourceAndTargetAsync();
+            var sourceFile = await AddFileOnDiskAsync(source, "part1.m4b");
+
+            // A same-named file already sits in the target folder, but the target has
+            // no DB row for it — ownership can still transfer, the disk move cannot.
+            Directory.CreateDirectory(target.BasePath!);
+            await File.WriteAllTextAsync(Path.Join(target.BasePath, "part1.m4b"), "other audio");
+
+            var result = await controller.TransferFiles(
+                source.Id,
+                new LibraryController.TransferFilesRequest { TargetAudiobookId = target.Id },
+                CancellationToken.None);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = ToJson(ok.Value);
+            Assert.Equal(1, payload.GetProperty("transferred").GetInt32());
+            Assert.Equal(0, payload.GetProperty("physicallyMoved").GetInt32());
+            Assert.Contains(
+                payload.GetProperty("warnings").EnumerateArray(),
+                w => w.GetString()!.Contains("file left in place"));
+
+            // Ownership moved; the file's path still points at the source folder.
+            var targetFiles = await _audiobookFileRepository.GetByAudiobookIdAsync(target.Id);
+            var moved = Assert.Single(targetFiles);
+            Assert.Equal(sourceFile.Path, moved.Path);
+            Assert.True(File.Exists(sourceFile.Path));
+        }
+    }
+}

--- a/tests/Features/Application/Audiobooks/FileClusteringTests.cs
+++ b/tests/Features/Application/Audiobooks/FileClusteringTests.cs
@@ -1,0 +1,317 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Application.Audiobooks;
+
+namespace Listenarr.Tests.Features.Application.Audiobooks
+{
+    /// <summary>
+    /// Fixtures are real filename shapes from the live 773-file Heinlein
+    /// collection record that motivated the Split workflow.
+    /// </summary>
+    public class FileClusteringTests
+    {
+        private const string Base = "/audiobooks/Robert A. Heinlein/Let There Be Light/Peter Coates";
+
+        private static AudiobookFile F(int id, string rel) => new() { Id = id, Path = $"{Base}/{rel}" };
+
+        [Fact]
+        public void Cluster_TrackNumberedSiblings_FormOneCluster()
+        {
+            var clusters = FileClustering.Cluster(new[]
+            {
+                F(1, "(heinlein_robert)-friday-01_77.mp3"),
+                F(2, "(heinlein_robert)-friday-02_77.mp3"),
+                F(3, "(heinlein_robert)-friday-44_77.mp3"),
+                F(4, "Robert A. Heinlein - Expanded Universe Part 01 of 26.mp3"),
+                F(5, "Robert A. Heinlein - Expanded Universe Part 26 of 26.mp3"),
+            }, Base);
+
+            Assert.Equal(2, clusters.Count);
+            Assert.Equal(3, clusters[0].Files.Count); // friday
+            Assert.Equal(2, clusters[1].Files.Count); // expanded universe
+        }
+
+        [Fact]
+        public void Cluster_SubdirectoryWins_OverFilenames()
+        {
+            var clusters = FileClustering.Cluster(new[]
+            {
+                F(1, "Future History/Revolt in 2100/01 Intro.mp3"),
+                F(2, "Future History/Revolt in 2100/02 Introduction; The Innocent Eye.mp3"),
+                F(3, "All You Zombies/Spider Robinson/All You Zombies.mp3"),
+            }, Base);
+
+            Assert.Equal(2, clusters.Count);
+            var dirCluster = clusters.First(c => c.DisplayName == "Future History");
+            Assert.Equal(2, dirCluster.Files.Count);
+        }
+
+        [Fact]
+        public void Cluster_SingleFiles_StaySeparate()
+        {
+            var clusters = FileClustering.Cluster(new[]
+            {
+                F(1, "Robert A. Heinlein - The Moon Is a Harsh Mistress.mp3"),
+                F(2, "Robert A. Heinlein - Stranger in a Strange Land.mp3"),
+            }, Base);
+
+            Assert.Equal(2, clusters.Count);
+            Assert.All(clusters, c => Assert.Single(c.Files));
+        }
+
+        [Fact]
+        public void Cluster_TwoCopiesWithDifferentNumberingStyles_FormTwoClusters()
+        {
+            // Live case: a record holding two complete copies of the same book.
+            // The "(N)" copy must not explode into singletons, AND must not
+            // merge with the "-NN" copy — the marker style is the identity that
+            // lets the user delete one redundant copy.
+            var clusters = FileClustering.Cluster(new[]
+            {
+                F(1, "The Rolling Stones (1).mp3"),
+                F(2, "The Rolling Stones (10).mp3"),
+                F(3, "The Rolling Stones (11).mp3"),
+                F(4, "The Rolling Stones-00.mp3"),
+                F(5, "The Rolling Stones-01.mp3"),
+            }, Base);
+
+            Assert.Equal(2, clusters.Count);
+            Assert.Equal(3, clusters[0].Files.Count); // the "(N)" copy
+            Assert.Equal(2, clusters[1].Files.Count); // the "-NN" copy
+            Assert.All(clusters, c => Assert.Equal("The Rolling Stones", c.DisplayName));
+        }
+
+        [Fact]
+        public void Cluster_EmbeddedBookTitles_SplitACollectionRenamedToTheParentName()
+        {
+            // Live case (John Scalzi "Old Man's War"): a collection's files were all renamed to
+            // the parent record's name and sit flat in the record's own folder, so filenames
+            // cluster into a single useless group — but each file's embedded tag names the real
+            // book. For flat files (no subfolder) the embedded title must win and split them,
+            // with track noise stripped.
+            const string omwBase = "/audiobooks/John Scalzi/Old Man's War/Old Man's War";
+            AudiobookFile E(int id, string rel) => new() { Id = id, Path = $"{omwBase}/{rel}" };
+
+            var files = new[]
+            {
+                E(1, "Old Man's War-001.mp3"),
+                E(2, "Old Man's War-030.mp3"),
+                E(3, "Old Man's War-072.mp3"),
+                E(4, "Old Man's War-114.mp3"),
+            };
+            var embedded = new Dictionary<int, string>
+            {
+                [1] = "Old Man's War 1-77",
+                [2] = "The Ghost Brigades 10-41",
+                [3] = "The Ghost Brigades 38-41",
+                [4] = "1 - The Sagan Diary",
+            };
+
+            var clusters = FileClustering.Cluster(files, omwBase, embedded);
+
+            Assert.Equal(3, clusters.Count);
+            Assert.Contains(clusters, c => c.DisplayName == "The Ghost Brigades" && c.Files.Count == 2);
+            Assert.Contains(clusters, c => c.DisplayName == "The Sagan Diary" && c.Files.Count == 1);
+            Assert.Contains(clusters, c => c.DisplayName == "Old Man's War" && c.Files.Count == 1);
+        }
+
+        [Fact]
+        public void Cluster_SubfolderWins_OverInconsistentEmbeddedTags()
+        {
+            // Live case (Throne of Glass, 2325): per-book subfolders, but the embedded album tags
+            // are series-based ("Throne of Glass bk 2") and even mis-applied — the Dramatized
+            // Adaptation file is tagged with the novel's title. The subfolder must win so
+            // different books don't merge on a shared/garbage tag, and a book whose files are
+            // inconsistently tagged (one file untagged, one tagged differently) still groups as
+            // one. Flat files with no subfolder still fall back to the embedded tag.
+            const string b = "/audiobooks/Sarah J. Maas/Throne of Glass/Elizabeth Evans";
+            AudiobookFile T(int id, string rel) => new() { Id = id, Path = $"{b}/{rel}" };
+
+            var files = new[]
+            {
+                T(1, "Crown of Midnight-01.mp3"),                              // flat
+                T(2, "Crown of Midnight/Crown of Midnight-001.mp3"),          // subfolder
+                T(3, "Throne of Glass [Dramatized Adaptation]/dram-001.mp3"), // subfolder, mis-tagged
+                T(4, "Queen of Shadows/Queen of Shadows-002.mp3"),            // subfolder, no tag
+                T(5, "Queen of Shadows/Queen of Shadows-003.mp3"),            // subfolder, different tag
+            };
+            var embedded = new Dictionary<int, string>
+            {
+                [1] = "Throne of Glass bk 2",
+                [2] = "Throne of Glass bk 2",
+                [3] = "Crown of Midnight",                     // mis-tag on the Dramatized file
+                [5] = "Throne of Glass 04 - Queen of Shadows", // file 4 has no tag
+            };
+
+            var clusters = FileClustering.Cluster(files, b, embedded);
+
+            Assert.Equal(4, clusters.Count);
+            // Subfolder books each cluster by their folder, regardless of the (bad) tags:
+            Assert.Contains(clusters, c => c.DisplayName == "Crown of Midnight" && c.Files.Count == 1);
+            // NOT merged with Crown of Midnight despite sharing its title tag:
+            Assert.Contains(clusters, c => c.DisplayName == "Throne of Glass [Dramatized Adaptation]" && c.Files.Count == 1);
+            // Both Queen of Shadows files merge by folder despite inconsistent tags:
+            Assert.Contains(clusters, c => c.DisplayName == "Queen of Shadows" && c.Files.Count == 2);
+            // The flat file falls back to its embedded tag:
+            Assert.Contains(clusters, c => c.DisplayName == "Throne of Glass bk 2" && c.Files.Count == 1);
+        }
+
+        [Fact]
+        public void Cluster_NoEmbeddedTitle_FallsBackToPathClustering()
+        {
+            // A file with no usable embedded tag must still cluster by filename/subdir, and a
+            // tag that cleans to nothing is treated as "no signal".
+            const string b = "/audiobooks/Author/Record/Narrator";
+            AudiobookFile F2(int id, string rel) => new() { Id = id, Path = $"{b}/{rel}" };
+
+            var files = new[] { F2(1, "Some Book-01.mp3"), F2(2, "Some Book-02.mp3") };
+            var embedded = new Dictionary<int, string> { [1] = "   ", [2] = "07" }; // whitespace + bare digits
+
+            var clusters = FileClustering.Cluster(files, b, embedded);
+
+            Assert.Single(clusters);
+            Assert.Equal("Some Book", clusters[0].DisplayName);
+        }
+
+        [Fact]
+        public void Cluster_DifferentVolumesInOneFolder_FormSeparateClusters()
+        {
+            // Live case (book 1335): a Vol. 2 set was moved into the Vol. 1
+            // record's folder, so both volumes sit side by side distinguished
+            // only by "Vol. 1-NNN" vs "Vol. 2-NNN". The track-numbering stripper
+            // must not also eat the volume number, or both reduce to
+            // "Expanded Universe, Vol." and collapse into a single cluster —
+            // making the record un-splittable.
+            const string volBase = "/audiobooks/Robert A. Heinlein/Expanded Universe, Vol. 1/Bronson Pinchot";
+            AudiobookFile V(int id, string rel) => new() { Id = id, Path = $"{volBase}/{rel}" };
+
+            var clusters = FileClustering.Cluster(new[]
+            {
+                V(1, "Expanded Universe, Vol. 1-001.mp3"),
+                V(2, "Expanded Universe, Vol. 1-002.mp3"),
+                V(3, "Expanded Universe, Vol. 1-031.mp3"),
+                V(4, "Expanded Universe, Vol. 2-001.mp3"),
+                V(5, "Expanded Universe, Vol. 2-002.mp3"),
+                V(6, "Expanded Universe, Vol. 2-031.mp3"),
+            }, volBase);
+
+            Assert.Equal(2, clusters.Count);
+            Assert.All(clusters, c => Assert.Equal(3, c.Files.Count));
+            Assert.Contains(clusters, c => c.DisplayName == "Expanded Universe, Vol. 1");
+            Assert.Contains(clusters, c => c.DisplayName == "Expanded Universe, Vol. 2");
+        }
+
+        [Fact]
+        public void Cluster_UnnumberedFirstTrack_JoinsItsNumberedSiblings()
+        {
+            // Numbering often starts at the unmarked file: "Title.mp3" IS track
+            // one of the "Title (N)" set (users renamed it "Title (0).mp3" by
+            // hand to fix this). Comparable duration → merge, listed first.
+            var clusters = FileClustering.Cluster(new[]
+            {
+                new AudiobookFile { Id = 1, Path = $"{Base}/Example Track.mp3", DurationSeconds = 600 },
+                new AudiobookFile { Id = 2, Path = $"{Base}/Example Track (1).mp3", DurationSeconds = 610 },
+                new AudiobookFile { Id = 3, Path = $"{Base}/Example Track (2).mp3", DurationSeconds = 590 },
+            }, Base);
+
+            Assert.Single(clusters);
+            Assert.Equal(3, clusters[0].Files.Count);
+            Assert.Equal(1, clusters[0].Files[0].Id);
+        }
+
+        [Fact]
+        public void Cluster_SameStemWholeBookFile_StaysItsOwnGroup()
+        {
+            // A complete single-file copy sharing the stem must NOT be swallowed
+            // into the track set — it is ~30× a track's duration.
+            var clusters = FileClustering.Cluster(new[]
+            {
+                new AudiobookFile { Id = 1, Path = $"{Base}/Example Track.mp3", DurationSeconds = 20000 },
+                new AudiobookFile { Id = 2, Path = $"{Base}/Example Track (1).mp3", DurationSeconds = 610 },
+                new AudiobookFile { Id = 3, Path = $"{Base}/Example Track (2).mp3", DurationSeconds = 590 },
+            }, Base);
+
+            Assert.Equal(2, clusters.Count);
+        }
+
+        [Theory]
+        [InlineData("The Rolling Stones (10)", "The Rolling Stones")]
+        [InlineData("Track [07]", "Track")]
+        [InlineData("(heinlein_robert)-friday-01_77", "(heinlein_robert)-friday")]
+        [InlineData("Robert A. Heinlein - Expanded Universe Part 01 of 26", "Robert A. Heinlein - Expanded Universe")]
+        [InlineData("TunnelintheSkyUnabridged_51", "TunnelintheSkyUnabridged")]
+        [InlineData("1 The Year of the Jackpot", "The Year of the Jackpot")]
+        [InlineData("HEINLEIN - Door 12_41", "HEINLEIN - Door")]
+        [InlineData("Robert A. Heinlein - Starship Troopers Part 61 of 61", "Robert A. Heinlein - Starship Troopers")]
+        // A volume/book designator keeps its own number; only the track marker goes.
+        [InlineData("Expanded Universe, Vol. 1-001", "Expanded Universe, Vol. 1")]
+        [InlineData("Expanded Universe, Vol. 2-031", "Expanded Universe, Vol. 2")]
+        [InlineData("Wheel of Time Book 3 - 12", "Wheel of Time Book 3")]
+        public void CleanStem_StripsNumberingNoise(string input, string expected)
+        {
+            Assert.Equal(expected, FileClustering.CleanStem(input));
+        }
+
+        [Fact]
+        public void CleanStem_NeverReturnsEmpty()
+        {
+            // A name that is nothing but numbering must fall back to itself.
+            Assert.Equal("01_77", FileClustering.CleanStem("01_77"));
+        }
+    }
+
+    public class SplitDestinationSuggesterTests
+    {
+        private static readonly List<(int, string)> Library = new()
+        {
+            (398, "Friday"),
+            (421, "Tunnel in the Sky"),
+            (395, "Expanded Universe, Vol. 1"),
+            (1335, "Expanded Universe, Vol. 2"),
+            (415, "The Moon Is a Harsh Mistress"),
+        };
+
+        [Fact]
+        public void Suggest_PrefersLongestTitle()
+        {
+            // "Vol. 2" must beat the shorter "Expanded Universe, Vol. 1"… both
+            // contain "expanded universe", but only Vol. 2's full title is in
+            // the cluster name.
+            Assert.Equal(1335, SplitDestinationSuggester.Suggest("Expanded Universe, Vol. 2", Library));
+        }
+
+        [Fact]
+        public void Suggest_SpaceInsensitive()
+        {
+            Assert.Equal(421, SplitDestinationSuggester.Suggest("TunnelintheSkyUnabridged", Library));
+        }
+
+        [Fact]
+        public void Suggest_NoContainment_ReturnsNull()
+        {
+            Assert.Null(SplitDestinationSuggester.Suggest("Robert A. Heinlein - 8 Books", Library));
+        }
+
+        [Fact]
+        public void Suggest_FullSentenceTitle_Matches()
+        {
+            Assert.Equal(415, SplitDestinationSuggester.Suggest(
+                "Robert A. Heinlein - The Moon Is a Harsh Mistress", Library));
+        }
+    }
+}


### PR DESCRIPTION
> **Stacked on #722** (split-collection) — reuses its `TitleMatcher.Normalize` and `FileClustering`. Diff collapses when the stack merges.

## What

`GET /library/duplicates` (read-only sweep, no ffprobe) plus a Settings → General section:

- **Duplicate records**: grouped by identical ASIN, else normalized title+author. Deliberately conservative — groups with ≥2 distinct ASINs (different editions) or ≥2 distinct subtitles AND years are dropped; false positives would erode trust. Each group nominates a suggested keeper (most files, oldest id) and offers record-only delete (files stay on disk) behind a danger confirm.
- **Duplicate copies within a record**: `FileClustering` signatures — same filename stem with a different numbering style, or two multi-file clusters with totals within 25%, flags a record as likely holding the same book twice (resolved on the book page via multi-select / split). Subdirectory clusters are excluded so CD1/CD2 layouts don't false-positive.

Per-book rows are returned (not just counts) so an upcoming dashboard can surface these as clickable health categories.

## Tests

7 new workflow tests (group formation, both conservative exclusions, keeper choice, two-scheme copy detection, single-scheme non-flag). Full suite 1063/1063; vue-tsc (3.3.4) + vite build + eslint + prettier + vitest clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)