### PR TITLE
Fix advanced-search ASIN lookup returning "Unknown Title" (#525)

### DIFF
--- a/listenarr.api/Features/Search/StructuredSearchWorkflow.cs
+++ b/listenarr.api/Features/Search/StructuredSearchWorkflow.cs
@@ -214,6 +214,22 @@ namespace Listenarr.Api.Features.Search
                 {
                     var metadata = _metadataConverters.ConvertAudibleToMetadata(audible, req.Asin, source: "Audible");
                     var sr = await _metadataConverters.ConvertMetadataToSearchResultAsync(metadata, req.Asin, req.Title, req.Author, fallbackImageUrl: null, fallbackLanguage: language);
+
+                    // #525: this inlined ASIN lookup used to return whatever ConvertMetadataToSearchResultAsync
+                    // produced, including its literal "Unknown Title" fallback (hit when an ASIN is searched with
+                    // no title, e.g. Library Import reading the ASIN from file tags). Returning null here falls
+                    // through to the validated unified search path (IntelligentSearchAsync -> AsinSearchHandler)
+                    // instead of surfacing a titleless result. Mirrors AsinSearchHandler's title check.
+                    if (string.IsNullOrWhiteSpace(sr?.Title)
+                        || string.Equals(sr.Title, "Unknown Title", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(sr.Title, "Amazon.com", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _logger.LogWarning(
+                            "ASIN {Asin} advanced-search metadata had no usable title; falling back to unified search",
+                            LogRedaction.SanitizeText(req.Asin));
+                        return null;
+                    }
+
                     _responseMapper.SanitizeResultForPublicApi(sr, region);
                     var md = SearchResultConverters.ToMetadata(sr);
                     await SearchResultImageNormalizer.NormalizeMetadataResultAsync(

--- a/tests/Features/Api/Features/Search/SearchControllerAsinTitleGuardTests.cs
+++ b/tests/Features/Api/Features/Search/SearchControllerAsinTitleGuardTests.cs
@@ -1,0 +1,94 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+using System.Text.Json;
+
+namespace Listenarr.Tests.Features.Api.Features.Search
+{
+    // Regression tests for #525: the advanced-search inlined ASIN lookup
+    // (StructuredSearchWorkflow.TryExecuteAsinSearchAsync) used to return whatever
+    // ConvertMetadataToSearchResultAsync produced, including its literal "Unknown Title" fallback
+    // when an ASIN was searched with no title (e.g. Library Import reading the ASIN from file tags).
+    // The title guard now makes such a lookup return null and fall through to the validated unified
+    // search path (IntelligentSearchAsync -> AsinSearchHandler) instead of surfacing a titleless result.
+    public class SearchControllerAsinTitleGuardTests
+    {
+        private static (StructuredSearchWorkflow workflow, Mock<ISearchService> search, Mock<AudibleService> audible) Build()
+        {
+            var search = new Mock<ISearchService>();
+            search
+                .Setup(s => s.IntelligentSearchAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<int>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<double>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<MetadataSearchResult>());
+
+            using var httpClient = new System.Net.Http.HttpClient();
+            var audible = new Mock<AudibleService>(httpClient, Mock.Of<ILogger<AudibleService>>());
+            var metadata = new Mock<IAudiobookMetadataService>();
+            var workflow = new StructuredSearchWorkflow(
+                search.Object,
+                Mock.Of<ILogger<StructuredSearchWorkflow>>(),
+                audible.Object,
+                metadata.Object,
+                imageCacheService: Mock.Of<IImageCacheService>());
+            return (workflow, search, audible);
+        }
+
+        private static JsonElement AdvancedAsinRequest(string asin)
+            => JsonSerializer.SerializeToElement(new SearchRequest { Mode = SearchMode.Advanced, Asin = asin, Title = null });
+
+        private void VerifyUnifiedSearchCalled(Mock<ISearchService> search, Times times)
+            => search.Verify(s => s.IntelligentSearchAsync(
+                It.IsAny<string>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<double>(),
+                It.IsAny<string>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()), times);
+
+        [Fact]
+        public async Task AdvancedAsinSearch_TitlelessMetadata_FallsThroughToUnifiedSearch()
+        {
+            var (workflow, search, audible) = Build();
+            // Audible returns a product with a cover but NO title (the #525 trigger).
+            audible
+                .Setup(a => a.GetBookMetadataAsync("B00NOTITLE", It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>()))
+                .ReturnsAsync(new AudibleBookResponse { Asin = "B00NOTITLE", Title = null, ImageUrl = "https://example.test/cover.jpg" });
+
+            await workflow.ExecuteAsync(AdvancedAsinRequest("B00NOTITLE"), simplified: true, new Microsoft.AspNetCore.Http.DefaultHttpContext());
+
+            // The titleless result is rejected -> flow falls through to the validated unified path.
+            VerifyUnifiedSearchCalled(search, Times.AtLeastOnce());
+        }
+
+        [Fact]
+        public async Task AdvancedAsinSearch_RealTitle_UsesInlinedResult_DoesNotFallThrough()
+        {
+            var (workflow, search, audible) = Build();
+            audible
+                .Setup(a => a.GetBookMetadataAsync("B00GOODASIN", It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<string?>()))
+                .ReturnsAsync(new AudibleBookResponse { Asin = "B00GOODASIN", Title = "Project Hail Mary" });
+
+            await workflow.ExecuteAsync(AdvancedAsinRequest("B00GOODASIN"), simplified: true, new Microsoft.AspNetCore.Http.DefaultHttpContext());
+
+            // A valid ASIN with a real title is handled by the inlined path and must NOT fall through.
+            VerifyUnifiedSearchCalled(search, Times.Never());
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Advanced search by ASIN can return a result with the literal title **"Unknown Title"** (blank cover, "Unknown Author") when Audible has no title for that ASIN. This happens with delisted / old-edition ASINs, or via Library Import reading an ASIN from file tags with no user-typed title. These titleless ghost results can then be added to the library.

## Root cause
`StructuredSearchWorkflow.TryExecuteAsinSearchAsync` returned whatever `ConvertMetadataToSearchResultAsync` produced, guarded only by `if (md != null)`, with no title validation. That converter falls back to the literal `"Unknown Title"` when the metadata title is empty, and this inlined path short-circuits before the validated unified search path (`IntelligentSearchAsync` then `AsinSearchHandler`, which already rejects titleless results) can run.

## Fix
Add a title guard mirroring `AsinSearchHandler`'s existing check: when the built result has no usable title (empty, `"Unknown Title"`, or `"Amazon.com"`), return `null` so the flow falls through to the validated unified path instead of surfacing a titleless result. Valid ASINs with a real title are unaffected.

## Tests
Adds `SearchControllerAsinTitleGuardTests`:
- titleless ASIN metadata falls through to unified search (no ghost result)
- valid-title ASIN is handled inline and does not fall through

Also verified manually: advanced ASIN search on a delisted/titleless ASIN now returns a clean "No results" instead of an "Unknown Title" card, and normal ASIN search is unchanged.

## Scope
Scoped to the advanced-search ASIN path. The analogous series shortcut (`TryExecuteSeriesSearchAsync`) shares the pattern but is left out of scope here.

Closes #525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
