### PR TITLE
fix(moves): organize moves into a subfolder of the source no longer fail as overlapping

### DIFF
--- a/listenarr.infrastructure/Library/Moving/MoveJobProcessor.DescendMove.cs
+++ b/listenarr.infrastructure/Library/Moving/MoveJobProcessor.DescendMove.cs
@@ -1,0 +1,101 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Domain.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Infrastructure.Library.Moving
+{
+    public partial class MoveJobProcessor
+    {
+        /// <summary>
+        /// Executes a move whose target sits INSIDE its own source — the
+        /// shape naming templates produce when they append subfolders
+        /// (".../Book" → ".../Book/Narrator"; a live library hit this on 97
+        /// consecutive organize jobs, every one failing "Source and target
+        /// paths overlap"). The copy walk can't do it (it would recurse into
+        /// its own output, then the source cleanup would delete the result),
+        /// but two same-volume renames can: rename the source aside (same
+        /// parent — atomic), recreate the vacated path, rename into place.
+        /// Throws on failure after best-effort rollback, leaving the library
+        /// as it was.
+        /// </summary>
+        private void ExecuteDescendMove(MoveJob job, string source, string target, string targetParent)
+        {
+            var sourceParent = Path.GetDirectoryName(source.TrimEnd(Path.DirectorySeparatorChar));
+            var asideName = source.TrimEnd(Path.DirectorySeparatorChar) + ".moving-" + job.Id.ToString("N");
+            string? asideReason = null;
+            if (string.IsNullOrEmpty(sourceParent)
+                || !FileSystemSafety.TryValidateMutationTarget(asideName, [sourceParent], out asideName, out asideReason))
+            {
+                throw new IOException($"Refused descend-move temp path: {asideReason ?? "no source parent"}");
+            }
+
+            Directory.Move(source, asideName);
+            try
+            {
+                Directory.CreateDirectory(targetParent);
+                Directory.Move(asideName, target);
+            }
+            catch
+            {
+                // Roll the rename back so a failed job leaves the library
+                // exactly as it was. The recreated parent skeleton is empty
+                // by construction — safe to drop.
+                try
+                {
+                    if (Directory.Exists(source)
+                        && !Directory.EnumerateFiles(source, "*", SearchOption.AllDirectories).Any())
+                    {
+                        Directory.Delete(source, true);
+                    }
+                    if (Directory.Exists(asideName) && !Directory.Exists(source))
+                    {
+                        Directory.Move(asideName, source);
+                    }
+                }
+                catch (Exception rollbackEx) when (rollbackEx is not OutOfMemoryException && rollbackEx is not StackOverflowException)
+                {
+                    logger.LogError(rollbackEx,
+                        "Descend-move rollback failed for job {JobId}; files remain at {Aside}",
+                        job.Id, LogRedaction.SanitizeFilePath(asideName));
+                }
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// The inverse overlap (source inside its own target — flattening a
+        /// folder up into its populated ancestor) stays blocked. Returns true
+        /// when the job was failed and the caller should stop.
+        /// </summary>
+        private async Task<bool> FailIfUpwardOverlapAsync(MoveJob job, string source, string target, CancellationToken stoppingToken)
+        {
+            if (!FileUtils.IsPathInsideOf(source, target)) return false;
+
+            await moveQueueService.UpdateJobStatusAsync(job.Id, "Failed", "Source and target paths overlap", stoppingToken);
+            metrics.Increment("worker.move.job.failed");
+            logger.LogWarning(
+                "Blocked overlapping move job {JobId}: {Source} -> {Target}",
+                job.Id,
+                LogRedaction.SanitizeFilePath(source),
+                LogRedaction.SanitizeFilePath(target));
+            return true;
+        }
+    }
+}

--- a/listenarr.infrastructure/Library/Moving/MoveJobProcessor.cs
+++ b/listenarr.infrastructure/Library/Moving/MoveJobProcessor.cs
@@ -21,7 +21,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 namespace Listenarr.Infrastructure.Library.Moving
 {
-    public class MoveJobProcessor(
+    public partial class MoveJobProcessor(
         IMoveQueueService moveQueueService,
         IToastService toastService,
         IScanQueueService scanQueueService,
@@ -107,17 +107,8 @@ namespace Listenarr.Infrastructure.Library.Moving
                     return;
                 }
 
-                if (FileUtils.IsPathInsideOf(target, source) || FileUtils.IsPathInsideOf(source, target))
-                {
-                    await moveQueueService.UpdateJobStatusAsync(job.Id, "Failed", "Source and target paths overlap", stoppingToken);
-                    metrics.Increment("worker.move.job.failed");
-                    logger.LogWarning(
-                        "Blocked overlapping move job {JobId}: {Source} -> {Target}",
-                        job.Id,
-                        LogRedaction.SanitizeFilePath(source),
-                        LogRedaction.SanitizeFilePath(target));
-                    return;
-                }
+                var descendMove = FileUtils.IsPathInsideOf(target, source);
+                if (!descendMove && await FailIfUpwardOverlapAsync(job, source, target, stoppingToken)) return;
 
                 // Ensure target parent exists
                 var targetParent = Path.GetDirectoryName(target);
@@ -128,7 +119,7 @@ namespace Listenarr.Infrastructure.Library.Moving
                     return;
                 }
 
-                if (!Directory.Exists(targetParent)) Directory.CreateDirectory(targetParent);
+                if (!descendMove && !Directory.Exists(targetParent)) Directory.CreateDirectory(targetParent);
 
                 // Check if target exists and has content - only fail if it has files/folders we'd overwrite
                 if (Directory.Exists(target))
@@ -157,6 +148,12 @@ namespace Listenarr.Infrastructure.Library.Moving
                 // Copy recursively with retries per file
                 try
                 {
+                    if (descendMove)
+                    {
+                        ExecuteDescendMove(job, source, target, targetParent);
+                    }
+                    else
+                    {
                     // Only create tempName if target doesn't exist; otherwise copy directly into existing empty target
                     var useTemp = !Directory.Exists(target);
                     var copyDest = useTemp ? tempName : target;
@@ -266,6 +263,7 @@ namespace Listenarr.Infrastructure.Library.Moving
                     }
 
                     Directory.Delete(source, true);
+                    }
 
                     await MovedAudiobookPathRewriter.RewriteAsync(
                         audiobook,

--- a/tests/Features/Infrastructure/Library/MoveJobProcessor_DescendMoveTests.cs
+++ b/tests/Features/Infrastructure/Library/MoveJobProcessor_DescendMoveTests.cs
@@ -1,0 +1,117 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Tests.Builders;
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Infrastructure.Library
+{
+    /// <summary>
+    /// The descend-move shape: naming templates that append subfolders make
+    /// organize request ".../Book" -> ".../Book/Narrator" — a target INSIDE
+    /// its own source. The copy-walk mover can't do that (it would recurse
+    /// into its own output), so it's handled by two same-volume renames.
+    /// Live case: 97 organize jobs, every one failed "Source and target
+    /// paths overlap".
+    /// </summary>
+    [Trait("Area", "Library")]
+    [Trait("Name", "MoveJobProcessor_DescendMoveTests")]
+    public class MoveJobProcessor_DescendMoveTests : BaseTests
+    {
+        private async Task<(Audiobook book, string source, int fileId)> CreateBookOnDiskAsync(string folder)
+        {
+            var source = FileService.GetTempDirectory(folder);
+            await File.WriteAllTextAsync(Path.Join(source, "Book-001.mp3"), "audio-1");
+            await File.WriteAllTextAsync(Path.Join(source, "Book-002.mp3"), "audio-2");
+
+            var book = await _audiobookRepository.AddAsync(new AudiobookBuilder()
+                .WithTitle("Elevation")
+                .WithBasePath(source)
+                .Build());
+            var file = await _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(book)
+                .WithPath(Path.Join(source, "Book-001.mp3"))
+                .Build());
+            return (book, source, file.Id);
+        }
+
+        [Fact]
+        [Trait("Method", "ProcessJobAsync")]
+        [Trait("Scenario", "TargetInsideSource_Succeeds")]
+        public async Task DescendMove_TargetInsideSource_RenamesIntoPlace()
+        {
+            var (book, source, fileId) = await CreateBookOnDiskAsync("descend-src");
+            var target = Path.Join(source, "Stephen King");
+
+            var queue = _provider.GetRequiredService<IMoveQueueService>();
+            var jobId = await queue.EnqueueMoveAsync(book.Id, target, source);
+            var job = await queue.GetJobAsync(jobId);
+            Assert.NotNull(job);
+
+            var processor = _provider.GetRequiredService<IMoveJobProcessor>();
+            await processor.ProcessJobAsync(job!, CancellationToken.None);
+
+            var finished = await queue.GetJobAsync(jobId);
+            Assert.Equal("Completed", finished!.Status);
+            Assert.True(string.IsNullOrEmpty(finished.Error), $"unexpected error: {finished.Error}");
+
+            // Files physically renamed into the child folder; nothing lingers
+            // beside it in the vacated source.
+            Assert.True(File.Exists(Path.Join(target, "Book-001.mp3")));
+            Assert.True(File.Exists(Path.Join(target, "Book-002.mp3")));
+            Assert.False(File.Exists(Path.Join(source, "Book-001.mp3")));
+            Assert.False(Directory.EnumerateFileSystemEntries(source).Any(e => !string.Equals(e, target, StringComparison.Ordinal)));
+
+            // History records the move. (BasePath is set by the enqueue
+            // workflow and file rows by the post-move scan — not this
+            // processor's job; this test drives the processor directly.)
+            var history = await _historyRepository.GetByAudiobookIdAsync(book.Id);
+            Assert.Contains(history, h => h.EventType == "Moved");
+            _ = fileId; // ownership unchanged by the processor itself
+        }
+
+        [Fact]
+        [Trait("Method", "ProcessJobAsync")]
+        [Trait("Scenario", "SourceInsideTarget_StillBlocked")]
+        public async Task UpwardOverlap_SourceInsideTarget_StillFails()
+        {
+            // The inverse shape (flattening a folder up into its ancestor)
+            // remains blocked — the ancestor is populated and the reclaim
+            // rules don't apply.
+            var parent = FileService.GetTempDirectory("descend-parent");
+            var source = Path.Join(parent, "Nested");
+            Directory.CreateDirectory(source);
+            await File.WriteAllTextAsync(Path.Join(source, "Book-001.mp3"), "audio");
+            var book = await _audiobookRepository.AddAsync(new AudiobookBuilder()
+                .WithTitle("Nested Book")
+                .WithBasePath(source)
+                .Build());
+
+            var queue = _provider.GetRequiredService<IMoveQueueService>();
+            var jobId = await queue.EnqueueMoveAsync(book.Id, parent, source);
+            var job = await queue.GetJobAsync(jobId);
+
+            var processor = _provider.GetRequiredService<IMoveJobProcessor>();
+            await processor.ProcessJobAsync(job!, CancellationToken.None);
+
+            var finished = await queue.GetJobAsync(jobId);
+            Assert.Equal("Failed", finished!.Status);
+            Assert.Contains("overlap", finished.Error, StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(Path.Join(source, "Book-001.mp3")));
+        }
+    }
+}


### PR DESCRIPTION
## The bug

Naming templates that append subfolders (narrator, edition, …) make organize request moves like:

```
/audiobooks/Stephen King/Elevation  →  /audiobooks/Stephen King/Elevation/Stephen King
```

— a target **inside its own source**. The copy-walk mover can't execute that shape (the recursive copy would descend into its own output, and the post-copy `Directory.Delete(source, true)` would delete the result), so the overlap guard failed the whole class with **"Source and target paths overlap"**.

On my live library this hit **97 consecutive organize jobs** — every book whose folder didn't yet contain the template's narrator subfolder.

## The fix

Descend-shaped moves don't need to copy anything: two same-volume atomic renames do it safely —

1. rename the source aside (same parent, atomic): `Elevation` → `Elevation.moving-<jobId>`
2. recreate the vacated path: `mkdir Elevation`
3. rename into place: `Elevation.moving-<jobId>` → `Elevation/Stephen King`

with best-effort rollback if step 2/3 fails (the recreated skeleton is empty by construction, so it's dropped and the aside-rename is reversed). The inverse shape — flattening a folder up into its populated ancestor — stays blocked exactly as before.

Implementation notes:
- The rename logic lives in a `MoveJobProcessor.DescendMove` partial; the processor itself gains only the branch points (it was 1 line under the 500-line architecture rule).
- The existing completion path (history entry, notifications, scan enqueue, status) is shared unchanged.

## Testing

- New integration tests drive `ProcessJobAsync` directly: the descend shape completes with files physically renamed into the child folder and a `Moved` history entry; the upward-overlap shape still fails with the original error and leaves files untouched.
- Full suite: 1191 passed.
- Live-verified on my instance before porting here: all 97 previously-failed jobs were requeued after this fix — 90 completed (the other 7 were stale requests whose source folders no longer exist).

Heads-up: #717 also works in the moves area — happy to rebase this on top of it if that lands first; the footprint here is deliberately small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)