### PR TITLE
fix(naming): don't lose a series position that isn't a plain number

### DIFF
--- a/listenarr.application/Common/FileNamingService.Helpers.cs
+++ b/listenarr.application/Common/FileNamingService.Helpers.cs
@@ -86,7 +86,11 @@ namespace Listenarr.Application.Common
                 { "Publisher", string.IsNullOrWhiteSpace(metadata.Publisher) ? string.Empty : SanitizePathComponent(metadata.Publisher) },
                 { "Language", string.IsNullOrWhiteSpace(metadata.Language) ? string.Empty : SanitizePathComponent(metadata.Language) },
                 { "Asin", string.IsNullOrWhiteSpace(metadata.Asin) ? string.Empty : SanitizePathComponent(metadata.Asin) },
-                { "SeriesNumber", FirstNonEmpty(metadata.SeriesPosition?.ToString(CultureInfo.InvariantCulture), metadata.TrackNumber?.ToString()) },
+                // Prefer the position exactly as the source gave it. A non-numeric but real
+                // position (an omnibus at "1-4") does not survive the decimal parse, and
+                // falling through to TrackNumber here would write a track number into the
+                // filename as if it were the series number.
+                { "SeriesNumber", FirstNonEmpty(metadata.SeriesPositionRaw, metadata.SeriesPosition?.ToString(CultureInfo.InvariantCulture), metadata.TrackNumber?.ToString()) },
                 { "Year", FirstNonEmpty(metadata.Year?.ToString()) },
                 { "Quality", FirstNonEmpty(metadata.BitRate.HasValue ? metadata.BitRate + "kbps" : null, metadata.Format) },
                 { "DiskNumber", metadata.DiscNumber?.ToString() ?? string.Empty },

--- a/listenarr.application/Downloads/Import/DownloadImportService.Naming.cs
+++ b/listenarr.application/Downloads/Import/DownloadImportService.Naming.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Listenarr.Application.Downloads.Import;
 
 public partial class DownloadImportService
@@ -50,10 +52,16 @@ public partial class DownloadImportService
                 Series = FirstNonEmpty(
                     audiobook.Series,
                     extractedMetadata?.Series),
+                // Parsed with InvariantCulture: the source value always uses '.' as the
+                // decimal separator, so parsing under the server's culture would read a
+                // position of "1.5" as 15 wherever '.' is the group separator.
                 SeriesPosition = !string.IsNullOrWhiteSpace(audiobook.SeriesNumber)
-                    && decimal.TryParse(audiobook.SeriesNumber, out var seriesPosition)
+                    && decimal.TryParse(audiobook.SeriesNumber, NumberStyles.Number, CultureInfo.InvariantCulture, out var seriesPosition)
                         ? seriesPosition
                         : extractedMetadata?.SeriesPosition,
+                SeriesPositionRaw = FirstNonEmpty(
+                    audiobook.SeriesNumber,
+                    extractedMetadata?.SeriesPositionRaw),
                 Year = !string.IsNullOrWhiteSpace(audiobook.PublishYear)
                     && int.TryParse(audiobook.PublishYear, out var year)
                         ? year
@@ -94,6 +102,26 @@ public partial class DownloadImportService
             AlbumArtist = "Unknown Author"
         };
     }
+
+    /// <summary>
+    /// The {SeriesNumber} token for a file being imported.
+    /// <para>
+    /// Prefers the position exactly as the source gave it. A real but non-numeric position
+    /// (an omnibus at "1-4") does not survive the decimal parse, and falling through to the
+    /// chapter number would write that into the filename as if it were the series number.
+    /// </para>
+    /// <para>
+    /// A parsed position is formatted with InvariantCulture, matching FileNamingService:
+    /// ToString() under the server's culture would put a comma into the filename.
+    /// </para>
+    /// </summary>
+    private static string SeriesNumberToken(
+        AudioMetadata metadata,
+        int? fallbackChapterNumber) =>
+        FirstNonEmpty(
+            metadata.SeriesPositionRaw,
+            metadata.SeriesPosition?.ToString(CultureInfo.InvariantCulture),
+            fallbackChapterNumber?.ToString());
 
     private static string ChooseAuthorFromMetadata(AudioMetadata? metadata)
     {

--- a/listenarr.application/Downloads/Import/DownloadImportService.Naming.cs
+++ b/listenarr.application/Downloads/Import/DownloadImportService.Naming.cs
@@ -4,7 +4,15 @@ namespace Listenarr.Application.Downloads.Import;
 
 public partial class DownloadImportService
 {
-    private static AudioMetadata BuildNamingMetadata(
+    /// <summary>
+    /// Merges the catalogue record and the file's own tags into the metadata the naming
+    /// tokens are rendered from.
+    /// </summary>
+    /// <remarks>
+    /// Internal rather than private so the series-position precedence can be asserted against
+    /// the real method rather than a copy of it.
+    /// </remarks>
+    internal static AudioMetadata BuildNamingMetadata(
         Audiobook? audiobook,
         AudioMetadata? extractedMetadata,
         string fallbackTitle)
@@ -16,6 +24,29 @@ public partial class DownloadImportService
                 : FirstNonEmpty(
                     ChooseAuthorFromMetadata(extractedMetadata),
                     "Unknown Author");
+
+            // One source wins for BOTH series-position fields. Choosing them independently
+            // lets them describe different books: a catalogue position of "1-4" fails the
+            // decimal parse, so the decimal falls through to the file's own 3 while the raw
+            // string keeps "1-4", and the sort key then disagrees with the label.
+            //
+            // Parsed with InvariantCulture: the source value always uses '.' as the decimal
+            // separator, so parsing under the server's culture would read a position of "1.5"
+            // as 15 wherever '.' is the group separator. NumberStyles.Float rather than
+            // Number because Number carries AllowThousands and the invariant group separator
+            // is ',', so "1,5" would parse as 15 by that same route.
+            var cataloguePosition = TrimmedOrNull(audiobook.SeriesNumber);
+            var seriesPositionRaw = cataloguePosition
+                ?? TrimmedOrNull(extractedMetadata?.SeriesPositionRaw);
+            var seriesPosition = cataloguePosition != null
+                ? decimal.TryParse(
+                    cataloguePosition,
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out var parsedPosition)
+                    ? parsedPosition
+                    : (decimal?)null
+                : extractedMetadata?.SeriesPosition;
 
             return new AudioMetadata
             {
@@ -52,16 +83,8 @@ public partial class DownloadImportService
                 Series = FirstNonEmpty(
                     audiobook.Series,
                     extractedMetadata?.Series),
-                // Parsed with InvariantCulture: the source value always uses '.' as the
-                // decimal separator, so parsing under the server's culture would read a
-                // position of "1.5" as 15 wherever '.' is the group separator.
-                SeriesPosition = !string.IsNullOrWhiteSpace(audiobook.SeriesNumber)
-                    && decimal.TryParse(audiobook.SeriesNumber, NumberStyles.Number, CultureInfo.InvariantCulture, out var seriesPosition)
-                        ? seriesPosition
-                        : extractedMetadata?.SeriesPosition,
-                SeriesPositionRaw = FirstNonEmpty(
-                    audiobook.SeriesNumber,
-                    extractedMetadata?.SeriesPositionRaw),
+                SeriesPosition = seriesPosition,
+                SeriesPositionRaw = seriesPositionRaw,
                 Year = !string.IsNullOrWhiteSpace(audiobook.PublishYear)
                     && int.TryParse(audiobook.PublishYear, out var year)
                         ? year
@@ -183,4 +206,11 @@ public partial class DownloadImportService
     private static string FirstNonEmpty(params string?[] candidates) =>
         candidates.FirstOrDefault(candidate => !string.IsNullOrWhiteSpace(candidate))
         ?? string.Empty;
+
+    /// <summary>
+    /// Null for a value that is absent or only whitespace, trimmed otherwise. Absence has one
+    /// spelling on this route, matching what Audiobook.CreateBasicAudioMetadata stores.
+    /// </summary>
+    private static string? TrimmedOrNull(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
 }

--- a/listenarr.application/Downloads/Import/DownloadImportService.cs
+++ b/listenarr.application/Downloads/Import/DownloadImportService.cs
@@ -313,7 +313,7 @@ namespace Listenarr.Application.Downloads.Import
                                 { "Publisher", string.IsNullOrWhiteSpace(namingMetadata.Publisher) ? string.Empty : namingMetadata.Publisher },
                                 { "Language", string.IsNullOrWhiteSpace(namingMetadata.Language) ? string.Empty : namingMetadata.Language },
                                 { "Asin", string.IsNullOrWhiteSpace(namingMetadata.Asin) ? string.Empty : namingMetadata.Asin },
-                                { "SeriesNumber", namingMetadata.SeriesPosition?.ToString() ?? effectiveChapterNumber?.ToString() ?? string.Empty },
+                                { "SeriesNumber", SeriesNumberToken(namingMetadata, effectiveChapterNumber) },
                                 { "Year", namingMetadata.Year?.ToString() ?? string.Empty },
                                 { "Quality", (namingMetadata.BitRate.HasValue ? $"{namingMetadata.BitRate}kbps" : null) ?? namingMetadata.Format ?? string.Empty },
                                 { "DiskNumber", effectiveDiskNumber?.ToString() ?? string.Empty },

--- a/listenarr.domain/Audiobooks/AudioMetadata.cs
+++ b/listenarr.domain/Audiobooks/AudioMetadata.cs
@@ -50,6 +50,22 @@ namespace Listenarr.Domain.Audiobooks
         public string? Language { get; set; }
         public string? Series { get; set; }
         public decimal? SeriesPosition { get; set; }
+
+        /// <summary>
+        /// The series position exactly as the metadata source gave it.
+        /// <para>
+        /// Audible/Audnexus report a position as a string, and it is not always a number:
+        /// an omnibus can sit at "1-4", a prequel at "0", a novella at "1.5". Those values
+        /// are meaningful, but they do not all fit in <see cref="SeriesPosition"/>, so a
+        /// position that fails to parse would otherwise be indistinguishable from a book
+        /// that has no series position at all.
+        /// </para>
+        /// <para>
+        /// Naming prefers this over <see cref="SeriesPosition"/> so that a real position is
+        /// never silently replaced by a track number.
+        /// </para>
+        /// </summary>
+        public string? SeriesPositionRaw { get; set; }
         public byte[]? CoverArt { get; set; }
         public string? CoverArtUrl { get; set; }
         public Dictionary<string, object> AdditionalData { get; set; } = [];
@@ -75,6 +91,8 @@ namespace Listenarr.Domain.Audiobooks
 
             if (!SeriesPosition.HasValue && value.SeriesPosition.HasValue)
                 SeriesPosition = value.SeriesPosition;
+            if (string.IsNullOrWhiteSpace(SeriesPositionRaw) && !string.IsNullOrWhiteSpace(value.SeriesPositionRaw))
+                SeriesPositionRaw = value.SeriesPositionRaw;
             if (!TrackNumber.HasValue && value.TrackNumber.HasValue)
                 TrackNumber = value.TrackNumber;
             if (!DiscNumber.HasValue && value.DiscNumber.HasValue)

--- a/listenarr.domain/Audiobooks/Audiobook.cs
+++ b/listenarr.domain/Audiobooks/Audiobook.cs
@@ -17,6 +17,7 @@
  */
 
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 
 namespace Listenarr.Domain.Audiobooks
 {
@@ -97,8 +98,17 @@ namespace Listenarr.Domain.Audiobooks
                 Series = Series,
                 // Prefer audiobook's publish year when available
                 Year = int.TryParse(PublishYear, out var py) ? py : (int?)null,
-                // Series position / number
-                SeriesPosition = !string.IsNullOrWhiteSpace(SeriesNumber) && decimal.TryParse(SeriesNumber, out var sp) ? sp : (decimal?)null,
+                // Series position / number.
+                // Parsed with InvariantCulture: the source value always uses '.' as the
+                // decimal separator, so parsing under the server's culture would read a
+                // position of "1.5" as 15 wherever '.' is the group separator.
+                // SeriesPositionRaw keeps the original either way -- a position such as
+                // "1-4" (an omnibus) is real, but is not a decimal.
+                SeriesPosition = !string.IsNullOrWhiteSpace(SeriesNumber)
+                    && decimal.TryParse(SeriesNumber, NumberStyles.Number, CultureInfo.InvariantCulture, out var sp)
+                        ? sp
+                        : (decimal?)null,
+                SeriesPositionRaw = !string.IsNullOrWhiteSpace(SeriesNumber) ? SeriesNumber.Trim() : null,
                 // Quality string from audiobook record
                 // Map into Bitrate/Format heuristically if useful; for now store textual quality
                 // We'll put it into AdditionalData so FileNamingService can use Format/Bitrate/Quality

--- a/listenarr.domain/Audiobooks/Audiobook.cs
+++ b/listenarr.domain/Audiobooks/Audiobook.cs
@@ -104,8 +104,12 @@ namespace Listenarr.Domain.Audiobooks
                 // position of "1.5" as 15 wherever '.' is the group separator.
                 // SeriesPositionRaw keeps the original either way -- a position such as
                 // "1-4" (an omnibus) is real, but is not a decimal.
+                // NumberStyles.Float rather than Number: Number carries AllowThousands and
+                // the invariant group separator is ',', so a position written "1,5" would
+                // parse as 15 rather than failing, which is the same wrong magnitude the
+                // invariant pin exists to prevent.
                 SeriesPosition = !string.IsNullOrWhiteSpace(SeriesNumber)
-                    && decimal.TryParse(SeriesNumber, NumberStyles.Number, CultureInfo.InvariantCulture, out var sp)
+                    && decimal.TryParse(SeriesNumber, NumberStyles.Float, CultureInfo.InvariantCulture, out var sp)
                         ? sp
                         : (decimal?)null,
                 SeriesPositionRaw = !string.IsNullOrWhiteSpace(SeriesNumber) ? SeriesNumber.Trim() : null,

--- a/tests/Features/Domain/Audiobooks/SeriesPositionReproTests.cs
+++ b/tests/Features/Domain/Audiobooks/SeriesPositionReproTests.cs
@@ -1,0 +1,158 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Globalization;
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Domain.Audiobooks
+{
+    /// <summary>
+    /// Audible/Audnexus report a series position as a STRING, and it is not always a number.
+    /// Real, live examples from the catalogue:
+    ///
+    ///   "The Father Brown Collection: Books 1-4"  -> position "1-4"  (one ASIN, four books)
+    ///   "The Thirty-Nine Steps"                   -> position "1-2"  (bundles its sequel)
+    ///   "She and Allan"                           -> position "0"    (prequel slot)
+    ///   a novella between two books               -> position "1.5"
+    ///
+    /// Two defects followed from squeezing that string through a decimal:
+    ///
+    ///  1. The parse used the server's culture. Where '.' is the group separator (de-DE),
+    ///     "1.5" parses as 15; under fr-FR it does not parse at all.
+    ///  2. A position that does not parse became null, which is indistinguishable from a
+    ///     book with NO series position -- so naming fell through to the track number and
+    ///     wrote it into the filename as if it were the series number.
+    /// </summary>
+    [Trait("Name", "SeriesPositionReproTests")]
+    [Trait("Category", "Domain")]
+    public sealed class SeriesPositionReproTests : BaseTests
+    {
+        private static Audiobook Book(string? seriesNumber) => new()
+        {
+            Title = "Test",
+            Series = "Test Series",
+            SeriesNumber = seriesNumber,
+        };
+
+        private static FileNamingService Naming()
+        {
+            var config = new Mock<IConfigurationService>();
+            var logger = new Mock<ILogger<FileNamingService>>();
+            return new FileNamingService(config.Object, logger.Object);
+        }
+
+        // ---------------------------------------------------------------
+        // 1. Culture: the source always uses '.', so parsing must be invariant.
+        // ---------------------------------------------------------------
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("de-DE")]  // '.' is the GROUP separator here -- "1.5" once parsed as 15
+        [InlineData("fr-FR")]  // "1.5" once failed to parse at all
+        public void DecimalPosition_SurvivesAnyServerCulture(string culture)
+        {
+            var original = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo(culture);
+                var metadata = Book("1.5").CreateBasicAudioMetadata();
+
+                Assert.Equal(1.5m, metadata.SeriesPosition);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = original;
+            }
+        }
+
+        [Fact]
+        public void DecimalPosition_IsWrittenInvariantly_NotWithALocalDecimalComma()
+        {
+            var original = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+                var metadata = Book("1.5").CreateBasicAudioMetadata();
+
+                var name = Naming().ApplyNamingPattern("{SeriesNumber}", metadata, treatAsFilename: true);
+
+                // Not "1,5" -- a comma in a filename is a locale leaking onto disk.
+                Assert.Equal("1.5", name);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = original;
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // 2. A real but non-numeric position must not be lost.
+        // ---------------------------------------------------------------
+
+        [Theory]
+        [InlineData("1-4")]   // The Father Brown Collection: Books 1-4
+        [InlineData("1-2")]   // The Thirty-Nine Steps (bundles Greenmantle)
+        public void RangePosition_IsPreserved_EvenThoughItIsNotADecimal(string position)
+        {
+            var metadata = Book(position).CreateBasicAudioMetadata();
+
+            // decimal? genuinely cannot hold "1-4", and should not try.
+            Assert.Null(metadata.SeriesPosition);
+
+            // But the value is real and must survive.
+            Assert.Equal(position, metadata.SeriesPositionRaw);
+        }
+
+        [Theory]
+        [InlineData("1-4")]
+        [InlineData("1-2")]
+        public void RangePosition_ReachesTheFilename_AndIsNotReplacedByTheTrackNumber(string position)
+        {
+            var metadata = Book(position).CreateBasicAudioMetadata();
+            metadata.TrackNumber = 7;   // the value that used to be written instead
+
+            var name = Naming().ApplyNamingPattern("{SeriesNumber}", metadata, treatAsFilename: true);
+
+            Assert.Equal(position, name);
+            Assert.NotEqual("7", name);
+        }
+
+        [Fact]
+        public void AbsentPosition_StillFallsBackToTheTrackNumber()
+        {
+            // The fallback itself is deliberate and must be preserved: a book with no series
+            // position at all should still get the track number. The bug was that a REAL
+            // position was being treated as an absent one.
+            var metadata = Book(null).CreateBasicAudioMetadata();
+            metadata.TrackNumber = 7;
+
+            var name = Naming().ApplyNamingPattern("{SeriesNumber}", metadata, treatAsFilename: true);
+
+            Assert.Equal("7", name);
+        }
+
+        [Fact]
+        public void ZeroPosition_Survives()
+        {
+            // She and Allan sits at position "0" of the Ayesha series.
+            var metadata = Book("0").CreateBasicAudioMetadata();
+
+            Assert.Equal(0m, metadata.SeriesPosition);
+            Assert.Equal("0", metadata.SeriesPositionRaw);
+        }
+    }
+}

--- a/tests/Features/Domain/Audiobooks/SeriesPositionReproTests.cs
+++ b/tests/Features/Domain/Audiobooks/SeriesPositionReproTests.cs
@@ -154,5 +154,204 @@ namespace Listenarr.Tests.Features.Domain.Audiobooks
             Assert.Equal(0m, metadata.SeriesPosition);
             Assert.Equal("0", metadata.SeriesPositionRaw);
         }
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("de-DE")]
+        [InlineData("fr-FR")]
+        public void CommaFormattedPosition_FailsTheParseInsteadOfChangingMagnitude(string culture)
+        {
+            // NumberStyles.Number carries AllowThousands and the invariant group separator is
+            // ',', so "1,5" parses as 15 under Number: the wrong magnitude the invariant pin
+            // exists to prevent, arriving by a different route. Float rejects it. The raw
+            // string is kept either way, so the filename is unaffected.
+            var original = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo(culture);
+                var metadata = Book("1,5").CreateBasicAudioMetadata();
+
+                Assert.Null(metadata.SeriesPosition);
+                Assert.Equal("1,5", metadata.SeriesPositionRaw);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = original;
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // 3. On the import route, both fields come from ONE source.
+        // ---------------------------------------------------------------
+
+        private static AudioMetadata FileTags(decimal? position, string? raw) => new()
+        {
+            Title = "From the file",
+            SeriesPosition = position,
+            SeriesPositionRaw = raw,
+        };
+
+        [Fact]
+        public void ImportPosition_TakesBothFieldsFromTheCatalogue_WhenItHasOne()
+        {
+            // The catalogue says "1-4" (an omnibus) and the file's own tags say 3. Deciding
+            // the two fields independently used to give SeriesPositionRaw "1-4" from the
+            // catalogue and SeriesPosition 3 from the file, so the sort key and the label
+            // described different books. The catalogue wins both, or neither.
+            var metadata = DownloadImportService.BuildNamingMetadata(
+                Book("1-4"),
+                FileTags(3m, "3"),
+                "fallback");
+
+            Assert.Equal("1-4", metadata.SeriesPositionRaw);
+            Assert.Null(metadata.SeriesPosition);
+        }
+
+        [Fact]
+        public void ImportPosition_TakesBothFieldsFromTheFile_WhenTheCatalogueHasNone()
+        {
+            var metadata = DownloadImportService.BuildNamingMetadata(
+                Book(null),
+                FileTags(3m, "3"),
+                "fallback");
+
+            Assert.Equal("3", metadata.SeriesPositionRaw);
+            Assert.Equal(3m, metadata.SeriesPosition);
+        }
+
+        [Fact]
+        public void ImportPosition_SpellsAbsenceAsNull_AndTrimsOnBothRoutes()
+        {
+            var absent = DownloadImportService.BuildNamingMetadata(
+                Book(null),
+                FileTags(null, null),
+                "fallback");
+
+            // Not string.Empty: absence has one spelling, matching the domain route.
+            Assert.Null(absent.SeriesPositionRaw);
+            Assert.Null(absent.SeriesPosition);
+
+            var fromCatalogue = DownloadImportService.BuildNamingMetadata(
+                Book("  2  "),
+                FileTags(null, null),
+                "fallback");
+
+            Assert.Equal("2", fromCatalogue.SeriesPositionRaw);
+            Assert.Equal(2m, fromCatalogue.SeriesPosition);
+
+            var fromFile = DownloadImportService.BuildNamingMetadata(
+                Book(null),
+                FileTags(null, "  1-4  "),
+                "fallback");
+
+            Assert.Equal("1-4", fromFile.SeriesPositionRaw);
+
+            var blankCatalogue = DownloadImportService.BuildNamingMetadata(
+                Book("   "),
+                FileTags(null, "1-4"),
+                "fallback");
+
+            // Whitespace is not a position, so the file still wins.
+            Assert.Equal("1-4", blankCatalogue.SeriesPositionRaw);
+        }
+
+        // ---------------------------------------------------------------
+        // 4. The raw position reaches a path, so it must not be able to BE a path.
+        // ---------------------------------------------------------------
+
+        [Theory]
+        [InlineData("1/2")]
+        [InlineData("1\\2")]
+        [InlineData("../../etc")]
+        [InlineData("..")]
+        [InlineData("C:\\Windows")]
+        public void RawPosition_CannotAddAPathComponent(string position)
+        {
+            // This PR widens the type of a value that reaches a path from decimal to an
+            // arbitrary source string, so the guard that stops it becoming a path is now
+            // load-bearing and is pinned here rather than left to the sanitiser's own tests.
+            var metadata = Book(position).CreateBasicAudioMetadata();
+            var naming = Naming();
+
+            var fileName = naming.ApplyNamingPattern("{SeriesNumber}", metadata, treatAsFilename: true);
+
+            Assert.DoesNotContain("/", fileName);
+            Assert.DoesNotContain("\\", fileName);
+            Assert.DoesNotContain(":", fileName);
+            Assert.NotEqual("..", fileName);
+            Assert.NotEqual(".", fileName);
+            Assert.Equal(fileName, Path.GetFileName(fileName));
+
+            // The folder route is the one that can actually make directories: the pattern has
+            // three components, so the rendered path must have three, whatever the position
+            // contained.
+            var folder = naming.ApplyNamingPattern(
+                "{Author}/{Series}/{SeriesNumber}",
+                metadata,
+                treatAsFilename: false);
+
+            var segments = folder.Split(
+                [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '/', '\\'],
+                StringSplitOptions.RemoveEmptyEntries);
+
+            Assert.Equal(3, segments.Length);
+            Assert.DoesNotContain("..", segments);
+            Assert.DoesNotContain(".", segments);
+        }
+
+        [Fact]
+        public void RawPositionWithASeparator_CreatesNoDirectoryOutsideTheRoot()
+        {
+            var root = Path.Combine(
+                Path.GetTempPath(),
+                "listenarr-series-position-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+
+            try
+            {
+                var metadata = Book("../../1/2").CreateBasicAudioMetadata();
+
+                var relative = Naming().ApplyNamingPattern(
+                    "{Author}/{Series}/{SeriesNumber}",
+                    metadata,
+                    treatAsFilename: false);
+
+                var relativeSegments = relative.Split(
+                    [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '/', '\\'],
+                    StringSplitOptions.RemoveEmptyEntries);
+
+                // Three tokens in the pattern, three components out. Asserting only that the
+                // destination stays under the root is not enough: ".." components that cancel
+                // each other still land inside the root while building a path nobody asked for.
+                Assert.Equal(3, relativeSegments.Length);
+                Assert.DoesNotContain("..", relativeSegments);
+                Assert.DoesNotContain(".", relativeSegments);
+
+                var destination = Path.GetFullPath(Path.Combine(root, relative));
+
+                // The rendered path stays inside the root: no ".." escapes, no absolute path
+                // takes over the Combine.
+                Assert.StartsWith(
+                    root + Path.DirectorySeparatorChar,
+                    destination,
+                    StringComparison.Ordinal);
+
+                Directory.CreateDirectory(destination);
+
+                // Author, Series, SeriesNumber and nothing else, as one chain.
+                var created = Directory.GetDirectories(root, "*", SearchOption.AllDirectories)
+                    .Select(directory => Path.GetRelativePath(root, directory))
+                    .OrderBy(directory => directory.Length)
+                    .ToArray();
+
+                Assert.Equal(3, created.Length);
+                Assert.Equal(relativeSegments[0], created[0]);
+                Assert.Equal(Path.GetRelativePath(root, destination), created[2]);
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #764.

Audnexus reports a series position as a **string**, and it is not always a number. Squeezing it through a `decimal` lost it in two ways, and the loss reached the filename.

Real positions from the catalogue (public domain, verifiable against `api.audnex.us`):

| Book | ASIN | `position` |
|---|---|---|
| The Father Brown Collection: Books 1-4 | `B0F84DFZ66` | `"1-4"` — one ASIN, four books |
| The Thirty-Nine Steps | `B002V1PLZK` | `"1-2"` — the product also ships *Greenmantle* |
| She and Allan | `B00CQ5WAXW` | `"0"` — a prequel slot |
| a novella between two books | — | `"1.5"` |

**The parse used the server's culture.** `decimal.TryParse` was called with no `CultureInfo`, while `FileNamingService` formatted the result back with `InvariantCulture`. The source always uses `.` as the decimal separator, so where `.` is the *group* separator the number changed:

```
en-US      "1.5" -> 1.5     "0.5" -> 0.5
de-DE      "1.5" -> 15      "0.5" -> 5
fr-FR      "1.5" -> null    "0.5" -> null
invariant  "1.5" -> 1.5     "0.5" -> 0.5
```

**A position that didn't parse was silently discarded.** It became `null` — indistinguishable from a book with no position — so naming fell through to the track number and wrote that into the filename instead. No error, nothing in the log.

## Changes

### Added
- `AudioMetadata.SeriesPositionRaw` — the series position exactly as the metadata source gave it. `SeriesPosition` (`decimal?`) is kept for callers that sort or compare, but it cannot hold `"1-4"` and no longer pretends to.
- `SeriesPositionReproTests` — 10 cases covering culture handling and non-numeric positions.

### Changed
- `Audiobook.CreateBasicAudioMetadata` and `DownloadImportService` now parse the position with `InvariantCulture`.
- Both naming sites (`FileNamingService.Helpers`, `DownloadImportService`) prefer `SeriesPositionRaw`, then the invariant-formatted decimal, then the track number. `DownloadImportService` previously formatted with a bare `.ToString()`, which would write `1,5` — with a comma — into a filename.

### Fixed
- A non-numeric but real series position is no longer replaced by the track number when a file is renamed.
- A decimal position no longer changes value depending on the server's locale.

## Testing

`SeriesPositionReproTests` (10 new cases):

- a decimal position survives under `en-US`, `de-DE` and `fr-FR`
- a decimal position is written invariantly, so no locale decimal-comma reaches a filename
- `"1-4"` and `"1-2"` are preserved and **reach the filename** rather than being replaced by the track number
- a book with no position still falls back to the track number, as before
- `"0"` survives

`dotnet test`: **1199 passing, 0 failing** (1189 existing + 10 new). No existing test was changed.

## Notes

The fall back to the track number is deliberate and is preserved — a book with genuinely no series position still gets it. The bug was that a *real* position was being treated as an absent one.

Apologies for opening this before the issue; #764 has the write-up. I've read `CONTRIBUTING.md` properly now.

Out of scope but worth flagging while it's in view: a book can hold **two** series memberships at once. Audnexus gives *She and Allan* (`B00CQ5WAXW`) `seriesPrimary` = Ayesha #0 **and** `seriesSecondary` = Allan Quatermain #7. `MetadataConverters` reads both, but `AudiobookSeriesMembership` is never constructed outside tests, so neither is persisted. Happy to open that separately if useful.