### PR TITLE
fix(scan): don't attribute every book by an author to whichever one is scanned

### DIFF
--- a/listenarr.infrastructure/Library/Scanning/ScanFileDiscovery.cs
+++ b/listenarr.infrastructure/Library/Scanning/ScanFileDiscovery.cs
@@ -33,8 +33,7 @@ internal static class ScanFileDiscovery
         foreach (var group in candidates.GroupBy(file => Path.GetDirectoryName(file) ?? string.Empty))
         {
             var directoryName = Path.GetFileName(group.Key) ?? string.Empty;
-            var groupHasMatch = group.Any(file =>
-                Matches(file, directoryName, titleToken, authorToken));
+            var groupHasMatch = group.Any(file => Matches(file, directoryName, titleToken));
             if (groupHasMatch)
             {
                 foundFiles.AddRange(group.Where(unique.Add));
@@ -42,7 +41,7 @@ internal static class ScanFileDiscovery
             }
 
             foreach (var file in group.Where(file =>
-                         Matches(file, directoryName: string.Empty, titleToken, authorToken)))
+                         Matches(file, directoryName: string.Empty, titleToken)))
             {
                 if (unique.Add(file))
                 {
@@ -103,20 +102,36 @@ internal static class ScanFileDiscovery
         return candidates;
     }
 
+    /// <summary>
+    /// Decides whether a file can be attributed to a specific audiobook from its path alone.
+    /// <para>
+    /// Only the TITLE can do this. The author names a shelf, not a book: in the usual
+    /// <c>{Author}/...</c> layout every file beneath an author's folder contains that author's
+    /// name, so accepting "the path contains the author" as a match attributes every book by
+    /// that author to whichever one is being scanned -- and the resulting common parent is the
+    /// author folder, which then becomes the audiobook's BasePath.
+    /// </para>
+    /// <para>
+    /// A path that carries neither the title nor anything else identifying is simply not
+    /// attributable by path, and is left for the embedded-tag pass to claim. Leaving a file
+    /// unmatched is recoverable; attaching it to the wrong book is not.
+    /// </para>
+    /// </summary>
     private static bool Matches(
         string file,
         string directoryName,
-        string titleToken,
-        string authorToken)
+        string titleToken)
     {
-        var fileNameMatchesTitle = !string.IsNullOrEmpty(titleToken)
-            && Path.GetFileNameWithoutExtension(file)
-                .Contains(titleToken, StringComparison.OrdinalIgnoreCase);
-        var filePathMatchesAuthor = !string.IsNullOrEmpty(authorToken)
-            && file.Contains(authorToken, StringComparison.OrdinalIgnoreCase);
+        if (string.IsNullOrEmpty(titleToken))
+        {
+            return false;
+        }
+
+        var fileNameMatchesTitle = Path.GetFileNameWithoutExtension(file)
+            .Contains(titleToken, StringComparison.OrdinalIgnoreCase);
         var directoryMatchesTitle = !string.IsNullOrEmpty(directoryName)
-            && !string.IsNullOrEmpty(titleToken)
             && directoryName.Contains(titleToken, StringComparison.OrdinalIgnoreCase);
-        return fileNameMatchesTitle || filePathMatchesAuthor || directoryMatchesTitle;
+
+        return fileNameMatchesTitle || directoryMatchesTitle;
     }
 }

--- a/tests/Features/Infrastructure/Library/Scanning/ScanFileDiscoveryReproTests.cs
+++ b/tests/Features/Infrastructure/Library/Scanning/ScanFileDiscoveryReproTests.cs
@@ -1,0 +1,166 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Listenarr.Tests.Features.Infrastructure.Library.Scanning
+{
+    /// <summary>
+    /// Path attribution in ScanFileDiscovery, exercised against real directory trees.
+    ///
+    /// When an audiobook has no BasePath the scan root falls back to the whole library, so every
+    /// audio file under it becomes a candidate and attribution rests entirely on the path.
+    /// Books used below are public domain (H. Rider Haggard, Jules Verne).
+    /// </summary>
+    public class ScanFileDiscoveryReproTests : IDisposable
+    {
+        private readonly string _root;
+
+        public ScanFileDiscoveryReproTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "listenarr-scan-" + Guid.NewGuid().ToString("N"));
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+            GC.SuppressFinalize(this);
+        }
+
+        private void AddBook(string relativeFolder, params string[] fileNames)
+        {
+            var dir = Path.Combine(_root, relativeFolder);
+            Directory.CreateDirectory(dir);
+            foreach (var name in fileNames)
+            {
+                File.WriteAllText(Path.Combine(dir, name), "not really audio");
+            }
+        }
+
+        private static Audiobook Book(string title, string author) => new()
+        {
+            Title = title,
+            Authors = new List<string> { author },
+        };
+
+        private List<string> Scan(Audiobook audiobook) =>
+            ScanFileDiscovery.FindMatchingAudioFiles(_root, audiobook, Guid.NewGuid(), NullLogger.Instance);
+
+        private static List<string> Names(IEnumerable<string> paths) =>
+            paths.Select(Path.GetFileName).OrderBy(n => n, StringComparer.Ordinal).ToList()!;
+
+        // -----------------------------------------------------------------
+        // The bug: the author names a shelf, not a book.
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void ScanningOneBook_DoesNotClaimTheOtherBooksByTheSameAuthor()
+        {
+            AddBook("H. Rider Haggard/H. Rider Haggard - She", "She.m4b");
+            AddBook("H. Rider Haggard/H. Rider Haggard - Allan Quatermain", "Allan Quatermain.m4b");
+            AddBook("H. Rider Haggard/H. Rider Haggard - King Solomon's Mines", "King Solomon's Mines.m4b");
+
+            var found = Scan(Book("She", "H. Rider Haggard"));
+
+            Assert.Equal(new List<string> { "She.m4b" }, Names(found));
+        }
+
+        [Fact]
+        public void BasePath_IsTheBookFolder_NotTheAuthorFolder()
+        {
+            AddBook("H. Rider Haggard/H. Rider Haggard - She", "She.m4b");
+            AddBook("H. Rider Haggard/H. Rider Haggard - Allan Quatermain", "Allan Quatermain.m4b");
+
+            var basePath = ScanPathPlanner.CalculateBasePath(Scan(Book("She", "H. Rider Haggard")));
+
+            // If the author counted as a match, the common parent of every Haggard file would be
+            // the AUTHOR folder -- and that would be stored as this book's BasePath, which is
+            // what rename and move then operate on.
+            Assert.EndsWith("H. Rider Haggard - She", basePath);
+        }
+
+        // -----------------------------------------------------------------
+        // Layouts that must keep working.
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void TitleInTheFolderName_Matches()
+        {
+            // The common Audnex/Plex shape: {Author}/{Author} - {Series} - {Title}/
+            AddBook("Jules Verne/Jules Verne - Captain Nemo - Twenty Thousand Leagues Under the Sea",
+                "Twenty Thousand Leagues Under the Sea.m4b");
+
+            var found = Scan(Book("Twenty Thousand Leagues Under the Sea", "Jules Verne"));
+
+            Assert.Single(found);
+        }
+
+        [Fact]
+        public void TitleInTheFileName_Matches_EvenWhenTheFolderDoesNotCarryIt()
+        {
+            AddBook("Jules Verne/Audiobooks", "Around the World in Eighty Days.mp3");
+
+            var found = Scan(Book("Around the World in Eighty Days", "Jules Verne"));
+
+            Assert.Single(found);
+        }
+
+        [Fact]
+        public void EveryFileInAMatchedBookFolder_IsClaimed()
+        {
+            // A multi-part book: the folder identifies it, so all its parts belong to it --
+            // including parts whose own filenames do not repeat the title.
+            AddBook("Jules Verne/1870 - Twenty Thousand Leagues Under the Sea",
+                "Part 01.mp3", "Part 02.mp3", "Part 03.mp3");
+
+            var found = Scan(Book("Twenty Thousand Leagues Under the Sea", "Jules Verne"));
+
+            Assert.Equal(3, found.Count);
+        }
+
+        [Fact]
+        public void ASiblingBookInTheSameSeriesFolder_IsNotClaimed()
+        {
+            AddBook("Jules Verne/Captain Nemo/1870 - Twenty Thousand Leagues Under the Sea", "book.m4b");
+            AddBook("Jules Verne/Captain Nemo/1874 - The Mysterious Island", "book.m4b");
+
+            var found = Scan(Book("The Mysterious Island", "Jules Verne"));
+
+            Assert.Single(found);
+            Assert.Contains("The Mysterious Island", found[0]);
+        }
+
+        // -----------------------------------------------------------------
+        // The trade-off, stated explicitly.
+        // -----------------------------------------------------------------
+
+        [Fact]
+        public void APathCarryingNeitherTitleNorAnythingIdentifying_IsLeftUnmatched()
+        {
+            // Previously this matched -- on the author alone -- and so did every other book by
+            // the same author. Unmatched is the correct outcome for a path that cannot identify
+            // a book: a miss is recoverable, a wrong link is not. Embedded tags are what should
+            // claim these.
+            AddBook("Elfie Donnelly/Bibi und Tina/61", "61 - track.mp3");
+
+            var found = Scan(Book("Retten die Biber", "Elfie Donnelly"));
+
+            Assert.Empty(found);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #765.

`ScanFileDiscovery.Matches` accepted "the path contains the author" as sufficient to attribute a file to a *specific* audiobook:

```csharp
var filePathMatchesAuthor = !string.IsNullOrEmpty(authorToken)
    && file.Contains(authorToken, StringComparison.OrdinalIgnoreCase);

return fileNameMatchesTitle || filePathMatchesAuthor || directoryMatchesTitle;
```

In the usual `{Author}/...` layout, *every* file beneath an author's folder contains that author's name — so the clause is true for all of them. `FindMatchingAudioFiles` takes **all** files in any directory group where **any** file matches, so each of the author's book folders is claimed whole, and `ScanPathPlanner.CalculateBasePath` reduces the result to its common parent: the **author folder**. That is then stored as the audiobook's `BasePath` — which is what rename and move operate on.

Reached whenever an audiobook has no `BasePath`, because the scan root then falls back to the configured `OutputPath` and the whole library becomes candidates. A `BasePath` is empty in normal use: it's only assigned on add when a destination path is supplied, and `ScanJobProcessor` sets it to `null` when the stored folder no longer exists.

### Reproduction

Three public-domain books by one author, conventional layout:

```
{root}/H. Rider Haggard/H. Rider Haggard - She/She.m4b
{root}/H. Rider Haggard/H. Rider Haggard - Allan Quatermain/Allan Quatermain.m4b
{root}/H. Rider Haggard/H. Rider Haggard - King Solomon's Mines/King Solomon's Mines.m4b
```

Scanning the audiobook **She**:

```
expected: ["She.m4b"]
actual:   ["Allan Quatermain.m4b", "King Solomon's Mines.m4b", "She.m4b"]

BasePath expected: .../H. Rider Haggard - She
BasePath actual:   .../H. Rider Haggard          <-- the author folder
```

## Changes

### Changed
- `ScanFileDiscovery.Matches` now attributes a file to an audiobook only when the **title** appears — in the filename or in the containing directory. The author is no longer a match on its own.

### Fixed
- A scan no longer claims every book by an author for whichever one is being scanned.
- An audiobook's `BasePath` is no longer collapsed to its author's folder.

## Testing

`ScanFileDiscoveryReproTests` — 7 new cases against real temp directory trees (`FindMatchingAudioFiles` is a static taking a root path and an `Audiobook`, so this needs no database or container):

- scanning one book does not claim the other books by the same author
- `BasePath` resolves to the book folder, not the author folder
- title in the folder name still matches (the common `{Author}/{Author} - {Series} - {Title}` shape)
- title in the filename still matches when the folder does not carry it
- every file in a matched book folder is still claimed (multi-part books whose part filenames don't repeat the title)
- a sibling book in the same series folder is not claimed
- a path carrying neither title nor anything identifying is left unmatched

`dotnet test`: **1196 passing, 0 failing** (1189 existing + 7 new). No existing test changed — nothing in the suite depended on author-only matching.

## Notes

**The trade-off, stated plainly:** layouts that encode neither the title nor the author in the path — AudioBookShelf-style series folders with numbered episode files — go from *wrongly matched* to *unmatched*.

That is the right direction. A miss is recoverable and visible to the user; a wrong link is neither, because the file is silently attached to a book the user has no reason to go and check. And those layouts are exactly what an embedded-tag pass should claim, which is what #688 proposes — the two changes complement each other rather than overlap.

Books cited are public domain with real Audible editions, so the case is reproducible by anyone.
