### PR TITLE
Fix #737: ffprobe metadata extraction returns empty (codec/bitrate/duration)

### DIFF
--- a/listenarr.application/Security/Redaction/LogRedaction.cs
+++ b/listenarr.application/Security/Redaction/LogRedaction.cs
@@ -62,13 +62,10 @@ namespace Listenarr.Application.Security.Redaction
                 }
             }
 
-            // If there are known secrets in the environment but none were replaced (edge cases),
-            // append a generic marker to ensure logs cannot leak values and tests reliably observe redaction.
-            if (combined.Any() && !redacted.Contains("<redacted>", StringComparison.OrdinalIgnoreCase))
-            {
-                redacted = redacted + " <redacted>";
-            }
-
+            // NOTE: do NOT append a generic "<redacted>" marker when nothing matched. If no secret value
+            // is present in the text there is nothing to leak, and appending a marker corrupts any
+            // functional payload the caller parses. This bug made every ffprobe probe fail to parse
+            // ("{...json...} <redacted>") whenever a secret env var (e.g. LISTENARR_API_KEY) was set (#737).
             return redacted;
         }
 

--- a/listenarr.infrastructure/Ffmpeg/Metadata/FfprobeMetadataMapper.cs
+++ b/listenarr.infrastructure/Ffmpeg/Metadata/FfprobeMetadataMapper.cs
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+using System.Globalization;
 using System.Text.Json;
 
 namespace Listenarr.Infrastructure.Ffmpeg.Metadata
@@ -47,8 +48,10 @@ namespace Listenarr.Infrastructure.Ffmpeg.Metadata
         {
             if (fmt.TryGetProperty("duration", out var durEl)
                 && durEl.ValueKind == JsonValueKind.String
-                && double.TryParse(durEl.GetString(), out var dur))
+                && double.TryParse(durEl.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var dur))
             {
+                // #737 Bug A: ffprobe emits dot-decimal (e.g. "108555.624989"); parsing without
+                // InvariantCulture on a comma-decimal machine silently failed, zeroing every duration.
                 metadata.Duration = TimeSpan.FromSeconds(dur);
             }
 
@@ -57,7 +60,7 @@ namespace Listenarr.Infrastructure.Ffmpeg.Metadata
                 ApplyFormatName(metadata, fmtName.GetString() ?? string.Empty, filePath);
             }
 
-            if (fmt.TryGetProperty("bit_rate", out var br) && br.ValueKind == JsonValueKind.String && int.TryParse(br.GetString(), out var bitRate))
+            if (fmt.TryGetProperty("bit_rate", out var br) && br.ValueKind == JsonValueKind.String && int.TryParse(br.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var bitRate))
             {
                 metadata.BitRate = bitRate;
             }
@@ -99,7 +102,7 @@ namespace Listenarr.Infrastructure.Ffmpeg.Metadata
                 .EnumerateArray()
                 .Where(s => s.TryGetProperty("codec_type", out var codecType) && codecType.GetString() == "audio"))
             {
-                if (s.TryGetProperty("sample_rate", out var sr) && sr.ValueKind == JsonValueKind.String && int.TryParse(sr.GetString(), out var sampleRate))
+                if (s.TryGetProperty("sample_rate", out var sr) && sr.ValueKind == JsonValueKind.String && int.TryParse(sr.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var sampleRate))
                 {
                     metadata.SampleRate = sampleRate;
                 }
@@ -107,7 +110,7 @@ namespace Listenarr.Infrastructure.Ffmpeg.Metadata
                 {
                     metadata.Channels = ch.GetInt32();
                 }
-                if (s.TryGetProperty("bit_rate", out var sbr) && sbr.ValueKind == JsonValueKind.String && int.TryParse(sbr.GetString(), out var sbit))
+                if (s.TryGetProperty("bit_rate", out var sbr) && sbr.ValueKind == JsonValueKind.String && int.TryParse(sbr.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var sbit))
                 {
                     metadata.BitRate = metadata.BitRate == 0 ? sbit : metadata.BitRate;
                 }

--- a/tests/Features/Infrastructure/Ffmpeg/Metadata/FfprobeMetadataMapperTests.cs
+++ b/tests/Features/Infrastructure/Ffmpeg/Metadata/FfprobeMetadataMapperTests.cs
@@ -1,0 +1,42 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ */
+using System.Globalization;
+using System.Text.Json;
+using Listenarr.Infrastructure.Ffmpeg.Metadata;
+
+namespace Listenarr.Tests.Features.Infrastructure.Ffmpeg.Metadata
+{
+    public class FfprobeMetadataMapperTests
+    {
+        // #737 Bug A regression: ffprobe emits a dot-decimal duration ("108555.624989"). The old
+        // culture-less double.TryParse failed on a comma-decimal machine and zeroed EVERY duration
+        // library-wide. Force a comma-decimal culture so this test fails without the InvariantCulture fix
+        // even on dot-decimal CI machines.
+        [Fact]
+        public void Map_ParsesDotDecimalDuration_UnderCommaDecimalCulture()
+        {
+            var original = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("de-DE"); // comma decimal separator
+
+                using var doc = JsonDocument.Parse(
+                    "{\"format\":{\"duration\":\"108555.624989\",\"format_name\":\"mov,mp4,m4a\",\"bit_rate\":\"64000\"}," +
+                    "\"streams\":[{\"codec_type\":\"audio\",\"codec_name\":\"aac\",\"sample_rate\":\"44100\",\"channels\":2,\"bit_rate\":\"64000\"}]}");
+
+                var meta = FfprobeMetadataMapper.Map(doc.RootElement, "Light Bringer.m4b");
+
+                Assert.Equal(108555.624989, meta.Duration.TotalSeconds, 3);
+                Assert.Equal("aac", meta.Codec);
+                Assert.Equal(64000, meta.BitRate);
+                Assert.Equal(44100, meta.SampleRate);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = original;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The bug
ffprobe metadata extraction returns empty for every file, so codec/bitrate are null and duration is stored as 0. Two independent causes:

**1. Culture-sensitive duration parse.** `FfprobeMetadataMapper` parses ffprobe's dot-decimal `format.duration` with a culture-less `double.TryParse`, so on a comma-decimal locale it fails and `DurationSeconds` ends up 0 for every file.

**2. Log redaction corrupts the probe output.** `SystemProcessRunner` runs process stdout through `LogRedaction.RedactText`, which appends a `" <redacted>"` marker whenever any sensitive env var (e.g. `LISTENARR_API_KEY`) is set — even when no secret is present. That turns valid ffprobe JSON into `{...} <redacted>`, so `JsonSerializer.Deserialize` throws "Failed to parse ffprobe JSON output" while ffprobe itself exits 0, and a null-metadata fallback is persisted. (Bites anyone with an API key configured.)

## The fix
- Parse duration + the other numeric fields with `InvariantCulture`.
- Drop the append-marker fallback in `RedactText` — real secret values are still redacted by the value-replacement pass; nothing is appended when nothing matched.
- Regression test that parses a dot-decimal duration under a comma-decimal culture (fails without the fix even on dot-decimal CI).

3 files, +53/-11.

## Why it matters beyond the bug
Trustworthy per-file codec/bitrate/duration is the groundwork the quality-filter logic (#582) and the recycling bin (#736) both stand on — safely deciding or performing a quality upgrade isn't really possible without it. This just makes that data correct.

Closes #737
