### PR TITLE
fix: use MaM's tor[searchType] parameter for filter options

### DIFF
--- a/listenarr.infrastructure/Search/Providers/MyAnonamouse/MyAnonamouseRequestFactory.cs
+++ b/listenarr.infrastructure/Search/Providers/MyAnonamouse/MyAnonamouseRequestFactory.cs
@@ -82,26 +82,20 @@ internal static class MyAnonamouseRequestFactory
             queryParameters.Add(new($"tor[srchIn][{field.Key}]", field.Value ? "true" : "false"));
         }
 
-        queryParameters.Add(new("tor[searchType]", searchType));
-
-        switch (request?.MyAnonamouse?.Filter)
+        // MaM uses tor[searchType] for both text-search mode (title/author/all) and
+        // content filters (active, fl, nVIP, etc.). A filter takes precedence over the
+        // text-search mode value, so resolve the final value once and add it once.
+        var filterValue = request?.MyAnonamouse?.Filter switch
         {
-            case MamTorrentFilter.Active:
-                queryParameters.Add(new("tor[onlyActive]", "1"));
-                break;
-            case MamTorrentFilter.Freeleech:
-                queryParameters.Add(new("tor[onlyFreeleech]", "1"));
-                break;
-            case MamTorrentFilter.FreeleechOrVip:
-                queryParameters.Add(new("tor[freeleechOrVip]", "1"));
-                break;
-            case MamTorrentFilter.Vip:
-                queryParameters.Add(new("tor[onlyVip]", "1"));
-                break;
-            case MamTorrentFilter.NotVip:
-                queryParameters.Add(new("tor[notVip]", "1"));
-                break;
-        }
+            MamTorrentFilter.Active         => "active",
+            MamTorrentFilter.Freeleech      => "fl",
+            MamTorrentFilter.FreeleechOrVip => "fl-VIP",
+            MamTorrentFilter.Vip            => "VIP",
+            MamTorrentFilter.NotVip         => "nVIP",
+            _                               => null
+        };
+
+        queryParameters.Add(new("tor[searchType]", filterValue ?? searchType));
 
         if (request?.MyAnonamouse?.FreeleechWedge is { } freeleechWedge)
         {


### PR DESCRIPTION
## Summary

Fixes #805

All MaM filter options (Active, Freeleech, Freeleech or VIP, VIP only, Not VIP) were silently broken. Listenarr was sending unrecognised boolean parameters that MaM ignores, returning unfiltered results regardless of the configured setting.

MaM's API uses a single `tor[searchType]` parameter with specific string values for content filters. This PR replaces the five separate boolean parameters with the correct values, matching Prowlarr's working implementation as a reference.

| Filter | Before (broken) | After (fixed) |
|---|---|---|
| Active | `tor[onlyActive]=1` | `tor[searchType]=active` |
| Freeleech | `tor[onlyFreeleech]=1` | `tor[searchType]=fl` |
| Freeleech or VIP | `tor[freeleechOrVip]=1` | `tor[searchType]=fl-VIP` |
| VIP only | `tor[onlyVip]=1` | `tor[searchType]=VIP` |
| Not VIP | `tor[notVip]=1` | `tor[searchType]=nVIP` |

## Test plan

- [ ] Configure MaM indexer with **Not VIP** filter
- [ ] Search for a title with both VIP and non-VIP results on MaM (e.g. *Ready Player Two* by Ernest Cline)
- [ ] Confirm only non-VIP results are returned
- [ ] Repeat for other filter values (Freeleech, VIP only, etc.)

**Empirically confirmed on canary:** Not VIP filter returned 5 results (including 3 VIP) before this fix, and 1 result (non-VIP only) after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)