### PR TITLE
Fix #542: audiobook total size = sum of per-file sizes

### DIFF
--- a/listenarr.api/Features/Library/LibraryQueryWorkflow.cs
+++ b/listenarr.api/Features/Library/LibraryQueryWorkflow.cs
@@ -66,7 +66,9 @@ public sealed class LibraryQueryWorkflow(
         publisher = audiobook.Publisher,
         language = audiobook.Language,
         filePath = audiobook.FilePath,
-        fileSize = audiobook.FileSize,
+        fileSize = audiobook.Files != null && audiobook.Files.Any()
+            ? audiobook.Files.Sum(f => f.Size ?? 0)
+            : audiobook.FileSize,
         basePath = audiobook.BasePath,
         runtime = audiobook.Runtime,
         edition = audiobook.Edition,

--- a/listenarr.application/Audiobooks/Catalog/LibraryListService.cs
+++ b/listenarr.application/Audiobooks/Catalog/LibraryListService.cs
@@ -69,6 +69,7 @@ namespace Listenarr.Application.Audiobooks.Catalog
             // was started on this context instance" under real database latency.
             var fileSummaryRows = await _audiobookFileRepository.GetFormatSummariesAsync();
             var fileCountById = await _audiobookFileRepository.GetCountsByAudiobookIdAsync();
+            var fileSizeById = await _audiobookFileRepository.GetTotalSizesByAudiobookIdAsync();
             var membershipsByAudiobookId = await _audiobookRepository.GetAllSeriesMembershipsGroupedByAudiobookIdAsync();
             var filesByAudiobookId = fileSummaryRows
                 .GroupBy(f => f.AudiobookId)
@@ -135,7 +136,7 @@ namespace Listenarr.Application.Audiobooks.Catalog
                     Monitored = a.Monitored,
                     BasePath = a.BasePath,
                     FilePath = a.FilePath,
-                    FileSize = a.FileSize,
+                    FileSize = fileSizeById.TryGetValue(a.Id, out var totalSize) ? totalSize : a.FileSize,
                     FileCount = fileCountById.TryGetValue(a.Id, out var trueCount) ? trueCount : 0,
                     Quality = a.Quality,
                     QualityProfileId = a.QualityProfileId,

--- a/listenarr.application/Audiobooks/Contracts/Repositories/IAudiobookFileRepository.cs
+++ b/listenarr.application/Audiobooks/Contracts/Repositories/IAudiobookFileRepository.cs
@@ -33,5 +33,6 @@ namespace Listenarr.Application.Audiobooks.Contracts.Repositories
         Task<List<AudiobookFile>> GetAllAsync(CancellationToken ct = default);
         Task<List<AudiobookFormatSummary>> GetFormatSummariesAsync(CancellationToken ct = default);
         Task<Dictionary<int, int>> GetCountsByAudiobookIdAsync(CancellationToken ct = default);
+        Task<Dictionary<int, long>> GetTotalSizesByAudiobookIdAsync(CancellationToken ct = default);
     }
 }

--- a/listenarr.application/Mapping/AudiobookDtoFactory.cs
+++ b/listenarr.application/Mapping/AudiobookDtoFactory.cs
@@ -72,7 +72,9 @@ namespace Listenarr.Application.Mapping
                     .ToArray(),
                 Monitored = audiobook.Monitored,
                 FilePath = audiobook.FilePath,
-                FileSize = audiobook.FileSize,
+                FileSize = audiobook.Files != null && audiobook.Files.Any()
+                    ? audiobook.Files.Sum(f => f.Size ?? 0)
+                    : audiobook.FileSize,
                 BasePath = audiobook.BasePath,
                 Files = files,
                 ImageUrl = audiobook.ImageUrl,

--- a/listenarr.infrastructure/Persistence/Repositories/EfAudiobookFileRepository.cs
+++ b/listenarr.infrastructure/Persistence/Repositories/EfAudiobookFileRepository.cs
@@ -142,5 +142,17 @@ namespace Listenarr.Infrastructure.Persistence.Repositories
                 .Select(g => new { AudiobookId = g.Key, Count = g.Count() })
                 .ToDictionaryAsync(r => r.AudiobookId, r => r.Count, ct);
         }
+
+        // #542: total size is the SUM of the audiobook's per-file sizes (an audiobook is often
+        // multi-file). Mirrors GetCountsByAudiobookIdAsync so the list view can show a correct total
+        // without loading every file row.
+        public async Task<Dictionary<int, long>> GetTotalSizesByAudiobookIdAsync(CancellationToken ct = default)
+        {
+            return await _db.AudiobookFiles
+                .AsNoTracking()
+                .GroupBy(f => f.AudiobookId)
+                .Select(g => new { AudiobookId = g.Key, Total = g.Sum(f => f.Size) ?? 0L })
+                .ToDictionaryAsync(r => r.AudiobookId, r => r.Total, ct);
+        }
     }
 }

--- a/tests/Features/Api/Models/AudiobookDtoFactoryTests.cs
+++ b/tests/Features/Api/Models/AudiobookDtoFactoryTests.cs
@@ -90,6 +90,33 @@ namespace Listenarr.Tests.Features.Api.Models
         }
 
         [Fact]
+        public async Task BuildFromEntity_SumsFileSizesAcrossMultipleFiles()
+        {
+            // #542: an audiobook is often multi-file; the total must be the SUM of per-file sizes,
+            // not the primary file's size or the stale Audiobook.FileSize scalar.
+            var options = new DbContextOptionsBuilder<ListenArrDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+
+            using var db = new ListenArrDbContext(options);
+
+            var book = new Audiobook { Title = "Multi-file Book", Monitored = true, FileSize = 999 };
+            db.Audiobooks.Add(book);
+            await db.SaveChangesAsync();
+
+            db.AudiobookFiles.Add(new AudiobookFileBuilder().WithAudiobook(book).WithPath("C:\\b\\1.mp3").WithSize(100).Build());
+            db.AudiobookFiles.Add(new AudiobookFileBuilder().WithAudiobook(book).WithPath("C:\\b\\2.mp3").WithSize(200).Build());
+            db.AudiobookFiles.Add(new AudiobookFileBuilder().WithAudiobook(book).WithPath("C:\\b\\3.mp3").WithSize(300).Build());
+            await db.SaveChangesAsync();
+
+            var updated = await db.Audiobooks.Include(a => a.Files).FirstOrDefaultAsync(a => a.Id == book.Id);
+            var dto = AudiobookDtoFactory.BuildFromEntity(updated);
+
+            // Sum of the three files (600), not the primary file (100) nor the stale scalar (999).
+            Assert.Equal(600, dto.FileSize);
+        }
+
+        [Fact]
         public async Task BuildFromEntity_ComputesWantedWhenNoFiles()
         {
             var options = new DbContextOptionsBuilder<ListenArrDbContext>()


### PR DESCRIPTION
## Problem
An audiobook's total size (`Audiobook.FileSize`) is wrong. For multi-file audiobooks it shows only one file's size (a 15-part, ~70 MB book displays ~4.7 MB), and for books that were never organized it shows nothing at all.

## Root cause
`FileSize` is a stored scalar that is only ever set to the primary (alphabetically-first) file's size during rename (`UpdateAudiobookPathSummary`), or left null. It is never the sum of the audiobook's files. The per-file sizes (`AudiobookFile.Size`, from the filesystem) are already correct; only the aggregate is wrong.

## Fix
Derive the total from the already-correct per-file sizes at read time, instead of relying on the stale scalar:
- New `IAudiobookFileRepository.GetTotalSizesByAudiobookIdAsync` (SUM grouped by audiobook), mirroring `GetCountsByAudiobookIdAsync`, for the list view (its format summaries carry no size).
- `AudiobookDtoFactory` and `LibraryQueryWorkflow.MapDetails` sum the loaded `Files`.

Nothing sorts/filters by `FileSize` in SQL, so in-memory/aggregate derivation is safe. No migration and no re-scan needed (per-file sizes are already stored).

## Tests
Adds a multi-file sum test to `AudiobookDtoFactoryTests` (three files summed, not the primary file nor the stale scalar). Verified live: a 15-part book that showed ~4.7 MB now shows its correct ~70 MB total, and a previously blank book now shows its size.

Closes #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
