### PR TITLE
Fix Discord/NTFY notifications double-posting via generic sender fall-through

### DIFF
--- a/listenarr.infrastructure/Notifications/Delivery/NotificationService.Webhooks.cs
+++ b/listenarr.infrastructure/Notifications/Delivery/NotificationService.Webhooks.cs
@@ -81,6 +81,8 @@ namespace Listenarr.Infrastructure.Notifications.Delivery
                 }
 #pragma warning restore CA1031
 
+                // Discord handled; do not fall through to the generic sender (would double-post).
+                return;
             }
 
             // NTFY-specific handling (https://docs.ntfy.sh/publish/)
@@ -139,6 +141,8 @@ namespace Listenarr.Infrastructure.Notifications.Delivery
                     _logger.LogError(ex, "Invalid operation while sending NTFY notification to {WebhookUrl}", LogRedaction.RedactText(webhookUrl, LogRedaction.GetSensitiveValuesFromEnvironment()));
                 }
 
+                // NTFY handled; do not fall through to the generic sender (would double-post).
+                return;
             }
 
             // Pushover (https://pushover.net/api)

--- a/tests/Features/Infrastructure/Notifications/Delivery/NotificationServiceSingleDispatchTests.cs
+++ b/tests/Features/Infrastructure/Notifications/Delivery/NotificationServiceSingleDispatchTests.cs
@@ -1,0 +1,111 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Net;
+
+namespace Listenarr.Tests.Features.Infrastructure.Notifications.Delivery
+{
+    // Regression tests: the Discord and NTFY handlers must not fall through to the
+    // generic webhook sender after handling the notification. The fall-through posted a
+    // second copy of every Discord/NTFY notification; for Discord the duplicate used a
+    // payload Discord rejects with 400 {"embeds": ["0"]} whenever the embed contained a
+    // relative thumbnail URL, making delivery look broken even though the first send
+    // had succeeded.
+    public partial class NotificationServiceTests
+    {
+        private static (NotificationService Service, Func<int> GetRequestCount) CreateServiceWithCountingHandler()
+        {
+            var requestCount = 0;
+            var mockHandler = new Mock<HttpMessageHandler>();
+            mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .Callback<HttpRequestMessage, CancellationToken>((_, _) => Interlocked.Increment(ref requestCount))
+                .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK));
+
+            var httpClient = new HttpClient(mockHandler.Object);
+
+            var mockConfigService = new Mock<IConfigurationService>();
+            mockConfigService
+                .Setup(x => x.GetStartupConfigAsync())
+                .ReturnsAsync(new StartupConfig { UrlBase = "https://listenarr.example.com" });
+
+            var services = new ServiceCollection();
+            services.AddSingleton<INotificationPayloadBuilder, NotificationPayloadBuilderAdapter>();
+            var provider = services.BuildServiceProvider();
+            var payloadBuilder = provider.GetRequiredService<INotificationPayloadBuilder>();
+
+            var service = new NotificationService(
+                httpClient,
+                Mock.Of<ILogger<NotificationService>>(),
+                mockConfigService.Object,
+                payloadBuilder,
+                Mock.Of<IRequestContextAccessor>()
+            );
+
+            return (service, () => requestCount);
+        }
+
+        [Fact]
+        public async Task SendNotificationAsync_DiscordWebhook_PostsExactlyOnce()
+        {
+            var (service, getRequestCount) = CreateServiceWithCountingHandler();
+            var trigger = "book-added";
+            var data = new
+            {
+                id = 1,
+                title = "Test Book",
+                authors = new[] { "Jane Doe" },
+                asin = "B00TEST"
+            };
+
+            await service.SendNotificationAsync(
+                trigger,
+                data,
+                "https://discord.com/api/webhooks/123456/token",
+                new List<string> { trigger });
+
+            Assert.Equal(1, getRequestCount());
+        }
+
+        [Fact]
+        public async Task SendNotificationAsync_NtfyWebhook_PostsExactlyOnce()
+        {
+            var (service, getRequestCount) = CreateServiceWithCountingHandler();
+            var trigger = "book-added";
+            var data = new
+            {
+                id = 1,
+                title = "Test Book",
+                authors = new[] { "Jane Doe" },
+                asin = "B00TEST"
+            };
+
+            await service.SendNotificationAsync(
+                trigger,
+                data,
+                "https://ntfy.sh/listenarr-test",
+                new List<string> { trigger });
+
+            Assert.Equal(1, getRequestCount());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #753

### Problem

The Discord and NTFY handlers in `SendNotificationAsync` (`NotificationService.Webhooks.cs`) do not `return` after handling the notification, so execution falls through to the generic webhook sender and every Discord/NTFY notification is posted a **second time**.

For Discord, the duplicate is built by `CreateDiscordPayload`; when the configured base URL is not an absolute `http(s)` URL (e.g. the default `UrlBase` of `"/"`), its embed thumbnail is a relative path, which the Discord API rejects with `400 {"embeds": ["0"]}` — so the log shows a delivery failure on every notification even though the first (Discord-specific) send succeeded. When the payload is valid, the channel simply receives two copies.

The Pushover and Telegram handlers already `return` and are unaffected.

### Fix

Add the missing `return;` at the end of the Discord and NTFY branches, making each service-specific handler terminal for URLs it handles — consistent with the existing Pushover/Telegram behavior.

### Tests

Adds `NotificationServiceSingleDispatchTests` with two regression tests asserting exactly **one** HTTP request is made per Discord/NTFY notification (using the same mocked-`HttpMessageHandler` pattern as the existing `NotificationServiceTests`).

Verified the tests fail before the fix and pass after:

```
WITHOUT fix: Failed! - Failed: 2, Passed: 0  (two HTTP requests observed per notification)
WITH fix:    Passed! - Failed: 0, Passed: 2
```

Full notification test group (`--filter FullyQualifiedName~NotificationService`, 13 tests) passes.

Also verified end-to-end against a live Discord webhook on a dev instance: one message delivered (with cover attachment), no `Sending Generic POST` follow-up, no 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
