### PR TITLE
fix(qbittorrent): add URL Base support for reverse-proxied instances

### DIFF
--- a/fe/src/__tests__/DownloadClientFormModal.spec.ts
+++ b/fe/src/__tests__/DownloadClientFormModal.spec.ts
@@ -172,4 +172,47 @@ describe('DownloadClientFormModal', () => {
     expect(calledWith.password).toBe('')
     expect(calledWith.id).toBe('4')
   })
+
+  it('renders URL Base field for qbittorrent and includes it in the test payload when set', async () => {
+    const api = await import('@/services/api')
+    ;(api.testDownloadClient as unknown) = vi.fn(async (config: unknown) => ({
+      success: true,
+      message: 'ok',
+      client: config,
+    }))
+
+    const wrapper = mount(DownloadClientFormModal, {
+      global: { plugins: [createPinia()] },
+      props: { visible: true, editingClient: null },
+    })
+
+    await wrapper.setProps({
+      editingClient: {
+        id: '5',
+        name: 'qbt',
+        type: 'qbittorrent',
+        host: 'qbittorrent.local',
+        port: 8080,
+        isEnabled: true,
+        useSSL: false,
+        downloadPath: '',
+        username: '',
+        password: '',
+        settings: {},
+      },
+    })
+    await wrapper.vm.$nextTick()
+
+    const urlBaseInput = wrapper.find('input[id="urlBase"]')
+    expect(urlBaseInput.exists()).toBe(true)
+
+    await urlBaseInput.setValue('/qbittorrent')
+
+    const testButton = wrapper.find('button.btn-info')
+    await testButton.trigger('click')
+
+    expect(api.testDownloadClient as unknown).toHaveBeenCalled()
+    const calledWith = (api.testDownloadClient as unknown).mock.calls[0][0]
+    expect(calledWith.settings.urlBase).toBe('/qbittorrent')
+  })
 })

--- a/fe/src/components/domain/download/DownloadClientFormModal.vue
+++ b/fe/src/components/domain/download/DownloadClientFormModal.vue
@@ -116,15 +116,22 @@
               </Checkbox>
             </div>
 
-            <div class="form-group" v-if="formData.type === 'transmission'">
+            <div class="form-group" v-if="showUrlBase">
               <label for="urlBase">URL Base</label>
               <input
                 id="urlBase"
                 v-model="formData.urlBase"
                 type="text"
-                placeholder="/transmission/rpc"
+                :placeholder="getUrlBasePlaceholder()"
               />
-              <small
+              <small v-if="formData.type === 'qbittorrent'"
+                >Path prefix for qBittorrent instances behind a reverse proxy (e.g.
+                <code>/qbittorrent</code>). Must match the prefix your reverse proxy strips before
+                forwarding to qBittorrent's own root-relative API - qBittorrent itself has no
+                built-in base path setting. Leave blank if qBittorrent is reachable directly at the
+                host/port above.</small
+              >
+              <small v-else
                 >RPC path for the Transmission endpoint. Default is <code>/transmission/rpc</code>.
                 Some seedbox providers use a custom path (e.g. <code>/rpc</code>).</small
               >
@@ -496,6 +503,14 @@ const getPortHelpText = () => {
   return hints[formData.value.type] || 'Port the download client is listening on.'
 }
 
+const showUrlBase = computed(() => {
+  return formData.value.type === 'transmission' || formData.value.type === 'qbittorrent'
+})
+
+const getUrlBasePlaceholder = () => {
+  return formData.value.type === 'qbittorrent' ? '/qbittorrent' : '/transmission/rpc'
+}
+
 const getCategoryHelp = () => {
   if (isUsenet.value) {
     return 'Adding a category specific to Listenarr avoids conflicts with unrelated non-Listenarr downloads. Using a category is optional, but strongly recommended.'
@@ -593,9 +608,7 @@ const testConnection = async () => {
         ...(formData.value.type === 'sabnzbd' && formData.value.apiKey
           ? { apiKey: formData.value.apiKey }
           : {}),
-        ...(formData.value.type === 'transmission' && formData.value.urlBase
-          ? { urlBase: formData.value.urlBase }
-          : {}),
+        ...(showUrlBase.value && formData.value.urlBase ? { urlBase: formData.value.urlBase } : {}),
         ...(formData.value.category && { category: formData.value.category }),
         ...(formData.value.tags && { tags: formData.value.tags }),
         recentPriority: formData.value.recentPriority,
@@ -653,9 +666,7 @@ const handleSubmit = async () => {
         ...(formData.value.type === 'sabnzbd' && formData.value.apiKey
           ? { apiKey: formData.value.apiKey }
           : {}),
-        ...(formData.value.type === 'transmission' && formData.value.urlBase
-          ? { urlBase: formData.value.urlBase }
-          : {}),
+        ...(showUrlBase.value && formData.value.urlBase ? { urlBase: formData.value.urlBase } : {}),
         ...(formData.value.category && { category: formData.value.category }),
         ...(formData.value.tags && { tags: formData.value.tags }),
         recentPriority: formData.value.recentPriority,

--- a/listenarr.infrastructure/DownloadClients/Qbittorrent/QBittorrentHelpers.cs
+++ b/listenarr.infrastructure/DownloadClients/Qbittorrent/QBittorrentHelpers.cs
@@ -69,5 +69,37 @@ namespace Listenarr.Infrastructure.DownloadClients.Qbittorrent
                 logger.LogInformation("Fetching qBittorrent queue filtered by category: {Category}", category);
             }
         }
+
+        /// <summary>
+        /// Builds the base URL used for every qBittorrent WebAPI call, including an optional
+        /// "urlBase" path prefix from client settings (e.g. "/qbittorrent") for instances that
+        /// sit behind a reverse proxy at a path prefix.
+        /// Unlike Transmission's urlBase (which replaces the whole RPC path to match Transmission's
+        /// own configurable --rpc-url-base setting), qBittorrent has no equivalent server-side base
+        /// path setting, so this is a plain prefix prepended before the fixed "/api/v2/..." routes -
+        /// it must match whatever prefix the reverse proxy strips before forwarding to qBittorrent.
+        /// </summary>
+        /// <param name="client">The download client configuration providing host/port and settings.</param>
+        /// <returns>The authority (scheme://host:port) with the normalized urlBase prefix appended, if configured.</returns>
+        public static string BuildBaseUrl(DownloadClientConfiguration client)
+        {
+            var authority = DownloadClientUriBuilder.BuildAuthority(client);
+            var prefix = ResolveUrlBasePrefix(client);
+            return prefix.Length == 0 ? authority : authority + prefix;
+        }
+
+        private static string ResolveUrlBasePrefix(DownloadClientConfiguration client)
+        {
+            if (client.Settings?.TryGetValue("urlBase", out var urlBaseObj) is true)
+            {
+                var trimmed = urlBaseObj?.ToString()?.Trim().TrimEnd('/');
+                if (!string.IsNullOrEmpty(trimmed))
+                {
+                    return trimmed.StartsWith('/') ? trimmed : "/" + trimmed;
+                }
+            }
+
+            return string.Empty;
+        }
     }
 }

--- a/listenarr.infrastructure/DownloadClients/Qbittorrent/QBittorrentHelpers.cs
+++ b/listenarr.infrastructure/DownloadClients/Qbittorrent/QBittorrentHelpers.cs
@@ -95,6 +95,17 @@ namespace Listenarr.Infrastructure.DownloadClients.Qbittorrent
                 var trimmed = urlBaseObj?.ToString()?.Trim().TrimEnd('/');
                 if (!string.IsNullOrEmpty(trimmed))
                 {
+                    // A pasted full URL (e.g. "https://seedbox.example.com/qbittorrent") would
+                    // otherwise be concatenated onto the authority as-is, producing a broken URL
+                    // instead of a clear error. Reject anything that parses as an absolute URI -
+                    // this field only accepts a path.
+                    if (Uri.TryCreate(trimmed, UriKind.Absolute, out _))
+                    {
+                        throw new QbittorrentException(
+                            $"qBittorrent URL Base must be a path (e.g. \"/qbittorrent\"), not a full URL. " +
+                            $"Remove the scheme and host from \"{trimmed}\" and enter only the path.");
+                    }
+
                     return trimmed.StartsWith('/') ? trimmed : "/" + trimmed;
                 }
             }

--- a/listenarr.infrastructure/DownloadClients/Qbittorrent/QBittorrentHelpers.cs
+++ b/listenarr.infrastructure/DownloadClients/Qbittorrent/QBittorrentHelpers.cs
@@ -97,9 +97,12 @@ namespace Listenarr.Infrastructure.DownloadClients.Qbittorrent
                 {
                     // A pasted full URL (e.g. "https://seedbox.example.com/qbittorrent") would
                     // otherwise be concatenated onto the authority as-is, producing a broken URL
-                    // instead of a clear error. Reject anything that parses as an absolute URI -
-                    // this field only accepts a path.
-                    if (Uri.TryCreate(trimmed, UriKind.Absolute, out _))
+                    // instead of a clear error. Reject only a genuine http/https absolute URI -
+                    // Uri.TryCreate(trimmed, UriKind.Absolute, out _) alone would also match an
+                    // ordinary leading-slash path like "/qbittorrent" as an absolute "file:" URI
+                    // on Unix (though not on Windows), rejecting the placeholder value from this
+                    // field's own help text.
+                    if (DownloadClientUriBuilder.TryParseHttpOrHttpsAbsoluteUri(trimmed, out _))
                     {
                         throw new QbittorrentException(
                             $"qBittorrent URL Base must be a path (e.g. \"/qbittorrent\"), not a full URL. " +

--- a/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentAddWorkflow.cs
+++ b/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentAddWorkflow.cs
@@ -28,7 +28,7 @@ namespace Listenarr.Infrastructure.DownloadClients.Qbittorrent
                 throw new DownloadClientSubmissionException("qBittorrent requires a prepared torrent submission.");
             }
 
-            var baseUrl = DownloadClientUriBuilder.BuildAuthority(client);
+            var baseUrl = QBittorrentHelpers.BuildBaseUrl(client);
             using var httpClient = httpClientFactory.CreateClient(clientType);
 
             try

--- a/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentAuthSession.cs
+++ b/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentAuthSession.cs
@@ -24,7 +24,7 @@ namespace Listenarr.Infrastructure.DownloadClients.Qbittorrent
 
         public async Task<bool> LoginAsync(HttpClient httpClient, DownloadClientConfiguration client, CancellationToken cancellationToken = default)
         {
-            var baseUrl = DownloadClientUriBuilder.BuildAuthority(client);
+            var baseUrl = QBittorrentHelpers.BuildBaseUrl(client);
 
             using var loginData = new FormUrlEncodedContent(
             [

--- a/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentConnectionTester.cs
+++ b/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentConnectionTester.cs
@@ -37,7 +37,7 @@ namespace Listenarr.Infrastructure.DownloadClients.Qbittorrent
         {
             try
             {
-                var baseUrl = DownloadClientUriBuilder.BuildAuthority(client);
+                var baseUrl = QBittorrentHelpers.BuildBaseUrl(client);
 
                 using var http = _httpClientFactory.CreateClient(_clientType);
                 using var resp = await http.GetAsync($"{baseUrl}/api/v2/app/version", ct);

--- a/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentConnectionTester.cs
+++ b/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentConnectionTester.cs
@@ -68,6 +68,10 @@ namespace Listenarr.Infrastructure.DownloadClients.Qbittorrent
             {
                 return (false, "Connection timed out.");
             }
+            catch (QbittorrentException exception)
+            {
+                return (false, exception.Message);
+            }
             catch (Exception exception) when (exception is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
             {
                 return (false, "Connection failed.");

--- a/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentImportItemResolver.cs
+++ b/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentImportItemResolver.cs
@@ -118,7 +118,7 @@ namespace Listenarr.Infrastructure.DownloadClients.Qbittorrent
             string hash,
             CancellationToken ct)
         {
-            var baseUrl = DownloadClientUriBuilder.BuildAuthority(client);
+            var baseUrl = QBittorrentHelpers.BuildBaseUrl(client);
 
             try
             {

--- a/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentImportMarkerWorkflow.cs
+++ b/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentImportMarkerWorkflow.cs
@@ -33,7 +33,7 @@ namespace Listenarr.Infrastructure.DownloadClients.Qbittorrent
                 return true; // No-op is success
             }
 
-            var baseUrl = DownloadClientUriBuilder.BuildAuthority(client);
+            var baseUrl = QBittorrentHelpers.BuildBaseUrl(client);
             try
             {
                 using var httpClient = httpClientFactory.CreateClient(clientType);

--- a/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentItemFetchWorkflow.cs
+++ b/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentItemFetchWorkflow.cs
@@ -26,7 +26,7 @@ namespace Listenarr.Infrastructure.DownloadClients.Qbittorrent
             var items = new List<DownloadClientItem>();
             if (client == null) return items;
 
-            var baseUrl = DownloadClientUriBuilder.BuildAuthority(client);
+            var baseUrl = QBittorrentHelpers.BuildBaseUrl(client);
             var categoryFilter = QBittorrentHelpers.BuildCategoryParameter(client.Settings, "&");
 
             try

--- a/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentQueueFetchWorkflow.cs
+++ b/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentQueueFetchWorkflow.cs
@@ -24,7 +24,7 @@ namespace Listenarr.Infrastructure.DownloadClients.Qbittorrent
             if (client == null) return items;
 
             var isMonitorPoll = ids.Count > 0;
-            var baseUrl = DownloadClientUriBuilder.BuildAuthority(client);
+            var baseUrl = QBittorrentHelpers.BuildBaseUrl(client);
 
             try
             {

--- a/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentRemovalWorkflow.cs
+++ b/listenarr.infrastructure/DownloadClients/Qbittorrent/QbittorrentRemovalWorkflow.cs
@@ -34,7 +34,7 @@ namespace Listenarr.Infrastructure.DownloadClients.Qbittorrent
             ArgumentNullException.ThrowIfNull(client);
             if (string.IsNullOrEmpty(id)) throw new ArgumentNullException(nameof(id));
 
-            var baseUrl = DownloadClientUriBuilder.BuildAuthority(client);
+            var baseUrl = QBittorrentHelpers.BuildBaseUrl(client);
 
             try
             {

--- a/tests/Features/Infrastructure/DownloadClients/Qbittorrent/QbittorrentAdapterTests.cs
+++ b/tests/Features/Infrastructure/DownloadClients/Qbittorrent/QbittorrentAdapterTests.cs
@@ -99,6 +99,35 @@ namespace Listenarr.Tests.Features.Infrastructure.DownloadClients.Qbittorrent
         }
 
         [Fact]
+        public async Task TestConnection_WithUrlBase_PrefixesApiPath()
+        {
+            var mock = _provider.GetRequiredService<QbittorrentApiMock>();
+
+            var client = await _downloadClientConfigurationRepository.SaveAsync(new DownloadClientConfigurationBuilder()
+                .WithHost("192.168.50.111")
+                .WithPort(8080)
+                .WithoutSsl()
+                .WithType("qbittorrent")
+                .WithUsername("admin")
+                .WithPassword("admin")
+                .WithUrlBase("/qbittorrent")
+                .Build());
+
+            var adapter = _provider.GetRequiredService<IDownloadClientGateway>();
+            var (success, message) = await adapter.TestConnectionAsync(client);
+
+            Assert.True(success);
+            Assert.Contains("Successfully connected to qBittorrent", message, StringComparison.OrdinalIgnoreCase);
+            Assert.NotNull(mock.GetLastRequest());
+
+            var uri = mock.GetLastRequest().RequestUri;
+            // Unlike Transmission's urlBase (which replaces the whole RPC path to match Transmission's
+            // own --rpc-url-base setting), qBittorrent has no equivalent server-side base path setting,
+            // so urlBase is a plain prefix: the fixed "/api/v2/..." routes must still follow it.
+            Assert.Equal("/qbittorrent/api/v2/app/version", uri.AbsolutePath);
+        }
+
+        [Fact]
         public async Task AddAsync_WhenMagnetAndTorrentUrlAreProvided_UsesVerifiedMagnetHashWithoutDownloading()
         {
             var downloader = new Mock<ITorrentFileDownloader>(MockBehavior.Strict);

--- a/tests/Features/Infrastructure/DownloadClients/Qbittorrent/QbittorrentAdapterTests.cs
+++ b/tests/Features/Infrastructure/DownloadClients/Qbittorrent/QbittorrentAdapterTests.cs
@@ -128,6 +128,26 @@ namespace Listenarr.Tests.Features.Infrastructure.DownloadClients.Qbittorrent
         }
 
         [Fact]
+        public async Task TestConnection_WithFullUrlAsUrlBase_ReturnsClearError()
+        {
+            var client = await _downloadClientConfigurationRepository.SaveAsync(new DownloadClientConfigurationBuilder()
+                .WithHost("192.168.50.111")
+                .WithPort(8080)
+                .WithoutSsl()
+                .WithType("qbittorrent")
+                .WithUsername("admin")
+                .WithPassword("admin")
+                .WithUrlBase("https://seedbox.example.com/qbittorrent")
+                .Build());
+
+            var adapter = _provider.GetRequiredService<IDownloadClientGateway>();
+            var (success, message) = await adapter.TestConnectionAsync(client);
+
+            Assert.False(success);
+            Assert.Contains("URL Base must be a path", message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
         public async Task AddAsync_WhenMagnetAndTorrentUrlAreProvided_UsesVerifiedMagnetHashWithoutDownloading()
         {
             var downloader = new Mock<ITorrentFileDownloader>(MockBehavior.Strict);


### PR DESCRIPTION
## Summary

Adds a "URL Base" field to the qBittorrent download client (closes #690), so Listenarr can reach qBittorrent instances served behind a path-prefixed reverse proxy (e.g. `example.com/qbittorrent`) — matching the field Transmission's client already has.

I deliberately didn't just copy Transmission's mechanism. Transmission's `urlBase` *replaces* its whole RPC path, because that mirrors Transmission's own daemon setting (`--rpc-url-base`) — Listenarr just matches whatever arbitrary path the user configured server-side. qBittorrent has no equivalent: I checked upstream, and a native WebUI base-path setting has been proposed twice (qbittorrent/qBittorrent#21471, closed unmerged; #23467, still open/unmerged) — neither has shipped. So every real qBittorrent-behind-a-proxy deployment today works by the *reverse proxy* stripping a path prefix before it reaches qBittorrent, which always serves at its own root regardless. That means the correct semantics here are a prefix prepended before the fixed `/api/v2/...` routes, not a full-path override.

## Changes

### Added
- `QBittorrentHelpers.BuildBaseUrl()` — composes authority + normalized `urlBase` prefix from client settings; no-op when unset, so existing configs are unaffected
- "URL Base" field now renders for qBittorrent in the download client form, with qBittorrent-specific placeholder/help text (distinct from Transmission's field, since the semantics differ)
- Backend test asserting the actual HTTP request hits `/qbittorrent/api/v2/app/version` when configured
- Frontend test asserting the field renders for qBittorrent and flows into the save/test payload

### Changed
- The 8 qBittorrent workflow files that each independently called `DownloadClientUriBuilder.BuildAuthority(client)` now go through the new helper instead (mechanical, one line each — no other behavior change)

## Testing
- `dotnet build` / `dotnet format --verify-no-changes` clean
- Targeted backend tests (qBittorrent + Transmission): 71/71 pass
- Full backend suite: 1185/1190 pass (5 pre-existing failures unrelated to this change — diacritics-normalization tests that only fail in an ICU-less sandbox, not a normal dev setup)
- Frontend: Prettier / `vue-tsc` clean, full suite 393/393 pass
- **Manually tested against a real reverse-proxied qBittorrent instance** and confirmed the connection works with the new URL Base field set

## Notes

**AI assistance disclosure:** this PR was developed with Claude Code's assistance - the implementation (the helper, the 8-file sweep, the frontend field, and the tests) was written by Claude Code. My role was directing the approach and validating the result: I pushed back on an initial draft that assumed we should just copy Transmission's urlBase mechanism, which prompted the investigation that found qBittorrent needs different (prefix, not replace) semantics - that upstream research and the resulting design decision are reflected above. I also manually tested this against my own qBittorrent instance behind a real reverse proxy and confirmed it resolves the actual problem reported in #690, which is real, live validation beyond the automated test suite. I have not done a line-by-line manual read of the full diff myself - flagging that plainly since this is my first PR on a project I don't maintain, and I'd rather be upfront about the split between direction/testing and code-writing than imply a level of manual review that didn't happen.

One unrelated thing noticed while auditing every place qBittorrent builds a URL: there are 5 separate, independently-written login implementations across these files (pre-existing, not introduced by this change), and only one of them sets a `Referrer` header that qBittorrent's CSRF check can care about. It shouldn't interact with `urlBase` (qBittorrent's CSRF/Referer check is origin-based, not path-based), so I left it alone here, but it seemed worth mentioning in case it's the cause of a future report like "Test Connection works but adding a torrent fails."
