### PR TITLE
fix(ffmpeg): point macOS at evermeet's ffprobe archive, not its ffmpeg one

### DIFF
--- a/listenarr.infrastructure/Ffmpeg/Installation/FfprobePlatformDefaults.cs
+++ b/listenarr.infrastructure/Ffmpeg/Installation/FfprobePlatformDefaults.cs
@@ -25,20 +25,49 @@ namespace Listenarr.Infrastructure.Ffmpeg.Installation
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
-                {
-                    return "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz";
-                }
-
-                return "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz";
+                return GetDownloadUrl(OSPlatform.Linux, RuntimeInformation.OSArchitecture);
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return "https://evermeet.cx/ffmpeg/ffmpeg-6.0.zip";
+                return GetDownloadUrl(OSPlatform.OSX, RuntimeInformation.OSArchitecture);
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return GetDownloadUrl(OSPlatform.Windows, RuntimeInformation.OSArchitecture);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Resolves the archive URL for an explicit platform, so the mapping for every platform can
+        /// be asserted from a test host running on any one of them.
+        /// </summary>
+        /// <remarks>
+        /// Two constraints apply to anything returned here. The archive has to contain ffprobe:
+        /// the Linux and Windows builds ship a bundle carrying both binaries, but evermeet
+        /// publishes one binary per archive, so macOS needs the ffprobe archive and not the ffmpeg
+        /// one. The URL also has to end in a suffix <see cref="FfprobeArchiveExtractor"/>
+        /// recognises, which rules out endpoints that redirect to the current release without
+        /// naming a file.
+        /// </remarks>
+        internal static string? GetDownloadUrl(OSPlatform platform, Architecture architecture)
+        {
+            if (platform == OSPlatform.Linux)
+            {
+                return architecture == Architecture.Arm64
+                    ? "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-arm64-static.tar.xz"
+                    : "https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz";
+            }
+
+            if (platform == OSPlatform.OSX)
+            {
+                return "https://evermeet.cx/ffmpeg/ffprobe-6.0.zip";
+            }
+
+            if (platform == OSPlatform.Windows)
             {
                 return "https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-essentials.zip";
             }

--- a/tests/Features/Infrastructure/Ffmpeg/Installation/FfprobePlatformDefaultsTests.cs
+++ b/tests/Features/Infrastructure/Ffmpeg/Installation/FfprobePlatformDefaultsTests.cs
@@ -1,0 +1,113 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Runtime.InteropServices;
+
+// Aliased because `Listenarr.Tests.Features.Architecture` is an enclosing namespace here, and a
+// namespace member wins over the type of the same name.
+using Arch = System.Runtime.InteropServices.Architecture;
+
+namespace Listenarr.Tests.Features.Infrastructure.Ffmpeg.Installation
+{
+    [Trait("Name", "FfprobePlatformDefaultsTests")]
+    [Trait("Category", "FfmpegService")]
+    public class FfprobePlatformDefaultsTests
+    {
+        // Suffixes FfprobeArchiveExtractor dispatches on. A URL outside this set downloads fine and
+        // then extracts nothing, which is the failure mode that hid the macOS bug: the install log
+        // shows a successful download and no binary ever appears.
+        private static readonly string[] ExtractableSuffixes = [".zip", ".tar.xz", ".tar.gz", ".tgz"];
+
+        public static TheoryData<OSPlatform, Arch> AllPlatforms() => new()
+        {
+            { OSPlatform.Linux, Arch.X64 },
+            { OSPlatform.Linux, Arch.Arm64 },
+            { OSPlatform.OSX, Arch.X64 },
+            { OSPlatform.Windows, Arch.X64 },
+        };
+
+        [Theory]
+        [MemberData(nameof(AllPlatforms))]
+        [Trait("Method", "GetDownloadUrl")]
+        public void GetDownloadUrl_ReturnsAnArchiveTheExtractorCanOpen(
+            OSPlatform platform,
+            Arch architecture)
+        {
+            var url = FfprobePlatformDefaults.GetDownloadUrl(platform, architecture);
+
+            Assert.NotNull(url);
+            Assert.Contains(
+                ExtractableSuffixes,
+                suffix => url!.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        [Trait("Method", "GetDownloadUrl")]
+        public void GetDownloadUrl_ForMacOs_PointsAtTheFfprobeArchive()
+        {
+            // evermeet ships a separate archive per binary, so the ffmpeg archive contains no
+            // ffprobe at all and the install can never succeed on macOS.
+            var url = FfprobePlatformDefaults.GetDownloadUrl(OSPlatform.OSX, Arch.X64);
+
+            Assert.NotNull(url);
+            var fileName = url!.Split('/')[^1];
+            Assert.Contains("ffprobe", fileName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllPlatforms))]
+        [Trait("Method", "GetDownloadUrl")]
+        public void GetDownloadUrl_IsServedOverHttps(OSPlatform platform, Arch architecture)
+        {
+            var url = FfprobePlatformDefaults.GetDownloadUrl(platform, architecture);
+
+            Assert.NotNull(url);
+            Assert.StartsWith("https://", url, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        [Trait("Method", "GetDownloadUrl")]
+        public void GetDownloadUrl_ForLinux_DistinguishesArm64FromX64()
+        {
+            var x64 = FfprobePlatformDefaults.GetDownloadUrl(OSPlatform.Linux, Arch.X64);
+            var arm64 = FfprobePlatformDefaults.GetDownloadUrl(OSPlatform.Linux, Arch.Arm64);
+
+            Assert.NotEqual(x64, arm64);
+            Assert.Contains("arm64", arm64!, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        [Trait("Method", "GetDownloadUrl")]
+        public void GetDownloadUrl_ForAnUnsupportedPlatform_ReturnsNull()
+        {
+            Assert.Null(FfprobePlatformDefaults.GetDownloadUrl(OSPlatform.FreeBSD, Arch.X64));
+        }
+
+        [Fact]
+        [Trait("Method", "GetDownloadUrl")]
+        public void GetDownloadUrl_WithoutArguments_MatchesTheHostPlatform()
+        {
+            var expected = FfprobePlatformDefaults.GetDownloadUrl(
+                OperatingSystem.IsWindows() ? OSPlatform.Windows
+                    : OperatingSystem.IsMacOS() ? OSPlatform.OSX
+                    : OSPlatform.Linux,
+                RuntimeInformation.OSArchitecture);
+
+            Assert.Equal(expected, FfprobePlatformDefaults.GetDownloadUrl());
+        }
+    }
+}

--- a/tests/Features/Infrastructure/Ffmpeg/Installation/FfprobePlatformDefaultsTests.cs
+++ b/tests/Features/Infrastructure/Ffmpeg/Installation/FfprobePlatformDefaultsTests.cs
@@ -1,0 +1,114 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Runtime.InteropServices;
+using Listenarr.Tests.Common;
+
+// Aliased because `Listenarr.Tests.Features.Architecture` is an enclosing namespace here, and a
+// namespace member wins over the type of the same name.
+using Arch = System.Runtime.InteropServices.Architecture;
+
+namespace Listenarr.Tests.Features.Infrastructure.Ffmpeg.Installation
+{
+    [Trait("Name", "FfprobePlatformDefaultsTests")]
+    [Trait("Category", "FfmpegService")]
+    public class FfprobePlatformDefaultsTests : BaseTests
+    {
+        // Suffixes FfprobeArchiveExtractor dispatches on. A URL outside this set downloads fine and
+        // then extracts nothing, which is the failure mode that hid the macOS bug: the install log
+        // shows a successful download and no binary ever appears.
+        private static readonly string[] ExtractableSuffixes = [".zip", ".tar.xz", ".tar.gz", ".tgz"];
+
+        public static TheoryData<OSPlatform, Arch> AllPlatforms() => new()
+        {
+            { OSPlatform.Linux, Arch.X64 },
+            { OSPlatform.Linux, Arch.Arm64 },
+            { OSPlatform.OSX, Arch.X64 },
+            { OSPlatform.Windows, Arch.X64 },
+        };
+
+        [Theory]
+        [MemberData(nameof(AllPlatforms))]
+        [Trait("Method", "GetDownloadUrl")]
+        public void GetDownloadUrl_ReturnsAnArchiveTheExtractorCanOpen(
+            OSPlatform platform,
+            Arch architecture)
+        {
+            var url = FfprobePlatformDefaults.GetDownloadUrl(platform, architecture);
+
+            Assert.NotNull(url);
+            Assert.Contains(
+                ExtractableSuffixes,
+                suffix => url!.EndsWith(suffix, StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        [Trait("Method", "GetDownloadUrl")]
+        public void GetDownloadUrl_ForMacOs_PointsAtTheFfprobeArchive()
+        {
+            // evermeet ships a separate archive per binary, so the ffmpeg archive contains no
+            // ffprobe at all and the install can never succeed on macOS.
+            var url = FfprobePlatformDefaults.GetDownloadUrl(OSPlatform.OSX, Arch.X64);
+
+            Assert.NotNull(url);
+            var fileName = url!.Split('/')[^1];
+            Assert.Contains("ffprobe", fileName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllPlatforms))]
+        [Trait("Method", "GetDownloadUrl")]
+        public void GetDownloadUrl_IsServedOverHttps(OSPlatform platform, Arch architecture)
+        {
+            var url = FfprobePlatformDefaults.GetDownloadUrl(platform, architecture);
+
+            Assert.NotNull(url);
+            Assert.StartsWith("https://", url, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        [Trait("Method", "GetDownloadUrl")]
+        public void GetDownloadUrl_ForLinux_DistinguishesArm64FromX64()
+        {
+            var x64 = FfprobePlatformDefaults.GetDownloadUrl(OSPlatform.Linux, Arch.X64);
+            var arm64 = FfprobePlatformDefaults.GetDownloadUrl(OSPlatform.Linux, Arch.Arm64);
+
+            Assert.NotEqual(x64, arm64);
+            Assert.Contains("arm64", arm64!, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        [Trait("Method", "GetDownloadUrl")]
+        public void GetDownloadUrl_ForAnUnsupportedPlatform_ReturnsNull()
+        {
+            Assert.Null(FfprobePlatformDefaults.GetDownloadUrl(OSPlatform.FreeBSD, Arch.X64));
+        }
+
+        [Fact]
+        [Trait("Method", "GetDownloadUrl")]
+        public void GetDownloadUrl_WithoutArguments_MatchesTheHostPlatform()
+        {
+            var expected = FfprobePlatformDefaults.GetDownloadUrl(
+                OperatingSystem.IsWindows() ? OSPlatform.Windows
+                    : OperatingSystem.IsMacOS() ? OSPlatform.OSX
+                    : OSPlatform.Linux,
+                RuntimeInformation.OSArchitecture);
+
+            Assert.Equal(expected, FfprobePlatformDefaults.GetDownloadUrl());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #777. The bundled ffprobe install can never succeed on macOS. The platform default points at evermeet's **ffmpeg** archive, and evermeet ships one binary per archive, so the download succeeds and the extractor then finds no `ffprobe` entry to install. Metadata import stays broken on every Mac.

evermeet publishes ffprobe as its own archive at the same version, so pointing macOS there fixes the install without touching any other platform.

## Changes

### Fixed
- macOS now downloads `https://evermeet.cx/ffmpeg/ffprobe-6.0.zip` rather than `ffmpeg-6.0.zip`. The version is the same, so this changes which artifact is fetched and nothing about how it is handled.

### Added
- An internal `GetDownloadUrl(OSPlatform, Architecture)` overload, so the mapping for every platform can be asserted from a test host running on any one of them. The public no-argument method behaves as it did and now delegates to it.
- `FfprobePlatformDefaultsTests`, covering the macOS regression and two invariants that hold for every platform.

## Testing

Checked against the live archives before changing anything:

```
$ curl -sSL https://evermeet.cx/ffmpeg/ffmpeg-6.0.zip -o ffmpeg-6.0.zip   # what macOS fetches today
$ unzip -l ffmpeg-6.0.zip
 78829164  2023-02-27 21:33   ffmpeg          <- one entry, no ffprobe

$ curl -sSL https://evermeet.cx/ffmpeg/ffprobe-6.0.zip -o ffprobe-6.0.zip
$ unzip -l ffprobe-6.0.zip
 78744828  2023-02-27 21:33   ffprobe

$ file ffprobe
ffprobe: Mach-O 64-bit x86_64 executable
```

x86_64 is the right architecture to want here, since the project publishes `osx-x64` only. On macOS it is therefore always an x64 process, running natively on Intel and under Rosetta on Apple Silicon.

12 new unit tests. The full backend suite passes locally on .NET 10, 1201 tests.

Two of the new tests assert invariants rather than a specific string, because a URL constant by itself is not worth a test:

- the filename has to name ffprobe on macOS, which is the regression fixed here.
- the URL has to end in a suffix the extractor dispatches on. `FfprobeArchiveExtractor` picks zip or tar handling from the URL suffix, so a URL outside `.zip`, `.tar.xz`, `.tar.gz` and `.tgz` downloads cleanly and then extracts nothing. That is worth guarding for this fix specifically. evermeet has a `getrelease/ffprobe/zip` endpoint that redirects to the current release, which looks like the tidier thing to point at and would fail quietly, because the URL ends in `/zip`. Naming the file avoids it.

## Notes

This is the narrow fix. Two related things I left out rather than fold in.

macOS stays on ffprobe 6.0. evermeet's current release is 8.1.2 and there is a versioned `.zip` URL for it, but I cannot execute a Mach-O binary on the Linux machine I tested from, so I cannot show that a version bump leaves the fields `FfprobeMetadataMapper` reads unchanged. That wants its own change and its own evidence.

`GetChecksum()` still returns `null`, so this download stays unverified, as the Linux and Windows ones are. That is the wider half of #777: the platform defaults are unpinned and unverified, and macOS is where it happens to be fatal rather than merely risky. The durable answer is the second option in that issue, switching the defaults to the `github:` provider path with a pinned release and a checksum, which covers all three platforms at once. `FfmpegService` already has that machinery, including `Provider`, `ReleaseOverride`, `Arch`, `ChecksumUrl`, `FfprobeGithubAssetDiscoverer` and abort-on-mismatch, so what is left is choosing a source to pin to and deciding whether you want that behaviour change for existing Linux and Windows users. I am happy to build it if you do.

One thing worth knowing in the meantime: the `github:` provider is not gated on the platform default being null and overrides it whenever discovery succeeds. A Mac user can unblock themselves today by setting `Ffmpeg.Provider`, without waiting for a release.
