### PR TITLE
fix(metadata): treat Audible's empty product stub as no answer so the provider chain can continue

### DIFF
--- a/listenarr.application/Metadata/Core/AudiobookMetadataService.cs
+++ b/listenarr.application/Metadata/Core/AudiobookMetadataService.cs
@@ -115,6 +115,18 @@ namespace Listenarr.Application.Metadata.Core
                         continue;
                     }
 
+                    // An ASIN missing from Audible's catalog comes back as a
+                    // non-null but EMPTY product stub (no title, no fields).
+                    // Treating that as an answer both returns junk to the
+                    // caller and blocks every later source in the chain.
+                    if (result is AudibleBookResponse shell && string.IsNullOrWhiteSpace(shell.Title))
+                    {
+                        _logger.LogInformation(
+                            "{SourceName} returned an empty product stub for ASIN {Asin}; treating as no answer",
+                            source.Name, asin);
+                        result = null;
+                    }
+
                     if (result != null)
                     {
                         _logger.LogInformation("Successfully fetched metadata from {SourceName} for ASIN: {Asin}", source.Name, asin);


### PR DESCRIPTION
## The bug

An ASIN that's missing from Audible's catalog doesn't 404 — the catalog API returns a product node with **every attribute null**, which `GetBookMetadataAsync` maps into a non-null but completely empty `AudibleBookResponse`. `AudiobookMetadataService.GetMetadataAsync`'s provider loop only checks `result != null`, so the empty shell counted as a win:

1. the caller receives junk (`source: Audible`, all fields null) — "fill missing from online" reports success while filling nothing;
2. every later provider in the chain (Audnexus today, anything added later) is silently skipped, even when it could have answered.

Live case that surfaced it: an Amazon-exclusive audiobook edition whose ASIN returns the empty stub from **all ten** regional Audible catalog APIs.

## The fix

A titleless `AudibleBookResponse` is treated as no answer (logged) and the loop falls through to the next configured source. One conditional; no behavior change for any ASIN Audible actually carries.

## Testing

Full suite: 1189 passed. Verified live on my instance: the previously-junk ASIN now falls through the chain instead of short-circuiting with an empty payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)