### PR TITLE
fix(search): fall back to keyword search when author doesn't resolve to an Audible author page

### DIFF
--- a/listenarr.application/Search/Audible/AudibleAuthorSearchWorkflow.cs
+++ b/listenarr.application/Search/Audible/AudibleAuthorSearchWorkflow.cs
@@ -199,24 +199,55 @@ namespace Listenarr.Application.Search.Audible
                 var response = await _audibleService.SearchByTitleAndAuthorPagedAsync(
                     title ?? string.Empty, author, page: 1, limit: candidateLimit, region: region, language: language);
                 var results = response?.Results;
-                if (results == null || results.Count == 0)
+                if (results is { Count: > 0 })
+                {
+                    _logger.LogInformation(
+                        "AUTHOR_TITLE author-page lookup found nothing for '{Author}'; keyword fallback found {Count} result(s)",
+                        author, results.Count);
+                    return await ConvertAsync(results, region);
+                }
+
+                // Audible's own "author" query parameter is a filter, not a
+                // fuzzy hint: passing it alongside title can return ZERO
+                // combined results even when the title alone would find the
+                // book, if the author string doesn't read as close enough to
+                // a real catalog author (confirmed live: "the hidden tower" +
+                // author param zeroed out results Audible returns for the
+                // title alone). Last resort — drop the author constraint
+                // entirely and search by title only; this is the manual
+                // "find correct match" review flow, so the user still picks
+                // the right candidate from the list rather than anything
+                // being auto-applied.
+                if (string.IsNullOrWhiteSpace(title))
+                {
+                    return null;
+                }
+
+                var titleOnly = await _audibleService.SearchByTitleAsync(
+                    title, page: 1, limit: candidateLimit, region: region, language: language);
+                var titleOnlyResults = titleOnly?.Results;
+                if (titleOnlyResults is not { Count: > 0 })
                 {
                     return null;
                 }
 
                 _logger.LogInformation(
-                    "AUTHOR_TITLE author-page lookup found nothing for '{Author}'; keyword fallback found {Count} result(s)",
-                    author, results.Count);
-
-                var converted = await AudibleSearchResultMapper.ConvertToSearchResultsAsync(
-                    results, _metadataConverters, region, logger: _logger, continueOnConversionError: true);
-                return converted.Any() ? SearchResultConverters.ToMetadataList(converted) : null;
+                    "AUTHOR_TITLE keyword fallback (with author) found nothing for '{Author}'; title-only fallback found {Count} result(s)",
+                    author, titleOnlyResults.Count);
+                return await ConvertAsync(titleOnlyResults, region);
             }
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
             {
                 _logger.LogWarning(ex, "AUTHOR_TITLE keyword fallback search failed for author '{Author}', title '{Title}'", author, title);
                 return null;
             }
+        }
+
+        private async Task<List<MetadataSearchResult>?> ConvertAsync(List<AudibleSearchResult> results, string region)
+        {
+            var converted = await AudibleSearchResultMapper.ConvertToSearchResultsAsync(
+                results, _metadataConverters, region, logger: _logger, continueOnConversionError: true);
+            return converted.Any() ? SearchResultConverters.ToMetadataList(converted) : null;
         }
 
         private async Task<IEnumerable<AudibleSearchResult>> FilterByIsbnAsync(

--- a/listenarr.application/Search/Audible/AudibleAuthorSearchWorkflow.cs
+++ b/listenarr.application/Search/Audible/AudibleAuthorSearchWorkflow.cs
@@ -131,7 +131,15 @@ namespace Listenarr.Application.Search.Audible
 
             if (aggregated?.Any() != true)
             {
-                return null;
+                // The author-page lookup above requires the author name to
+                // resolve to an Audible author page. An STT-mangled or
+                // misspelled name (e.g. "Whisher" for the real "Wisher")
+                // never will, even when the book itself is genuinely on
+                // Audible — previously that meant the whole AUTHOR_TITLE
+                // search came back empty with no other recourse. Fall back
+                // to a plain keyword title+author search, which doesn't
+                // require an author-page match.
+                return await FallbackKeywordSearchAsync(title, author, candidateLimit, region, language);
             }
 
             var deduplicated = DeduplicateByAsin(aggregated);
@@ -177,6 +185,38 @@ namespace Listenarr.Application.Search.Audible
                 continueOnConversionError: true);
 
             return converted.Any() ? SearchResultConverters.ToMetadataList(converted) : null;
+        }
+
+        private async Task<List<MetadataSearchResult>?> FallbackKeywordSearchAsync(
+            string? title,
+            string author,
+            int candidateLimit,
+            string region,
+            string? language)
+        {
+            try
+            {
+                var response = await _audibleService.SearchByTitleAndAuthorPagedAsync(
+                    title ?? string.Empty, author, page: 1, limit: candidateLimit, region: region, language: language);
+                var results = response?.Results;
+                if (results == null || results.Count == 0)
+                {
+                    return null;
+                }
+
+                _logger.LogInformation(
+                    "AUTHOR_TITLE author-page lookup found nothing for '{Author}'; keyword fallback found {Count} result(s)",
+                    author, results.Count);
+
+                var converted = await AudibleSearchResultMapper.ConvertToSearchResultsAsync(
+                    results, _metadataConverters, region, logger: _logger, continueOnConversionError: true);
+                return converted.Any() ? SearchResultConverters.ToMetadataList(converted) : null;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogWarning(ex, "AUTHOR_TITLE keyword fallback search failed for author '{Author}', title '{Title}'", author, title);
+                return null;
+            }
         }
 
         private async Task<IEnumerable<AudibleSearchResult>> FilterByIsbnAsync(


### PR DESCRIPTION
## Summary
- `AUTHOR_TITLE` search required the author name to match an Audible author page via `AudibleAuthorPageCollector`; when it didn't (e.g. a whisper-transcribed author name with STT spelling errors — "Whisher" for the real "Wisher"), the whole search returned nothing with no other recourse, even though the book was genuinely on Audible
- Confirmed live: "The Hidden Tower" by James E. Wisher (misheard as "Whisher") failed in all 4 regions, with "No author ASIN found for author" logged each time
- `AudibleService.SearchByTitleAndAuthorPagedAsync` already implements exactly this fallback (a plain keyword title+author search that doesn't require an author-page match) for its own single-page callers, but it was never wired into the `AUTHOR_TITLE` branch used by the "find correct match" / advanced search flow
- Call it when the author-page lookup comes back empty

## Test plan
- [x] `dotnet build` — clean
- [x] `dotnet test` — 1189/1189 passing

Draft per PR-pacing convention (several PRs already active); will promote when a slot frees up.