### PR TITLE
Fix sidebar sub-nav items not reacting to hover

### DIFF
--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -2188,23 +2188,18 @@ these are not present, the Google Fonts import in `fe/index.html` will be used a
   flex-direction: column;
   padding-left: 36px;
   margin-bottom: 0.5rem;
-  /* collapse layout space when closed */
-  max-height: 0;
-  overflow: hidden;
-  /* Use transform-scale for smooth animation */
-  transform-origin: top;
-  transform: scaleY(0);
-  opacity: 0;
-  pointer-events: none;
-  transition:
-    max-height 220ms ease,
-    transform 160ms cubic-bezier(0.2, 0.9, 0.3, 1),
-    opacity 120ms ease;
+  /* Always expanded: sub-items stay visible and interactive so they highlight on their own
+     hover, with no need to hover the parent top node first. */
+  max-height: none;
+  overflow: visible;
+  transform: none;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .sidebar .nav-sub.open {
-  max-height: 400px; /* large enough to contain items */
-  transform: scaleY(1);
+  max-height: none;
+  transform: none;
   opacity: 1;
   pointer-events: auto;
 }
@@ -2233,6 +2228,16 @@ these are not present, the Google Fonts import in `fe/index.html` will be used a
   color: #ffffff;
   font-weight: 500;
   border-left: 3px solid #2196f3; /* Highlighted border for active */
+}
+
+/* Hover / keyboard-focus feedback: sub-items previously had no reactive state, so they never
+   highlighted on hover. Distinct from the muted default and the solid-blue active state. */
+.sidebar .nav-subitem:hover,
+.sidebar .nav-subitem:focus-visible {
+  color: #ffffff;
+  border-left-color: rgba(33, 150, 243, 0.55);
+  background: rgba(255, 255, 255, 0.04);
+  outline: none;
 }
 
 .inline-spinner {


### PR DESCRIPTION
## Summary

In the left sidebar, the sub-nav items (Books/Authors/Series under Audiobooks, and the Settings
children) did not react to hover. You had to hover the parent top node first before a child would
respond, which read as broken.

## Changes

### Fixed
- **Sub-items had no hover or focus feedback.** `.nav-subitem` had CSS for only its default and
  `.active` states, so hovering (or keyboard-focusing) a sub-item produced no visual change. Added a
  `:hover` / `:focus-visible` highlight that matches the existing blue accent.
- **Children were unreachable until the parent was hovered.** `.nav-sub` was collapsed with
  `pointer-events: none` until it received `.open` (driven by hovering the parent). So for any section
  you were not currently on, the children could not be hovered at all until you first hovered the top
  node. Made the sub-navs stay expanded so children are always interactive and highlight on their own
  hover.

## Testing
- Frontend builds clean.
- Verified live: hovering any sub-item (in the active section or any other) now highlights it
  directly, with no need to hover the parent first. Keyboard focus highlights too.

## Notes
- The second change removes the collapse/expand animation in favor of an always-expanded tree, since
  that collapse was the source of the reachability gate. If maintainers prefer to keep the accordion,
  I am happy to instead fix reachability another way (for example expanding on child focus/hover
  without the `pointer-events` block). Flagging it since it is a small behavior change.
- Suggested version label: **patch**.
