### PR TITLE
fix(downloads): orphan cleanup skipped live empty-queue snapshots, stranding deleted downloads and blocking re-grabs with 409

### DIFF
--- a/listenarr.application/Downloads/Queue/DownloadOrphanCleanupService.cs
+++ b/listenarr.application/Downloads/Queue/DownloadOrphanCleanupService.cs
@@ -48,16 +48,14 @@ namespace Listenarr.Application.Downloads.Queue
                 return;
             }
 
+            // A snapshot that reaches this point is guaranteed live: the UsedCachedSnapshot
+            // and IsUnavailable guards above already excluded every unreachable path (the
+            // poller surfaces timeout/cancel/error as cached or unavailable, never as a live
+            // empty snapshot). An empty live queue therefore means the items really are gone,
+            // so an empty snapshot must be allowed to terminalize orphans - otherwise deleting
+            // your only active torrent strands its Download record forever and blocks re-grabs
+            // with 409. The per-item grace period below still protects fresh adds.
             var clientQueue = clientQueueResult.QueueItems;
-            if (clientQueue.Count == 0 && clientDownloads.Any())
-            {
-                logger.LogWarning(
-                    "Skipping orphan cleanup for client {ClientName}: client returned 0 queue items but {Count} downloads are tracked. Client may be temporarily unreachable.",
-                    client.Name,
-                    clientDownloads.Count);
-                return;
-            }
-
             var liveClientItemIds = BuildLiveClientItemIds(clientQueue, mappedQueueItems);
             var now = DateTime.UtcNow;
             var cleanupCandidates = clientDownloads

--- a/tests/Features/Application/Downloads/Queue/DownloadOrphanCleanupServiceTests.cs
+++ b/tests/Features/Application/Downloads/Queue/DownloadOrphanCleanupServiceTests.cs
@@ -86,7 +86,7 @@ namespace Listenarr.Tests.Features.Application.Downloads.Queue
 
         [Fact]
         [Trait("Method", "RemoveOrphansAsync")]
-        public async Task RemoveOrphansAsync_DoesNotRemoveIdlessDownloadWhenLiveSnapshotIsEmpty()
+        public async Task RemoveOrphansAsync_RemovesIdlessDownloadWhenLiveSnapshotIsEmpty()
         {
             var client = CreateClient();
             var download = await AddDownloadAsync(
@@ -99,6 +99,96 @@ namespace Listenarr.Tests.Features.Application.Downloads.Queue
             await service.RemoveOrphansAsync(
                 client,
                 CreateLiveSnapshot(client, []),
+                [],
+                [download]);
+
+            Assert.Null(await _downloadRepository.GetByIdAsync(download.Id));
+            _metricsMock.Verify(m => m.Increment("download.orphan.unlinked_removed", 1), Times.Once);
+            _metricsMock.Verify(m => m.Increment("download.orphan.removed", It.IsAny<double>()), Times.Never);
+        }
+
+        [Fact]
+        [Trait("Method", "RemoveOrphansAsync")]
+        public async Task RemoveOrphansAsync_RemovesOnlyTrackedDownloadWhenLiveSnapshotIsEmpty()
+        {
+            var client = CreateClient();
+            var download = await AddDownloadAsync(
+                id: "sole-active-orphan",
+                clientId: client.Id,
+                status: DownloadStatus.Downloading,
+                startedAt: DateTime.UtcNow.AddMinutes(-10),
+                metadata: new Dictionary<string, object>
+                {
+                    ["ClientDownloadId"] = "deleted-in-client"
+                });
+            var service = _provider.GetRequiredService<DownloadOrphanCleanupService>();
+
+            await service.RemoveOrphansAsync(
+                client,
+                CreateLiveSnapshot(client, []),
+                [],
+                [download]);
+
+            Assert.Null(await _downloadRepository.GetByIdAsync(download.Id));
+            _metricsMock.Verify(m => m.Increment("download.orphan.removed", 1), Times.Once);
+            _metricsMock.Verify(m => m.Increment("download.orphan.unlinked_removed", It.IsAny<double>()), Times.Never);
+        }
+
+        [Fact]
+        [Trait("Method", "RemoveOrphansAsync")]
+        public async Task RemoveOrphansAsync_DoesNotRemoveRecentDownloadWhenLiveSnapshotIsEmpty()
+        {
+            var client = CreateClient();
+            var download = await AddDownloadAsync(
+                id: "recent-empty-snapshot-download",
+                clientId: client.Id,
+                status: DownloadStatus.Downloading,
+                startedAt: DateTime.UtcNow.AddMinutes(-1),
+                metadata: new Dictionary<string, object>
+                {
+                    ["ClientDownloadId"] = "deleted-in-client"
+                });
+            var service = _provider.GetRequiredService<DownloadOrphanCleanupService>();
+
+            await service.RemoveOrphansAsync(
+                client,
+                CreateLiveSnapshot(client, []),
+                [],
+                [download]);
+
+            Assert.NotNull(await _downloadRepository.GetByIdAsync(download.Id));
+            _metricsMock.Verify(m => m.Increment(It.IsAny<string>(), It.IsAny<double>()), Times.Never);
+        }
+
+        [Theory]
+        [Trait("Method", "RemoveOrphansAsync")]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public async Task RemoveOrphansAsync_DoesNotRemoveWhenEmptySnapshotIsNotTrusted(bool usedCachedSnapshot, bool isUnavailable)
+        {
+            var client = CreateClient();
+            var download = await AddDownloadAsync(
+                id: "untrusted-empty-snapshot-download",
+                clientId: client.Id,
+                status: DownloadStatus.Downloading,
+                startedAt: DateTime.UtcNow.AddMinutes(-10),
+                metadata: new Dictionary<string, object>
+                {
+                    ["ClientDownloadId"] = "deleted-in-client"
+                });
+            var service = _provider.GetRequiredService<DownloadOrphanCleanupService>();
+
+            await service.RemoveOrphansAsync(
+                client,
+                new ClientQueueFetchResult(
+                    client,
+                    [],
+                    usedCachedSnapshot,
+                    isUnavailable,
+                    snapshotAge: null,
+                    failureReason: isUnavailable ? "unavailable" : null,
+                    snapshotState: isUnavailable ? "unavailable" : "cached",
+                    snapshotRefreshedAtUtc: DateTimeOffset.UtcNow),
                 [],
                 [download]);
 


### PR DESCRIPTION
## The bug

Delete a torrent directly in the download client while it is the **only** active download, and its `Download` record is stranded forever: every re-grab of that audiobook returns HTTP 409 "A download for this audiobook is already active" with no way to recover except manual removal. Delete one of several torrents and it self-heals, which makes the bug look intermittent.

## Root cause

`DownloadOrphanCleanupService.RemoveOrphansAsync` bailed out whenever the client snapshot returned 0 queue items while downloads were tracked, on the theory that the client might be temporarily unreachable. But by that point unreachability is already fully excluded by the two guards above it (`UsedCachedSnapshot` and `IsUnavailable`): `DownloadClientQueuePoller` surfaces every timeout/cancel/error path as a *cached* or *unavailable* snapshot (`BuildFallbackQueueResult`), never as a live one — `snapshotState: "live"` is produced only by the success path. So a live empty queue genuinely means the items are gone, and the guard's only real effect was to make the sole-torrent deletion permanently uncleanable.

## The fix

Remove the redundant guard so cleanup proceeds on live empty snapshots. The design cares from #640 are preserved unchanged:

- unreachable clients still short-circuit via the cached/unavailable guards;
- only `Queued`/`Downloading`/`Paused` are ever terminalized — `ImportPending`/`Ready`/`ImportBlocked` remain untouched;
- the per-item 5-minute grace period still shields fresh adds.

## Tests

- `RemovesOnlyTrackedDownloadWhenLiveSnapshotIsEmpty` — the reported scenario: sole tracked download, live empty snapshot, past grace → removed.
- `DoesNotRemoveWhenEmptySnapshotIsNotTrusted` (Theory: cached / unavailable) — the #640 protection stays intact.
- `DoesNotRemoveRecentDownloadWhenLiveSnapshotIsEmpty` — grace period respected.
- Flipped `DoesNotRemoveIdlessDownloadWhenLiveSnapshotIsEmpty` → `RemovesIdlessDownloadWhenLiveSnapshotIsEmpty`: the old test encoded the bug behavior.

Full suite green: 1193 passed / 0 failed; `dotnet format --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)