### PR TITLE
fix(library): seed a default quality profile and reject invalid profile ids; profile-less adds were silently never searched

### DIFF
--- a/listenarr.api/Features/Library/LibraryAddWorkflow.cs
+++ b/listenarr.api/Features/Library/LibraryAddWorkflow.cs
@@ -67,6 +67,11 @@ namespace Listenarr.Api.Features.Library
                     HistoryMessage = $"Audiobook '{request.Metadata.Title}' added to library from Add New page"
                 });
 
+                if (result.Rejected)
+                {
+                    return new BadRequestObjectResult(new { message = result.Message });
+                }
+
                 if (result.AlreadyExists)
                 {
                     return new ConflictObjectResult(new { message = result.Message, audiobook = result.Audiobook });
@@ -129,7 +134,11 @@ namespace Listenarr.Api.Features.Library
             _logger.LogInformation("Created Audiobook entity: Title={Title}, Asin={Asin}, PublishYear={PublishYear}",
                 LogRedaction.SanitizeText(audiobook.Title), LogRedaction.SanitizeText(audiobook.Asin), LogRedaction.SanitizeText(audiobook.PublishYear));
 
-            await AssignQualityProfileAsync(audiobook, request);
+            var profileError = await AssignQualityProfileAsync(audiobook, request);
+            if (profileError != null)
+            {
+                return profileError;
+            }
 
             if (!string.IsNullOrWhiteSpace(request.DestinationPath))
             {
@@ -251,29 +260,38 @@ namespace Listenarr.Api.Features.Library
             return fallbackImageUrl;
         }
 
-        private async Task AssignQualityProfileAsync(Audiobook audiobook, LibraryController.AddToLibraryRequest request)
+        private async Task<IActionResult?> AssignQualityProfileAsync(Audiobook audiobook, LibraryController.AddToLibraryRequest request)
         {
-            if (request.QualityProfileId.HasValue)
-            {
-                audiobook.QualityProfileId = request.QualityProfileId.Value;
-                _logger.LogInformation("Assigned custom quality profile ID {ProfileId} to new audiobook '{Title}'",
-                    request.QualityProfileId.Value, LogRedaction.SanitizeText(audiobook.Title));
-                return;
-            }
-
             using var scope = _scopeFactory.CreateScope();
             var qualityProfileService = scope.ServiceProvider.GetRequiredService<IQualityProfileService>();
+
+            if (request.QualityProfileId.HasValue)
+            {
+                var suppliedProfile = await qualityProfileService.GetByIdAsync(request.QualityProfileId.Value);
+                if (suppliedProfile == null)
+                {
+                    _logger.LogWarning("Rejected library add for '{Title}': quality profile {ProfileId} does not exist.",
+                        LogRedaction.SanitizeText(audiobook.Title), request.QualityProfileId.Value);
+                    return new BadRequestObjectResult(new { message = $"Quality profile with ID {request.QualityProfileId.Value} does not exist." });
+                }
+
+                audiobook.QualityProfileId = suppliedProfile.Id;
+                _logger.LogInformation("Assigned custom quality profile ID {ProfileId} to new audiobook '{Title}'",
+                    suppliedProfile.Id, LogRedaction.SanitizeText(audiobook.Title));
+                return null;
+            }
+
             var defaultProfile = await qualityProfileService.GetDefaultAsync();
-            if (defaultProfile != null)
+            if (defaultProfile == null)
             {
-                audiobook.QualityProfileId = defaultProfile.Id;
-                _logger.LogInformation("Assigned default quality profile '{ProfileName}' (ID: {ProfileId}) to new audiobook '{Title}'",
-                    defaultProfile.Name, defaultProfile.Id, audiobook.Title);
+                _logger.LogWarning("Rejected library add for '{Title}': no quality profile supplied and no default profile is configured.", LogRedaction.SanitizeText(audiobook.Title));
+                return new BadRequestObjectResult(new { message = "No quality profile was supplied and no default quality profile is configured." });
             }
-            else
-            {
-                _logger.LogWarning("No default quality profile found. New audiobook '{Title}' will not have a quality profile assigned.", LogRedaction.SanitizeText(audiobook.Title));
-            }
+
+            audiobook.QualityProfileId = defaultProfile.Id;
+            _logger.LogInformation("Assigned default quality profile '{ProfileName}' (ID: {ProfileId}) to new audiobook '{Title}'",
+                defaultProfile.Name, defaultProfile.Id, audiobook.Title);
+            return null;
         }
 
         private async Task ResolveAuthorAsinsAsync(Audiobook audiobook)

--- a/listenarr.application/Audiobooks/Catalog/LibraryAddService.cs
+++ b/listenarr.application/Audiobooks/Catalog/LibraryAddService.cs
@@ -119,6 +119,14 @@ namespace Listenarr.Application.Audiobooks.Catalog
                 }
             }
 
+            // Resolve and validate the quality profile before doing any persistence-side work.
+            // A profile-less audiobook is never searched, so refuse the add instead of storing it silently.
+            var resolvedProfile = await ResolveQualityProfileAsync(request, metadata.Title);
+            if (resolvedProfile.Rejected)
+            {
+                return resolvedProfile.Result!;
+            }
+
             var imageUrl = await MoveImageToLibraryStorageAsync(metadata, request.SearchResult, firstIsbn);
 
             var audiobook = metadata.ToAudiobook();
@@ -128,24 +136,7 @@ namespace Listenarr.Application.Audiobooks.Catalog
 
             AudiobookIdentifierMapper.SyncImportedIdentifiersFromLegacyFields(audiobook, metadata.Region);
 
-            if (request.QualityProfileId.HasValue)
-            {
-                audiobook.QualityProfileId = request.QualityProfileId.Value;
-            }
-            else
-            {
-                var defaultProfile = await _qualityProfileService.GetDefaultAsync();
-                if (defaultProfile != null)
-                {
-                    audiobook.QualityProfileId = defaultProfile.Id;
-                }
-                else
-                {
-                    _logger.LogWarning(
-                        "No default quality profile found. New audiobook '{Title}' will not have a quality profile assigned.",
-                        audiobook.Title);
-                }
-            }
+            audiobook.QualityProfileId = resolvedProfile.ProfileId;
 
             var settings = await _configurationService.GetApplicationSettingsAsync();
 
@@ -196,6 +187,45 @@ namespace Listenarr.Application.Audiobooks.Catalog
                 Message = "Audiobook added to library successfully",
                 Audiobook = audiobook
             };
+        }
+
+        private async Task<(bool Rejected, int ProfileId, LibraryAddOperationResult? Result)> ResolveQualityProfileAsync(
+            LibraryAddOperationRequest request,
+            string? title)
+        {
+            if (request.QualityProfileId.HasValue)
+            {
+                var suppliedProfile = await _qualityProfileService.GetByIdAsync(request.QualityProfileId.Value);
+                if (suppliedProfile == null)
+                {
+                    _logger.LogWarning(
+                        "Rejected library add for '{Title}': quality profile {ProfileId} does not exist.",
+                        title,
+                        request.QualityProfileId.Value);
+                    return (true, 0, new LibraryAddOperationResult
+                    {
+                        Rejected = true,
+                        Message = $"Quality profile with ID {request.QualityProfileId.Value} does not exist."
+                    });
+                }
+
+                return (false, suppliedProfile.Id, null);
+            }
+
+            var defaultProfile = await _qualityProfileService.GetDefaultAsync();
+            if (defaultProfile == null)
+            {
+                _logger.LogWarning(
+                    "Rejected library add for '{Title}': no quality profile supplied and no default profile is configured.",
+                    title);
+                return (true, 0, new LibraryAddOperationResult
+                {
+                    Rejected = true,
+                    Message = "No quality profile was supplied and no default quality profile is configured."
+                });
+            }
+
+            return (false, defaultProfile.Id, null);
         }
 
         private async Task<string?> MoveImageToLibraryStorageAsync(

--- a/listenarr.application/Audiobooks/Contracts/ILibraryAddService.cs
+++ b/listenarr.application/Audiobooks/Contracts/ILibraryAddService.cs
@@ -50,6 +50,12 @@ namespace Listenarr.Application.Audiobooks.Contracts
 
         public bool AlreadyExists { get; set; }
 
+        /// <summary>
+        /// True when the add was refused (e.g. an invalid quality profile id, or no profile
+        /// could be resolved). The caller should surface this as a 400-style validation error.
+        /// </summary>
+        public bool Rejected { get; set; }
+
         public string Message { get; set; } = string.Empty;
 
         public Audiobook? Audiobook { get; set; }

--- a/listenarr.application/Audiobooks/Contracts/Repositories/IQualityProfileRepository.cs
+++ b/listenarr.application/Audiobooks/Contracts/Repositories/IQualityProfileRepository.cs
@@ -27,5 +27,11 @@ namespace Listenarr.Application.Audiobooks.Contracts.Repositories
         Task<QualityProfile> UpdateAsync(QualityProfile profile);
         Task<bool> DeleteAsync(int id);
         Task<int> CountAudiobooksUsingProfileAsync(int profileId);
+
+        /// <summary>
+        /// Seeds a single default quality profile when the table is empty. Idempotent:
+        /// does nothing when any profile already exists. Returns true if a profile was seeded.
+        /// </summary>
+        Task<bool> SeedDefaultProfileIfMissingAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/listenarr.domain/Audiobooks/QualityProfile.cs
+++ b/listenarr.domain/Audiobooks/QualityProfile.cs
@@ -112,6 +112,35 @@ namespace Listenarr.Domain.Audiobooks
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// Builds the permissive "Any Quality" profile used to seed a fresh install so that
+        /// monitored audiobooks always resolve a quality profile and become searchable.
+        /// Every codec/bitrate rung is allowed and there is no cutoff, so no release is rejected on quality.
+        /// </summary>
+        public static QualityProfile CreateDefault()
+        {
+            return new QualityProfile
+            {
+                Name = "Any Quality",
+                Description = "Default profile seeded automatically. Accepts any audio quality.",
+                IsDefault = true,
+                Qualities = new List<QualityDefinition>
+                {
+                    new() { Quality = "AAC 320kbps", Allowed = true, Priority = 0, Codec = "AAC", Bitrate = 320 },
+                    new() { Quality = "AAC 256kbps", Allowed = true, Priority = 1, Codec = "AAC", Bitrate = 256 },
+                    new() { Quality = "AAC 192kbps", Allowed = true, Priority = 2, Codec = "AAC", Bitrate = 192 },
+                    new() { Quality = "AAC 128kbps", Allowed = true, Priority = 3, Codec = "AAC", Bitrate = 128 },
+                    new() { Quality = "AAC 64kbps", Allowed = true, Priority = 4, Codec = "AAC", Bitrate = 64 },
+                    new() { Quality = "MP3 320kbps", Allowed = true, Priority = 5, Codec = "MP3", Bitrate = 320 },
+                    new() { Quality = "MP3 256kbps", Allowed = true, Priority = 6, Codec = "MP3", Bitrate = 256 },
+                    new() { Quality = "MP3 VBR", Allowed = true, Priority = 7, Codec = "MP3" },
+                    new() { Quality = "MP3 192kbps", Allowed = true, Priority = 8, Codec = "MP3", Bitrate = 192 },
+                    new() { Quality = "MP3 128kbps", Allowed = true, Priority = 9, Codec = "MP3", Bitrate = 128 },
+                    new() { Quality = "MP3 64kbps", Allowed = true, Priority = 10, Codec = "MP3", Bitrate = 64 },
+                }
+            };
+        }
     }
 
     /// <summary>

--- a/listenarr.infrastructure/Persistence/Repositories/QualityProfileRepository.cs
+++ b/listenarr.infrastructure/Persistence/Repositories/QualityProfileRepository.cs
@@ -128,5 +128,17 @@ namespace Listenarr.Infrastructure.Persistence.Repositories
         {
             return await _db.Audiobooks.CountAsync(a => a.QualityProfileId == profileId);
         }
+
+        public async Task<bool> SeedDefaultProfileIfMissingAsync(CancellationToken cancellationToken = default)
+        {
+            if (await _db.QualityProfiles.AnyAsync(cancellationToken))
+            {
+                return false;
+            }
+
+            _db.QualityProfiles.Add(QualityProfile.CreateDefault());
+            await _db.SaveChangesAsync(cancellationToken);
+            return true;
+        }
     }
 }

--- a/listenarr.infrastructure/Persistence/StartupDbNormalizer.cs
+++ b/listenarr.infrastructure/Persistence/StartupDbNormalizer.cs
@@ -39,9 +39,18 @@ namespace Listenarr.Infrastructure.Persistence
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
+            using var scope = _provider.CreateScope();
+
+            // Each pass is guarded independently: a failure normalizing legacy columns must not
+            // prevent seeding the default quality profile, which fresh installs rely on to search at all.
+            await NormalizeJsonColumnsAsync(scope, cancellationToken);
+            await SeedDefaultQualityProfileAsync(scope, cancellationToken);
+        }
+
+        private async Task NormalizeJsonColumnsAsync(IServiceScope scope, CancellationToken cancellationToken)
+        {
             try
             {
-                using var scope = _provider.CreateScope();
                 var audiobookRepository = scope.ServiceProvider.GetRequiredService<IAudiobookRepository>();
                 await audiobookRepository.NormalizeJsonColumnsAsync(cancellationToken);
                 _logger.LogInformation("StartupDbNormalizer: normalization pass complete.");
@@ -57,6 +66,27 @@ namespace Listenarr.Infrastructure.Persistence
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
             {
                 _logger.LogError(ex, "StartupDbNormalizer: unexpected error while running normalization");
+            }
+        }
+
+        private async Task SeedDefaultQualityProfileAsync(IServiceScope scope, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var qualityProfileRepository = scope.ServiceProvider.GetRequiredService<IQualityProfileRepository>();
+                var seededDefaultProfile = await qualityProfileRepository.SeedDefaultProfileIfMissingAsync(cancellationToken);
+                if (seededDefaultProfile)
+                {
+                    _logger.LogInformation("StartupDbNormalizer: seeded default quality profile (none existed).");
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                Debug.WriteLine("Suppressed non-fatal exception in catch block.");
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogError(ex, "StartupDbNormalizer: unexpected error while seeding default quality profile");
             }
         }
 

--- a/tests/Features/Api/Features/Library/LibraryController_AddToLibraryTests.cs
+++ b/tests/Features/Api/Features/Library/LibraryController_AddToLibraryTests.cs
@@ -50,6 +50,9 @@ namespace Listenarr.Tests.Features.Api.Features.Library
                 .WithIsDefault()
                 .WithPath(tempRoot)
                 .Build());
+
+            // Adds now require a resolvable quality profile; production seeds this at startup.
+            await _qualityProfileRepository.AddAsync(QualityProfile.CreateDefault());
         }
 
         [Fact]

--- a/tests/Features/Api/Features/Library/LibraryController_QualityProfileValidationTests.cs
+++ b/tests/Features/Api/Features/Library/LibraryController_QualityProfileValidationTests.cs
@@ -1,0 +1,95 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+using Microsoft.AspNetCore.Mvc;
+using Listenarr.Tests.Common;
+using Listenarr.Tests.Builders;
+
+namespace Listenarr.Tests.Features.Api.Features.Library
+{
+    public class LibraryController_QualityProfileValidationTests : BaseTests
+    {
+        private readonly Mock<IImageCacheService> _imageCacheServiceMock = new();
+        private string _tempRoot = null!;
+        private int _defaultProfileId;
+
+        public override async Task InitializeAsync()
+        {
+            _imageCacheServiceMock
+                .Setup(m => m.MoveToLibraryStorageAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync((string?)null);
+
+            Init(services => services.WithSingleton(_imageCacheServiceMock.Object));
+
+            _tempRoot = FileService.GetTempDirectory("listenarr-test");
+
+            await _applicationSettingsRepository.SaveAsync(new ApplicationSettingsBuilder()
+                .WithFolderNamingPattern("{Author}")
+                .WithFileNamingPattern("{Title}")
+                .Build());
+
+            await _rootFolderRepository.AddAsync(new RootFolderBuilder()
+                .WithIsDefault()
+                .WithPath(_tempRoot)
+                .Build());
+
+            var defaultProfile = await _qualityProfileRepository.AddAsync(QualityProfile.CreateDefault());
+            _defaultProfileId = defaultProfile.Id;
+        }
+
+        [Fact]
+        public async Task AddToLibrary_WithBogusQualityProfileId_ReturnsBadRequestAndPersistsNothing()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+
+            var request = new LibraryController.AddToLibraryRequest
+            {
+                Metadata = new AudibleBookMetadata
+                {
+                    Title = "Bogus Profile Title",
+                    Author = "Some Author"
+                },
+                Monitored = true,
+                QualityProfileId = 999999
+            };
+
+            // Act
+            var actionResult = await controller.AddToLibrary(request);
+
+            // Assert
+            Assert.IsType<BadRequestObjectResult>(actionResult);
+            Assert.Empty(await _audiobookRepository.GetAllAsync());
+        }
+
+        [Fact]
+        public async Task AddToLibrary_WithNoQualityProfileId_AssignsDefaultAndPersists()
+        {
+            var controller = _provider.GetRequiredService<LibraryController>();
+
+            var request = new LibraryController.AddToLibraryRequest
+            {
+                Metadata = new AudibleBookMetadata
+                {
+                    Title = "Default Profile Title",
+                    Author = "Some Author"
+                },
+                Monitored = true
+            };
+
+            // Act
+            var actionResult = await controller.AddToLibrary(request);
+
+            // Assert
+            Assert.IsType<OkObjectResult>(actionResult);
+            var stored = Assert.Single(await _audiobookRepository.GetAllAsync());
+            Assert.Equal(_defaultProfileId, stored.QualityProfileId);
+        }
+    }
+}

--- a/tests/Features/Application/Audiobooks/Monitoring/SeriesMonitoringServiceTests.cs
+++ b/tests/Features/Application/Audiobooks/Monitoring/SeriesMonitoringServiceTests.cs
@@ -146,6 +146,9 @@ namespace Listenarr.Tests.Features.Application.Audiobooks.Monitoring
                 .WithPath(rootPath)
                 .Build());
 
+            // Adds now require a resolvable quality profile; production seeds this at startup.
+            await _qualityProfileRepository.AddAsync(QualityProfile.CreateDefault());
+
             _seriesCatalogService
                 .Setup(service => service.GetCatalogAsync(
                     "Dungeon Crawler Carl",

--- a/tests/Features/Infrastructure/Persistence/QualityProfileSeedTests.cs
+++ b/tests/Features/Infrastructure/Persistence/QualityProfileSeedTests.cs
@@ -1,0 +1,98 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+using Listenarr.Infrastructure.Persistence.Repositories;
+using Listenarr.Tests.Builders;
+using Microsoft.EntityFrameworkCore;
+
+namespace Listenarr.Tests.Features.Infrastructure.Persistence;
+
+public sealed class QualityProfileSeedTests : IAsyncLifetime
+{
+    private readonly string _databasePath =
+        Path.Join(Path.GetTempPath(), "listenarr-tests", $"quality-seed-{Guid.NewGuid():N}.db");
+    private DbContextOptions<ListenArrDbContext> _options = null!;
+
+    public async Task InitializeAsync()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_databasePath)!);
+        _options = new DbContextOptionsBuilder<ListenArrDbContext>()
+            .UseSqlite($"Data Source={_databasePath};Pooling=False")
+            .Options;
+        await using var db = new ListenArrDbContext(_options);
+        await db.Database.EnsureCreatedAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        if (File.Exists(_databasePath))
+        {
+            File.Delete(_databasePath);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task SeedDefaultProfile_WhenTableEmpty_CreatesExactlyOneDefaultProfile()
+    {
+        // Given an empty QualityProfiles table
+        await using var db = new ListenArrDbContext(_options);
+        var repository = new QualityProfileRepository(db);
+
+        // When seeding
+        var seeded = await repository.SeedDefaultProfileIfMissingAsync();
+
+        // Then exactly one default profile exists
+        Assert.True(seeded);
+        var profiles = await repository.GetAllAsync();
+        var profile = Assert.Single(profiles);
+        Assert.True(profile.IsDefault);
+        Assert.Equal("Any Quality", profile.Name);
+        Assert.NotEmpty(profile.Qualities);
+        Assert.All(profile.Qualities, quality => Assert.True(quality.Allowed));
+    }
+
+    [Fact]
+    public async Task SeedDefaultProfile_RunTwice_RemainsExactlyOneProfile()
+    {
+        // Given a fresh database seeded once
+        await using var db = new ListenArrDbContext(_options);
+        var repository = new QualityProfileRepository(db);
+        Assert.True(await repository.SeedDefaultProfileIfMissingAsync());
+
+        // When seeding again
+        var seededSecond = await repository.SeedDefaultProfileIfMissingAsync();
+
+        // Then nothing is added and exactly one profile remains (idempotent)
+        Assert.False(seededSecond);
+        Assert.Single(await repository.GetAllAsync());
+    }
+
+    [Fact]
+    public async Task SeedDefaultProfile_WhenProfilesExist_SeedsNothing()
+    {
+        // Given a table that already has a (non-default) profile
+        await using var db = new ListenArrDbContext(_options);
+        var repository = new QualityProfileRepository(db);
+        await repository.AddAsync(new QualityProfileBuilder()
+            .WithName("Custom Only")
+            .Build());
+
+        // When seeding
+        var seeded = await repository.SeedDefaultProfileIfMissingAsync();
+
+        // Then no seed happens and the original profile is untouched
+        Assert.False(seeded);
+        var profile = Assert.Single(await repository.GetAllAsync());
+        Assert.Equal("Custom Only", profile.Name);
+        Assert.False(profile.IsDefault);
+    }
+}

--- a/tests/Features/Infrastructure/Persistence/StartupDbNormalizerSeedTests.cs
+++ b/tests/Features/Infrastructure/Persistence/StartupDbNormalizerSeedTests.cs
@@ -1,0 +1,49 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Infrastructure.Persistence
+{
+    public sealed class StartupDbNormalizerSeedTests : BaseTests
+    {
+        [Fact]
+        public async Task StartAsync_OnFreshDatabase_SeedsExactlyOneDefaultProfile()
+        {
+            // Given a fresh database with no quality profiles
+            Assert.Empty(await _qualityProfileRepository.GetAllAsync());
+            var normalizer = new StartupDbNormalizer(
+                _provider,
+                _provider.GetRequiredService<ILogger<StartupDbNormalizer>>());
+
+            // When the startup normalizer runs
+            await normalizer.StartAsync(CancellationToken.None);
+
+            // Then exactly one default profile has been seeded
+            var profile = Assert.Single(await _qualityProfileRepository.GetAllAsync());
+            Assert.True(profile.IsDefault);
+        }
+
+        [Fact]
+        public async Task StartAsync_RunTwice_RemainsExactlyOneProfile()
+        {
+            var normalizer = new StartupDbNormalizer(
+                _provider,
+                _provider.GetRequiredService<ILogger<StartupDbNormalizer>>());
+
+            // When the startup normalizer runs twice
+            await normalizer.StartAsync(CancellationToken.None);
+            await normalizer.StartAsync(CancellationToken.None);
+
+            // Then seeding stays idempotent
+            Assert.Single(await _qualityProfileRepository.GetAllAsync());
+        }
+    }
+}


### PR DESCRIPTION
## The bug

Three compounding gaps meant a monitored book on a fresh install could silently never grab anything, with no warning anywhere:

1. No default quality profile is ever seeded — `QualityProfileRepository.GetDefaultAsync` returns null on a fresh database (there is no seed data repo-wide).
2. Adds proceeded anyway: both the production add path (`LibraryAddService`) and the workflow fallback (`LibraryAddWorkflow`) logged a warning and persisted the audiobook with `QualityProfileId = null`; a caller-supplied profile id was assigned without checking it exists.
3. The automatic-search query filters `QualityProfileId != null`, so those books are never searched — and nothing ever surfaces that.

## The fix

- **Seed on startup:** `StartupDbNormalizer` (the existing startup-normalization hosted service) now seeds one permissive "Any Quality" default profile when the `QualityProfiles` table is empty. Idempotent (`AnyAsync` gate); the shape matches what the UI creates (built on the required-qualities set that `EnsureProfileHasRequiredQualitiesAsync` back-fills anyway). The normalizer's JSON-column pass and the seed pass are now independently guarded, so a normalization error can't swallow the seed.
- **Validate on add:** in `LibraryAddService` (and the workflow fallback, which had the identical bug), a supplied profile id that doesn't exist rejects the add with a 400 and a clear message, before any side effects (image move/persistence); no supplied id resolves the default, and if somehow none exists the add is rejected instead of persisting a book that will never be searched.

Out of scope, flagged for maintainers: rows already persisted with `QualityProfileId = null` on existing installs still need manual assignment (or a follow-up normalizer) before automatic search will see them. The search query itself is deliberately untouched.

## Tests (7 new)

- `QualityProfileSeedTests`: empty table seeds exactly one default; running twice stays at one; non-empty table seeds nothing.
- `StartupDbNormalizerSeedTests`: fresh DB via the hosted service seeds exactly one; idempotent on re-run.
- `LibraryController_QualityProfileValidationTests`: bogus profile id → 400, nothing persisted; no profile id → default assigned, persisted non-null.
- Two existing fixtures that relied on null-profile adds being accepted now seed the default profile in setup.

Full suite green: 1196 passed / 0 failed; `dotnet format --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)