### PR TITLE
fix(search): zero configured indexers returned five fake mock releases into the real grab pipeline

### DIFF
--- a/listenarr.application/Search/Indexers/Common/IndexerSearchWorkflow.cs
+++ b/listenarr.application/Search/Indexers/Common/IndexerSearchWorkflow.cs
@@ -63,8 +63,8 @@ public class IndexerSearchWorkflow
 
         if (!indexers.Any())
         {
-            _logger.LogWarning("No indexers configured, returning mock results for query: {Query}", query);
-            return GenerateMockIndexerResults(query);
+            _logger.LogWarning("No indexers configured or enabled; search returned no results for query: {Query}", query);
+            return results;
         }
 
         var searchTasks = indexers.Select(async indexer =>
@@ -253,62 +253,5 @@ public class IndexerSearchWorkflow
         {
             return "Indexer";
         }
-    }
-
-    private List<IndexerSearchResult> GenerateMockIndexerResults(string query)
-    {
-        return GenerateMockIndexerResults(query, "Mock Indexer", "Torrent");
-    }
-
-    private List<IndexerSearchResult> GenerateMockIndexerResults(string query, string indexerName, string indexerType)
-    {
-        var random = new Random();
-        var results = new List<IndexerSearchResult>();
-        var isUsenet = indexerType.Equals("Usenet", StringComparison.OrdinalIgnoreCase);
-
-        _logger.LogInformation("Generating {Count} mock {Type} results for indexer {IndexerName}", 5, indexerType, indexerName);
-
-        for (int i = 0; i < 5; i++)
-        {
-            var result = new IndexerSearchResult
-            {
-                Id = Guid.NewGuid().ToString(),
-                Title = $"{query} - Quality {i + 1}",
-                Artist = "Various Authors",
-                Album = $"{query} Series",
-                Category = "Audiobook",
-                Size = random.Next(200_000_000, 1_500_000_000),
-                Seeders = isUsenet ? 0 : random.Next(5, 100),
-                Leechers = isUsenet ? 0 : random.Next(0, 20),
-                Source = indexerName,
-                PublishedDate = DateTime.UtcNow.AddDays(-random.Next(1, 365)).ToString("o"),
-                Quality = i switch
-                {
-                    0 => "MP3 64kbps",
-                    1 => "MP3 128kbps",
-                    2 => "MP3 192kbps",
-                    3 => "M4B 128kbps",
-                    _ => "FLAC"
-                },
-                Format = i >= 3 ? "M4B" : "MP3",
-                Language = "English"
-            };
-
-            if (isUsenet)
-            {
-                result.NzbUrl = $"https://{indexerName.ToLowerInvariant()}.example.com/api/nzb/{Guid.NewGuid():N}";
-                result.MagnetLink = string.Empty;
-                result.TorrentUrl = string.Empty;
-            }
-            else
-            {
-                result.MagnetLink = $"magnet:?xt=urn:btih:{Guid.NewGuid():N}";
-                result.NzbUrl = string.Empty;
-            }
-
-            results.Add(result);
-        }
-
-        return results;
     }
 }

--- a/tests/Features/Application/Search/IndexerSearchWorkflowTests.cs
+++ b/tests/Features/Application/Search/IndexerSearchWorkflowTests.cs
@@ -1,0 +1,44 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Application.Search
+{
+    [Trait("Area", "Search")]
+    [Trait("Name", "IndexerSearchWorkflowTests")]
+    [Trait("Category", "IndexerSearchWorkflow")]
+    public class IndexerSearchWorkflowTests : BaseTests
+    {
+        [Fact]
+        [Trait("Method", "SearchIndexersAsync")]
+        [Trait("Scenario", "NoIndexersConfiguredReturnsEmptyNotMockResults")]
+        public async Task SearchIndexers_NoIndexersConfigured_ReturnsEmptyWithoutSyntheticResults()
+        {
+            // Given
+            var workflow = _provider.GetRequiredService<IndexerSearchWorkflow>();
+            Assert.Empty(await _indexerRepository.GetEnabledAsync(isAutomaticSearch: false));
+
+            // When
+            var results = await workflow.SearchIndexersAsync("Dune");
+
+            // Then
+            Assert.Empty(results);
+        }
+    }
+}


### PR DESCRIPTION
## The bug

With zero indexers configured/enabled, `IndexerSearchWorkflow.SearchIndexersAsync` logged a warning and then returned `GenerateMockIndexerResults(query)`: five synthetic releases with fabricated titles, sizes, and URLs. Because this method also serves the automatic-search path, those fake releases flowed into real scoring and the grab decision, where one could be selected and handed to a download client.

This is not only reachable by a manual search click: `AutomaticSearchService` (a `BackgroundService` on a five-minute initial delay and recurring interval) also calls `SearchAsync(isAutomaticSearch: true)`, so on an install with no indexers configured yet the fake releases enter scoring unattended, on a timer. The fabricated entries carry realistic qualities (MP3 64kbps through FLAC), sizes, and non-zero seeders; the only tell is the `Mock Indexer` source string, which nothing in the pipeline gates on.

## The fix

Zero indexers now returns an empty result set with a clear warning ("No indexers configured or enabled; search returned no results"). Both `GenerateMockIndexerResults` overloads are deleted — a repo-wide search (backend, tests, `fe/`) found no other consumers, and no dev/debug flag gated them.

## Tests

- `SearchIndexers_NoIndexersConfigured_ReturnsEmptyWithoutSyntheticResults`

Full suite green: 1190 passed / 0 failed; `dotnet format --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
