### PR TITLE
Add "Date Added" sort option to the library

### DIFF
--- a/fe/src/__tests__/AudiobooksView.spec.ts
+++ b/fe/src/__tests__/AudiobooksView.spec.ts
@@ -796,3 +796,82 @@ describe('AudiobooksView Grouping', () => {
     expect(wrapper.find('.series-bottom-placard').exists()).toBe(true)
   })
 })
+
+describe('AudiobooksView Date Added sorting', () => {
+  beforeEach(() => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+  })
+
+  it('sorts by date-added (file import date) with fileless books last', async () => {
+    if (
+      typeof (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver === 'undefined'
+    ) {
+      ;(globalThis as unknown as Record<string, unknown>).ResizeObserver = class {
+        observe() {}
+        disconnect() {}
+      }
+    }
+    if (typeof (globalThis as unknown as { WebSocket?: unknown }).WebSocket === 'undefined') {
+      ;(globalThis as unknown as Record<string, unknown>).WebSocket = function () {
+        /* noop */
+      }
+    }
+
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'home', component: { template: '<div />' } },
+        { path: '/audiobooks', name: 'audiobooks', component: AudiobooksView },
+      ],
+    })
+    await router.push('/audiobooks')
+    await router.isReady().catch(() => {})
+
+    const store = useLibraryStore()
+    store.audiobooks = [
+      { id: 1, title: 'Oldest', authors: ['A'], dateDownloaded: '2023-01-01T00:00:00Z', files: [] },
+      { id: 2, title: 'Newest', authors: ['A'], dateDownloaded: '2025-06-01T00:00:00Z', files: [] },
+      { id: 3, title: 'Middle', authors: ['A'], dateDownloaded: '2024-03-15T00:00:00Z', files: [] },
+      { id: 4, title: 'No File', authors: ['A'], files: [] }, // no dateDownloaded
+    ] as unknown as import('@/types').Audiobook[]
+    store.fetchLibrary = vi.fn(async () => undefined)
+
+    const wrapper = mount(AudiobooksView, {
+      global: {
+        plugins: [pinia, router],
+        stubs: ['BulkEditModal', 'EditAudiobookModal', 'CustomFilterModal', 'FiltersDropdown', 'CustomSelect'],
+      },
+    })
+    await new Promise((r) => setTimeout(r, 0))
+
+    const vm = wrapper.vm as unknown as {
+      sortKey: string
+      sortOrder: string
+      groupBy: string
+      setGroupBy?: (value: string) => Promise<void> | void
+      audiobooks: Array<{ title?: string }>
+      sortOptions: Array<{ value: string; label: string }>
+    }
+
+    // Ensure we're in the flat books view (grouping may persist from other tests)
+    await vm.setGroupBy?.('books')
+    await wrapper.vm.$nextTick()
+
+    // The 'Date Added' option is offered when grouping by books
+    expect(vm.sortOptions.map((o) => o.value)).toContain('date-added')
+
+    // Descending: newest first, book with no file last
+    vm.sortKey = 'date-added'
+    vm.sortOrder = 'desc'
+    await wrapper.vm.$nextTick()
+    expect(vm.audiobooks.map((a) => a.title)).toEqual(['Newest', 'Middle', 'Oldest', 'No File'])
+
+    // Ascending: oldest first, book with no file still last
+    vm.sortOrder = 'asc'
+    await wrapper.vm.$nextTick()
+    expect(vm.audiobooks.map((a) => a.title)).toEqual(['Oldest', 'Middle', 'Newest', 'No File'])
+  })
+})

--- a/fe/src/__tests__/AudiobooksView.spec.ts
+++ b/fe/src/__tests__/AudiobooksView.spec.ts
@@ -873,5 +873,15 @@ describe('AudiobooksView Date Added sorting', () => {
     vm.sortOrder = 'asc'
     await wrapper.vm.$nextTick()
     expect(vm.audiobooks.map((a) => a.title)).toEqual(['Oldest', 'Middle', 'Newest', 'No File'])
+
+    // Selecting 'date-added' via the toolbar defaults to descending (newest first)
+    const vmProxy = wrapper.vm as unknown as { sortKey: string; sortOrder: string; sortKeyProxy: string }
+    vmProxy.sortKey = 'title'
+    vmProxy.sortOrder = 'asc'
+    await wrapper.vm.$nextTick()
+    vmProxy.sortKeyProxy = 'date-added'
+    await wrapper.vm.$nextTick()
+    expect(vmProxy.sortKey).toBe('date-added')
+    expect(vmProxy.sortOrder).toBe('desc')
   })
 })

--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -756,6 +756,9 @@ export interface Audiobook {
   wanted?: boolean
   // Server-computed list status used by slim /library responses.
   status?: AudiobookStatus
+  // When the earliest file for this audiobook was imported (UTC ISO string); undefined for
+  // audiobooks with no tracked files yet. Used for "Date Added" sorting.
+  dateDownloaded?: string
 }
 
 export interface AudiobookUpdateRequest {

--- a/fe/src/views/library/AudiobooksView.vue
+++ b/fe/src/views/library/AudiobooksView.vue
@@ -1167,6 +1167,18 @@ const filteredAndSortedAudiobooks = computed(() => {
         av = (a.publishYear || '').toString().toLowerCase()
         bv = (b.publishYear || '').toString().toLowerCase()
         break
+      case 'date-added': {
+        // Sort by when the earliest file was imported. Audiobooks with no file yet
+        // (no dateDownloaded) always sort last, regardless of ascending/descending.
+        const at = a.dateDownloaded ? Date.parse(a.dateDownloaded) : NaN
+        const bt = b.dateDownloaded ? Date.parse(b.dateDownloaded) : NaN
+        const aMissing = Number.isNaN(at)
+        const bMissing = Number.isNaN(bt)
+        if (aMissing && bMissing) return 0
+        if (aMissing) return 1
+        if (bMissing) return -1
+        return (at - bt) * (sortOrder.value === 'asc' ? 1 : -1)
+      }
       case 'monitored':
         av = !!a.monitored
         bv = !!b.monitored
@@ -1557,6 +1569,7 @@ const sortOptions = computed(() => {
       { value: 'narrator-first', label: 'Narrator First Name' },
       { value: 'publisher', label: 'Publisher' },
       { value: 'year', label: 'Release Year' },
+      { value: 'date-added', label: 'Date Added' },
       { value: 'monitored', label: 'Monitored' },
       { value: 'status', label: 'Status' },
     ]

--- a/fe/src/views/library/AudiobooksView.vue
+++ b/fe/src/views/library/AudiobooksView.vue
@@ -1599,7 +1599,8 @@ const sortKeyProxy = computed<string>({
       sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
     } else {
       sortKey.value = val
-      sortOrder.value = 'asc'
+      // "Date Added" is most useful newest-first, so default it to descending.
+      sortOrder.value = val === 'date-added' ? 'desc' : 'asc'
     }
   },
 })

--- a/listenarr.application/Audiobooks/Catalog/LibraryAudiobookListItem.cs
+++ b/listenarr.application/Audiobooks/Catalog/LibraryAudiobookListItem.cs
@@ -47,5 +47,11 @@ namespace Listenarr.Application.Audiobooks.Catalog
         public string[]? AuthorAsins { get; set; }
         public bool Wanted { get; set; }
         public string Status { get; set; } = string.Empty;
+
+        /// <summary>
+        /// When the audiobook's earliest file was imported (UTC). Null for audiobooks that
+        /// have no tracked files yet (e.g. wanted books). Used for "Date Added" sorting.
+        /// </summary>
+        public DateTime? DateDownloaded { get; set; }
     }
 }

--- a/listenarr.application/Audiobooks/Catalog/LibraryListService.cs
+++ b/listenarr.application/Audiobooks/Catalog/LibraryListService.cs
@@ -69,6 +69,7 @@ namespace Listenarr.Application.Audiobooks.Catalog
             // was started on this context instance" under real database latency.
             var fileSummaryRows = await _audiobookFileRepository.GetFormatSummariesAsync();
             var fileCountById = await _audiobookFileRepository.GetCountsByAudiobookIdAsync();
+            var earliestFileDateById = await _audiobookFileRepository.GetEarliestCreatedAtByAudiobookIdAsync();
             var membershipsByAudiobookId = await _audiobookRepository.GetAllSeriesMembershipsGroupedByAudiobookIdAsync();
             var filesByAudiobookId = fileSummaryRows
                 .GroupBy(f => f.AudiobookId)
@@ -146,7 +147,10 @@ namespace Listenarr.Application.Audiobooks.Catalog
                          hasAnyFile,
                          a.Quality,
                          qualityProfile,
-                         files)
+                         files),
+                    DateDownloaded = earliestFileDateById.TryGetValue(a.Id, out var earliestFileDate)
+                        ? earliestFileDate
+                        : (DateTime?)null
                 };
             }).ToList();
         }

--- a/listenarr.application/Audiobooks/Contracts/Repositories/IAudiobookFileRepository.cs
+++ b/listenarr.application/Audiobooks/Contracts/Repositories/IAudiobookFileRepository.cs
@@ -86,5 +86,6 @@ namespace Listenarr.Application.Audiobooks.Contracts.Repositories
             CancellationToken ct = default);
         Task<List<AudiobookFormatSummary>> GetFormatSummariesAsync(CancellationToken ct = default);
         Task<Dictionary<int, int>> GetCountsByAudiobookIdAsync(CancellationToken ct = default);
+        Task<Dictionary<int, DateTime>> GetEarliestCreatedAtByAudiobookIdAsync(CancellationToken ct = default);
     }
 }

--- a/listenarr.infrastructure/Persistence/Repositories/EfAudiobookFileRepository.cs
+++ b/listenarr.infrastructure/Persistence/Repositories/EfAudiobookFileRepository.cs
@@ -434,5 +434,14 @@ namespace Listenarr.Infrastructure.Persistence.Repositories
                     ownership.Reason),
                 _ => throw new ArgumentOutOfRangeException(nameof(ownership))
             };
+
+        public async Task<Dictionary<int, DateTime>> GetEarliestCreatedAtByAudiobookIdAsync(CancellationToken ct = default)
+        {
+            return await _db.AudiobookFiles
+                .AsNoTracking()
+                .GroupBy(f => f.AudiobookId)
+                .Select(g => new { AudiobookId = g.Key, EarliestCreatedAt = g.Min(f => f.CreatedAt) })
+                .ToDictionaryAsync(r => r.AudiobookId, r => r.EarliestCreatedAt, ct);
+        }
     }
 }


### PR DESCRIPTION
Implements #778

### What

Adds a **"Date Added"** option to the Audiobooks (books) sort dropdown, sorting by when each audiobook's earliest file was imported.

### How

- **Backend (no schema change):** new `IAudiobookFileRepository.GetEarliestCreatedAtByAudiobookIdAsync` — `Min(CreatedAt)` grouped by audiobook, mirroring the existing `GetCountsByAudiobookIdAsync`. Surfaced as `LibraryAudiobookListItem.DateDownloaded` in the slim `/library` payload. Reuses the existing `AudiobookFile.CreatedAt`, so no migration.
- **Frontend:** new `Date Added` sort option + comparator in `AudiobooksView`. Audiobooks with no tracked file yet (e.g. wanted books) have no date and **always sort last**, in both ascending and descending order.
- **Test:** extends `AudiobooksView.spec.ts` — asserts ascending/descending order and fileless-last placement, and that the option is exposed in the books grouping.

### Design note / open question

This treats **file-import date** as the "added" date, since `Audiobook` has no dedicated timestamp today. If you'd prefer a canonical `Added` column on `Audiobook` (Sonarr/Radarr-style, set on add + backfilled) so wanted books also get a date, I'm happy to take it that direction instead — just wanted to keep this PR minimal and migration-free. See #778.

### Testing

- `dotnet build` — clean (0 warnings)
- `vue-tsc` type-check — clean
- `vitest run AudiobooksView.spec.ts` — 11/11 pass (incl. the new date-added test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
