### PR TITLE
feat(integrations): Audiobookshelf connection with post-import scan trigger

### DIFF
--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -22,6 +22,8 @@ import type {
   DownloadClientConfiguration,
   ApplicationSettings,
   ProwlarrImportConnectionSettings,
+  AudiobookshelfConnectionSettings,
+  AudiobookshelfActionResult,
   Audiobook,
   History,
   Indexer,
@@ -876,6 +878,40 @@ class ApiService {
 
   async getProwlarrImportSettings(): Promise<ProwlarrImportConnectionSettings> {
     return this.request<ProwlarrImportConnectionSettings>('/configuration/prowlarr-import')
+  }
+
+  // Audiobookshelf integration
+  async getAudiobookshelfSettings(): Promise<AudiobookshelfConnectionSettings> {
+    return this.request<AudiobookshelfConnectionSettings>('/configuration/audiobookshelf')
+  }
+
+  async saveAudiobookshelfSettings(
+    settings: AudiobookshelfConnectionSettings,
+  ): Promise<AudiobookshelfConnectionSettings> {
+    return this.request<AudiobookshelfConnectionSettings>('/configuration/audiobookshelf', {
+      method: 'POST',
+      body: JSON.stringify(settings),
+    })
+  }
+
+  async testAudiobookshelfConnection(payload: {
+    url?: string
+    apiKey?: string
+  }): Promise<AudiobookshelfActionResult> {
+    return this.request<AudiobookshelfActionResult>('/audiobookshelf/test', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+  }
+
+  async getAudiobookshelfLibraries(): Promise<AudiobookshelfActionResult> {
+    return this.request<AudiobookshelfActionResult>('/audiobookshelf/libraries')
+  }
+
+  async triggerAudiobookshelfScan(): Promise<AudiobookshelfActionResult> {
+    return this.request<AudiobookshelfActionResult>('/audiobookshelf/scan', {
+      method: 'POST',
+    })
   }
 
   // Root Folders

--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -377,6 +377,26 @@ export interface ProwlarrImportConnectionSettings {
   hasSavedApiKey: boolean
 }
 
+export interface AudiobookshelfConnectionSettings {
+  url: string
+  apiKey?: string | null
+  libraryId?: string | null
+  notifyOnImport: boolean
+  hasSavedApiKey: boolean
+}
+
+export interface AudiobookshelfLibrary {
+  id: string
+  name: string
+  mediaType: string
+}
+
+export interface AudiobookshelfActionResult {
+  success: boolean
+  message: string
+  libraries?: AudiobookshelfLibrary[] | null
+}
+
 export interface StartupConfig {
   logLevel?: string
   enableSsl?: boolean

--- a/fe/src/views/SettingsView.vue
+++ b/fe/src/views/SettingsView.vue
@@ -85,6 +85,14 @@
             Discord Bot
           </button>
           <button
+            @click="router.push({ hash: '#audiobookshelf' })"
+            :class="{ active: activeTab === 'audiobookshelf' }"
+            class="tab-button"
+          >
+            <PhBooks />
+            Audiobookshelf
+          </button>
+          <button
             @click="router.push({ hash: '#general' })"
             :class="{ active: activeTab === 'general' }"
             class="tab-button"
@@ -257,6 +265,8 @@
         ref="notificationsRef"
         :settings="settings"
       />
+
+      <AudiobookshelfTab v-if="activeTab === 'audiobookshelf'" />
     </div>
 
     <!-- Metadata Source Configuration Modal -->
@@ -400,6 +410,7 @@ import RootFoldersTab from '@/views/settings/RootFoldersTab.vue'
 import DownloadClientsTab from '@/views/settings/DownloadClientsTab.vue'
 import QualityProfilesTab from '@/views/settings/QualityProfilesTab.vue'
 import DiscordBotTab from '@/views/settings/DiscordBotTab.vue'
+import AudiobookshelfTab from '@/views/settings/AudiobookshelfTab.vue'
 import NotificationsTab from '@/views/settings/NotificationsTab.vue'
 import IndexersTab from '@/views/settings/IndexersTab.vue'
 import { Modal, ModalHeader, ModalFooter } from '@/components/feedback'
@@ -414,6 +425,7 @@ import {
   PhStar,
   PhBell,
   PhGlobe,
+  PhBooks,
   PhSliders,
   PhPlus,
   PhSpinner,
@@ -450,7 +462,14 @@ logger.debug(
   (globalThis as unknown as { __vitest?: unknown }).__vitest,
 )
 const activeTab = ref<
-  'rootfolders' | 'indexers' | 'clients' | 'quality-profiles' | 'notifications' | 'bot' | 'general'
+  | 'rootfolders'
+  | 'indexers'
+  | 'clients'
+  | 'quality-profiles'
+  | 'notifications'
+  | 'bot'
+  | 'audiobookshelf'
+  | 'general'
 >('rootfolders')
 
 const mobileTabOptions = computed(() => [
@@ -460,6 +479,7 @@ const mobileTabOptions = computed(() => [
   { value: 'quality-profiles', label: 'Quality Profiles', icon: PhStar },
   { value: 'notifications', label: 'Notifications', icon: PhBell },
   { value: 'bot', label: 'Discord Bot', icon: PhGlobe },
+  { value: 'audiobookshelf', label: 'Audiobookshelf', icon: PhBooks },
   { value: 'general', label: 'General Settings', icon: PhSliders },
   // Integrations removed
 ])
@@ -1124,6 +1144,7 @@ const syncTabFromHash = () => {
     | 'quality-profiles'
     | 'notifications'
     | 'bot'
+    | 'audiobookshelf'
     | 'general'
   if (
     hash &&
@@ -1134,6 +1155,7 @@ const syncTabFromHash = () => {
       'quality-profiles',
       'notifications',
       'bot',
+      'audiobookshelf',
       'general',
     ].includes(hash)
   ) {

--- a/fe/src/views/library/AudiobookDetailView.vue
+++ b/fe/src/views/library/AudiobookDetailView.vue
@@ -680,6 +680,7 @@ import {
   PhArrowLeft,
   PhArrowClockwise,
   PhBookmark,
+  PhBooks,
   PhSpinner,
   PhMagnifyingGlass,
   PhFolderOpen,
@@ -732,6 +733,8 @@ const deleteFilesOnDisk = ref(false)
 const deleteFolderOnDisk = ref(false)
 const showFullDescription = ref(false)
 const scanning = ref(false)
+const audiobookshelfScanning = ref(false)
+const audiobookshelfConfigured = ref(false)
 const rescanningMetadata = ref(false)
 const scanQueued = ref(false)
 const scanJobId = ref<string | null>(null)
@@ -833,6 +836,23 @@ const topActions = computed<DetailTopAction[]>(() => [
       showOrganizeModal.value = true
     },
   },
+  ...(audiobookshelfConfigured.value
+    ? [
+        {
+          key: 'audiobookshelf-scan' as const,
+          label: audiobookshelfScanning.value ? 'Updating Audiobookshelf...' : 'Update Audiobookshelf',
+          title: 'Request an Audiobookshelf scan so this book shows up there',
+          ariaLabel: 'Update Audiobookshelf',
+          icon: audiobookshelfScanning.value ? PhSpinner : PhBooks,
+          iconClass: audiobookshelfScanning.value ? 'ph-spin' : undefined,
+          disabled: audiobookshelfScanning.value,
+          desktopGroup: 'secondary' as const,
+          onClick: () => {
+            void updateAudiobookshelf()
+          },
+        },
+      ]
+    : []),
   {
     key: 'delete',
     label: 'Delete',
@@ -878,6 +898,7 @@ type DetailTopAction = {
     | 'edit'
     | 'rescan-metadata'
     | 'organize'
+    | 'audiobookshelf-scan'
     | 'delete'
   label: string
   title: string
@@ -1186,6 +1207,19 @@ onMounted(async () => {
   syncActiveTabFromRoute()
   document.addEventListener('click', handleClickOutside)
 
+  // Show the Audiobookshelf action only when the integration is configured
+  // (typeof guard keeps partial apiService mocks in tests working)
+  if (typeof apiService.getAudiobookshelfSettings === 'function') {
+    void apiService
+      .getAudiobookshelfSettings()
+      .then((settings) => {
+        audiobookshelfConfigured.value = Boolean(settings.url && settings.hasSavedApiKey)
+      })
+      .catch(() => {
+        audiobookshelfConfigured.value = false
+      })
+  }
+
   await loadAudiobook()
 
   // subscribe to scan job updates
@@ -1451,6 +1485,28 @@ function handleDownloaded(result: SearchResult) {
   const toast = useToast()
   toast.success('Download Added', `${result.title} has been sent to your download client`)
   closeManualSearch()
+}
+
+async function updateAudiobookshelf() {
+  const toast = useToast()
+  audiobookshelfScanning.value = true
+  try {
+    const result = await apiService.triggerAudiobookshelfScan()
+    if (result.success) {
+      toast.success('Audiobookshelf', result.message)
+    } else {
+      toast.error('Audiobookshelf scan failed', result.message)
+    }
+  } catch (err) {
+    errorTracking.captureException(err as Error, {
+      component: 'AudiobookDetailView',
+      operation: 'updateAudiobookshelf',
+      metadata: { audiobookId: audiobook.value?.id },
+    })
+    toast.error('Audiobookshelf scan failed', 'Could not reach the Listenarr API')
+  } finally {
+    audiobookshelfScanning.value = false
+  }
 }
 
 async function scanFiles() {

--- a/fe/src/views/library/CollectionView.vue
+++ b/fe/src/views/library/CollectionView.vue
@@ -311,6 +311,17 @@
               <component v-else :is="isCurrentSeriesMonitored ? PhEye : PhPlus" />
               {{ isCurrentSeriesMonitored ? 'Monitoring Series' : 'Monitor Series' }}
             </button>
+            <button
+              v-if="audiobookshelfConfigured"
+              class="toolbar-btn"
+              :disabled="audiobookshelfScanning"
+              @click="updateAudiobookshelf"
+              title="Request an Audiobookshelf scan so new books in this series show up there"
+            >
+              <PhArrowClockwise v-if="audiobookshelfScanning" class="spin-icon" />
+              <PhBooks v-else />
+              {{ audiobookshelfScanning ? 'Updating Audiobookshelf...' : 'Update Audiobookshelf' }}
+            </button>
           </div>
         </div>
         <div class="toolbar-filters">
@@ -879,6 +890,8 @@ const seriesLookup = ref<SeriesLookupResponse | null>(null)
 const seriesLookupLoading = ref(false)
 const seriesLookupRequestId = ref(0)
 const seriesMetadataRefreshBusy = ref(false)
+const audiobookshelfScanning = ref(false)
+const audiobookshelfConfigured = ref(false)
 const seriesMonitoringBusy = ref(false)
 const seriesMonitoringStatus = ref<MonitoredSeries | null>(null)
 const seriesMonitoringStatusRequestId = ref(0)
@@ -1970,6 +1983,28 @@ async function refreshSeriesMetadata() {
   }
 }
 
+async function updateAudiobookshelf() {
+  if (audiobookshelfScanning.value) return
+  audiobookshelfScanning.value = true
+  try {
+    const result = await apiService.triggerAudiobookshelfScan()
+    if (result.success) {
+      toast.success('Audiobookshelf', result.message)
+    } else {
+      toast.error('Audiobookshelf scan failed', result.message)
+    }
+  } catch (err) {
+    errorTracking.captureException(err as Error, {
+      component: 'CollectionView',
+      operation: 'updateAudiobookshelf',
+      metadata: { series: name.value },
+    })
+    toast.error('Audiobookshelf scan failed', 'Could not reach the Listenarr API')
+  } finally {
+    audiobookshelfScanning.value = false
+  }
+}
+
 const goBack = () => {
   router.back()
 }
@@ -2287,6 +2322,18 @@ function handleCheckboxKeydown(audiobook: CollectionDisplayItem, event: Keyboard
 }
 
 onMounted(async () => {
+  // Show the Audiobookshelf action only when the integration is configured
+  // (typeof guard keeps partial apiService mocks in tests working)
+  if (typeof apiService.getAudiobookshelfSettings === 'function') {
+    void apiService
+      .getAudiobookshelfSettings()
+      .then((settings) => {
+        audiobookshelfConfigured.value = Boolean(settings.url && settings.hasSavedApiKey)
+      })
+      .catch(() => {
+        audiobookshelfConfigured.value = false
+      })
+  }
   await loadCollectionData(false)
 })
 

--- a/fe/src/views/settings/AudiobookshelfTab.vue
+++ b/fe/src/views/settings/AudiobookshelfTab.vue
@@ -1,0 +1,280 @@
+<!--
+  Listenarr - Audiobook Management System
+  Copyright (C) 2024-2026 Listenarr Contributors
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published
+  by the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <https://www.gnu.org/licenses/>.
+-->
+<template>
+  <div class="tab-content">
+    <div class="audiobookshelf-tab">
+      <div class="section-header">
+        <h3>
+          Audiobookshelf
+          <PhSpinner v-if="loading" class="ph-spin small-inline-spinner" />
+        </h3>
+      </div>
+
+      <div class="form-section">
+        <p class="section-description">
+          Connect an Audiobookshelf server so it picks up books imported by Listenarr without a
+          manual library scan. Useful when Audiobookshelf's folder watcher cannot see file changes
+          (network shares, separate hosts).
+        </p>
+
+        <FormRow
+          label="Server URL"
+          help="Base URL of your Audiobookshelf server, e.g. http://audiobookshelf:13378"
+        >
+          <input v-model="url" type="text" placeholder="http://audiobookshelf:13378" />
+        </FormRow>
+
+        <FormRow
+          label="API Token"
+          :help="
+            hasSavedApiKey
+              ? 'A token is saved. Leave blank to keep it, or enter a new one to replace it.'
+              : 'An Audiobookshelf API token with admin permissions (Settings → Users → your user → API Token).'
+          "
+        >
+          <div class="password-field">
+            <input
+              v-model="apiKey"
+              :type="showApiKey ? 'text' : 'password'"
+              :placeholder="hasSavedApiKey ? '(unchanged)' : 'Audiobookshelf API token'"
+              autocomplete="off"
+            />
+            <button
+              type="button"
+              class="icon-button"
+              :title="showApiKey ? 'Hide token' : 'Show token'"
+              @click="showApiKey = !showApiKey"
+            >
+              <PhEyeSlash v-if="showApiKey" />
+              <PhEye v-else />
+            </button>
+          </div>
+        </FormRow>
+
+        <FormRow
+          label="Library"
+          help="Which Audiobookshelf library to scan. With 'All book libraries', every library with media type 'book' is scanned."
+        >
+          <CustomSelect v-model="libraryId" :options="libraryOptions" />
+        </FormRow>
+
+        <CheckboxCard
+          v-model="notifyOnImport"
+          title="Scan automatically after import"
+          description="Request an Audiobookshelf scan whenever Listenarr imports files (downloads and manual uploads). Bursts of imports are coalesced into a single scan."
+        />
+
+        <div class="actions-row">
+          <button class="btn btn-primary" :disabled="saving" @click="save">
+            <PhSpinner v-if="saving" class="ph-spin" />
+            <PhFloppyDisk v-else />
+            {{ saving ? 'Saving...' : 'Save' }}
+          </button>
+          <button class="btn" :disabled="testing || !url" @click="testConnection">
+            <PhSpinner v-if="testing" class="ph-spin" />
+            <PhPlugs v-else />
+            {{ testing ? 'Testing...' : 'Test Connection' }}
+          </button>
+          <button class="btn" :disabled="scanning || !canScan" @click="scanNow">
+            <PhSpinner v-if="scanning" class="ph-spin" />
+            <PhArrowsClockwise v-else />
+            {{ scanning ? 'Scanning...' : 'Scan Now' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { apiService } from '@/services/api'
+import { useToast } from '@/services/toastService'
+import { errorTracking } from '@/services/errorTracking'
+import type { AudiobookshelfLibrary } from '@/types'
+import {
+  PhArrowsClockwise,
+  PhEye,
+  PhEyeSlash,
+  PhFloppyDisk,
+  PhPlugs,
+  PhSpinner,
+} from '@phosphor-icons/vue'
+import FormRow from '@/components/settings/FormRow.vue'
+import CheckboxCard from '@/components/settings/CheckboxCard.vue'
+import CustomSelect from '@/components/form/CustomSelect.vue'
+
+const toast = useToast()
+
+const loading = ref(false)
+const saving = ref(false)
+const testing = ref(false)
+const scanning = ref(false)
+const showApiKey = ref(false)
+
+const url = ref('')
+const apiKey = ref('')
+const libraryId = ref<string | null>('')
+const notifyOnImport = ref(false)
+const hasSavedApiKey = ref(false)
+const libraries = ref<AudiobookshelfLibrary[]>([])
+
+// Scan Now uses the saved connection server-side, so it needs a saved token
+const canScan = computed(() => Boolean(url.value && hasSavedApiKey.value))
+
+const libraryOptions = computed(() => {
+  const options = [{ value: '', label: 'All book libraries' }]
+  for (const library of libraries.value) {
+    options.push({
+      value: library.id,
+      label: library.mediaType === 'book' ? library.name : `${library.name} (${library.mediaType})`,
+    })
+  }
+  // Keep a configured id selectable even before the library list has loaded
+  if (libraryId.value && !options.some((o) => o.value === libraryId.value)) {
+    options.push({ value: libraryId.value, label: libraryId.value })
+  }
+  return options
+})
+
+onMounted(async () => {
+  loading.value = true
+  try {
+    const settings = await apiService.getAudiobookshelfSettings()
+    url.value = settings.url ?? ''
+    libraryId.value = settings.libraryId ?? ''
+    notifyOnImport.value = settings.notifyOnImport
+    hasSavedApiKey.value = settings.hasSavedApiKey
+    if (settings.url && settings.hasSavedApiKey) {
+      const result = await apiService.getAudiobookshelfLibraries()
+      if (result.success && result.libraries) {
+        libraries.value = result.libraries
+      }
+    }
+  } catch (error) {
+    errorTracking.captureException(error as Error, {
+      component: 'AudiobookshelfTab',
+      operation: 'load',
+    })
+    toast.error('Load failed', 'Could not load Audiobookshelf settings')
+  } finally {
+    loading.value = false
+  }
+})
+
+const save = async () => {
+  saving.value = true
+  try {
+    const saved = await apiService.saveAudiobookshelfSettings({
+      url: url.value.trim(),
+      apiKey: apiKey.value.trim() || undefined,
+      libraryId: libraryId.value || '',
+      notifyOnImport: notifyOnImport.value,
+      hasSavedApiKey: hasSavedApiKey.value,
+    })
+    hasSavedApiKey.value = saved.hasSavedApiKey
+    apiKey.value = ''
+    toast.success('Saved', 'Audiobookshelf settings saved')
+  } catch (error) {
+    errorTracking.captureException(error as Error, {
+      component: 'AudiobookshelfTab',
+      operation: 'save',
+    })
+    toast.error('Save failed', 'Could not save Audiobookshelf settings')
+  } finally {
+    saving.value = false
+  }
+}
+
+const testConnection = async () => {
+  testing.value = true
+  try {
+    const result = await apiService.testAudiobookshelfConnection({
+      url: url.value.trim() || undefined,
+      apiKey: apiKey.value.trim() || undefined,
+    })
+    if (result.success) {
+      if (result.libraries) {
+        libraries.value = result.libraries
+      }
+      toast.success('Connected', result.message)
+    } else {
+      toast.error('Connection failed', result.message)
+    }
+  } catch (error) {
+    errorTracking.captureException(error as Error, {
+      component: 'AudiobookshelfTab',
+      operation: 'test',
+    })
+    toast.error('Connection failed', 'Could not reach the Listenarr API')
+  } finally {
+    testing.value = false
+  }
+}
+
+const scanNow = async () => {
+  scanning.value = true
+  try {
+    const result = await apiService.triggerAudiobookshelfScan()
+    if (result.success) {
+      toast.success('Scan requested', result.message)
+    } else {
+      toast.error('Scan failed', result.message)
+    }
+  } catch (error) {
+    errorTracking.captureException(error as Error, {
+      component: 'AudiobookshelfTab',
+      operation: 'scan',
+    })
+    toast.error('Scan failed', 'Could not reach the Listenarr API')
+  } finally {
+    scanning.value = false
+  }
+}
+</script>
+
+<style scoped>
+.section-description {
+  margin: 0 0 1.25rem;
+  color: #adb5bd;
+  line-height: 1.5;
+}
+
+.password-field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.password-field input {
+  flex: 1;
+}
+
+.actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.actions-row .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+</style>

--- a/listenarr.api/Features/Audiobookshelf/AudiobookshelfController.cs
+++ b/listenarr.api/Features/Audiobookshelf/AudiobookshelfController.cs
@@ -1,0 +1,77 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Api.Attributes;
+using Listenarr.Application.Integrations.Audiobookshelf.Contracts;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Api.Features.Audiobookshelf
+{
+    [ApiController]
+    [Route("api/v{version:apiVersion}/audiobookshelf")]
+    [RequireAdminOrApiKey]
+    [Tags("Audiobookshelf")]
+    public class AudiobookshelfController : ControllerBase
+    {
+        private readonly IAudiobookshelfService _audiobookshelfService;
+
+        public AudiobookshelfController(IAudiobookshelfService audiobookshelfService)
+        {
+            _audiobookshelfService = audiobookshelfService;
+        }
+
+        /// <summary>
+        /// Test connectivity to an Audiobookshelf server. Blank fields fall back to the
+        /// saved connection, so a saved configuration can be re-tested without re-entering
+        /// the API token. Returns the server's libraries on success.
+        /// </summary>
+        [HttpPost("test")]
+        public async Task<ActionResult<object>> TestConnection([FromBody] AudiobookshelfTestRequestDto? request, CancellationToken cancellationToken)
+        {
+            var result = await _audiobookshelfService.TestConnectionAsync(request?.Url, request?.ApiKey, cancellationToken);
+            return Ok(new { success = result.Success, message = result.Message, libraries = result.Libraries });
+        }
+
+        /// <summary>
+        /// List libraries from the configured Audiobookshelf server (for the settings library picker).
+        /// </summary>
+        [HttpGet("libraries")]
+        public async Task<ActionResult<object>> GetLibraries(CancellationToken cancellationToken)
+        {
+            var result = await _audiobookshelfService.GetLibrariesAsync(cancellationToken);
+            return Ok(new { success = result.Success, message = result.Message, libraries = result.Libraries });
+        }
+
+        /// <summary>
+        /// Request an Audiobookshelf scan of the configured library (or all book libraries),
+        /// so newly imported files show up without a manual scan in Audiobookshelf.
+        /// </summary>
+        [HttpPost("scan")]
+        public async Task<ActionResult<object>> TriggerScan(CancellationToken cancellationToken)
+        {
+            var result = await _audiobookshelfService.TriggerScanAsync(cancellationToken);
+            return Ok(new { success = result.Success, message = result.Message });
+        }
+    }
+
+    public sealed class AudiobookshelfTestRequestDto
+    {
+        public string? Url { get; set; }
+        public string? ApiKey { get; set; }
+    }
+}

--- a/listenarr.api/Features/Configuration/SettingsController.cs
+++ b/listenarr.api/Features/Configuration/SettingsController.cs
@@ -114,7 +114,49 @@ namespace Listenarr.Api.Features.Configuration
             clone.AdminUsername = null;
             clone.AdminPassword = null;
             clone.ProwlarrApiKeyEncrypted = null;
+            clone.AudiobookshelfApiKeyEncrypted = null;
             return clone;
+        }
+
+        /// <summary>
+        /// Get the saved Audiobookshelf connection metadata.
+        /// The API token itself is never returned; callers only receive whether a saved token exists.
+        /// </summary>
+        [Tags("Settings")]
+        [HttpGet("audiobookshelf")]
+        public async Task<ActionResult<AudiobookshelfConnectionSettings>> GetAudiobookshelfSettings()
+        {
+            try
+            {
+                var settings = await _configurationService.GetAudiobookshelfSettingsAsync();
+                settings.ApiKey = null;
+                return Ok(settings);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogError(ex, "Error retrieving saved Audiobookshelf settings");
+                return StatusCode(500, "Internal server error");
+            }
+        }
+
+        /// <summary>
+        /// Save the Audiobookshelf connection settings. A blank or redacted API token keeps the saved one.
+        /// </summary>
+        [Tags("Settings")]
+        [HttpPost("audiobookshelf")]
+        public async Task<ActionResult<AudiobookshelfConnectionSettings>> SaveAudiobookshelfSettings([FromBody] AudiobookshelfConnectionSettings settings)
+        {
+            try
+            {
+                var saved = await _configurationService.SaveAudiobookshelfSettingsAsync(settings);
+                saved.ApiKey = null;
+                return Ok(saved);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogError(ex, "Error saving Audiobookshelf settings");
+                return StatusCode(500, new { error = "Failed to save Audiobookshelf settings", message = ex.Message });
+            }
         }
 
         /// <summary>

--- a/listenarr.api/GlobalUsings.cs
+++ b/listenarr.api/GlobalUsings.cs
@@ -47,6 +47,7 @@ global using Listenarr.Domain.Audiobooks.Enumerations;
 global using Listenarr.Domain.Audiobooks.Rules;
 global using Listenarr.Domain.Configuration;
 global using Listenarr.Domain.Downloads;
+global using Listenarr.Domain.Integrations;
 global using Listenarr.Domain.Search;
 global using Listenarr.Domain.SystemDiagnostics;
 global using Listenarr.Domain.SystemDiagnostics.Exceptions;

--- a/listenarr.application/Configuration/Contracts/IConfigurationService.cs
+++ b/listenarr.application/Configuration/Contracts/IConfigurationService.cs
@@ -85,6 +85,18 @@ namespace Listenarr.Application.Configuration.Contracts
         Task<ProwlarrImportConnectionSettings> SaveProwlarrImportSettingsAsync(ProwlarrImportConnectionSettings settings);
 
         /// <summary>
+        /// Gets the saved Audiobookshelf connection settings.
+        /// </summary>
+        /// <param name="includeSecret">When true, includes the decrypted API token for server-side use.</param>
+        Task<AudiobookshelfConnectionSettings> GetAudiobookshelfSettingsAsync(bool includeSecret = false);
+
+        /// <summary>
+        /// Saves the Audiobookshelf connection settings.
+        /// </summary>
+        /// <param name="settings">The connection settings to save.</param>
+        Task<AudiobookshelfConnectionSettings> SaveAudiobookshelfSettingsAsync(AudiobookshelfConnectionSettings settings);
+
+        /// <summary>
         /// Gets the startup configuration
         /// </summary>
         /// <returns>Startup configuration</returns>

--- a/listenarr.application/Configuration/Core/ConfigurationService.Audiobookshelf.cs
+++ b/listenarr.application/Configuration/Core/ConfigurationService.Audiobookshelf.cs
@@ -1,0 +1,111 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Application.Configuration.Core
+{
+    public partial class ConfigurationService
+    {
+        public async Task<AudiobookshelfConnectionSettings> GetAudiobookshelfSettingsAsync(bool includeSecret = false)
+        {
+            try
+            {
+                var settings = await settingsRepository.GetAsync();
+
+                if (settings == null)
+                {
+                    return new AudiobookshelfConnectionSettings();
+                }
+
+                var result = new AudiobookshelfConnectionSettings
+                {
+                    Url = settings.AudiobookshelfUrl?.Trim() ?? string.Empty,
+                    LibraryId = settings.AudiobookshelfLibraryId?.Trim(),
+                    NotifyOnImport = settings.AudiobookshelfNotifyOnImport == true,
+                    HasSavedApiKey = !string.IsNullOrWhiteSpace(settings.AudiobookshelfApiKeyEncrypted),
+                };
+
+                if (includeSecret && result.HasSavedApiKey)
+                {
+                    result.ApiKey = TryUnprotectAudiobookshelfApiKey(settings.AudiobookshelfApiKeyEncrypted);
+                    if (string.IsNullOrWhiteSpace(result.ApiKey))
+                    {
+                        result.HasSavedApiKey = false;
+                    }
+                }
+
+                return result;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                logger.LogError(ex, "Error loading saved Audiobookshelf settings");
+                return new AudiobookshelfConnectionSettings();
+            }
+        }
+
+        public async Task<AudiobookshelfConnectionSettings> SaveAudiobookshelfSettingsAsync(AudiobookshelfConnectionSettings settings)
+        {
+            try
+            {
+                var existing = await settingsRepository.GetAsync() ?? new ApplicationSettings { Id = 1 };
+
+                existing.AudiobookshelfUrl = string.IsNullOrWhiteSpace(settings.Url) ? string.Empty : settings.Url.Trim();
+                existing.AudiobookshelfLibraryId = string.IsNullOrWhiteSpace(settings.LibraryId) ? null : settings.LibraryId.Trim();
+                existing.AudiobookshelfNotifyOnImport = settings.NotifyOnImport;
+
+                if (!string.IsNullOrWhiteSpace(settings.ApiKey)
+                    && !string.Equals(settings.ApiKey, ApiResponseRedactor.RedactedValue, StringComparison.Ordinal))
+                {
+                    existing.AudiobookshelfApiKeyEncrypted = secretProtector.Protect(settings.ApiKey.Trim());
+                }
+                else if (string.IsNullOrWhiteSpace(existing.AudiobookshelfUrl))
+                {
+                    // Clearing the URL disconnects the integration; drop the stored token with it.
+                    existing.AudiobookshelfApiKeyEncrypted = null;
+                }
+
+                await settingsRepository.SaveAsync(existing);
+                return await GetAudiobookshelfSettingsAsync();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                logger.LogError(ex, "Error saving Audiobookshelf settings");
+                throw;
+            }
+        }
+
+        private string? TryUnprotectAudiobookshelfApiKey(string? encryptedApiKey)
+        {
+            if (string.IsNullOrWhiteSpace(encryptedApiKey))
+            {
+                return null;
+            }
+
+            try
+            {
+                return secretProtector.Unprotect(encryptedApiKey);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                logger.LogWarning(ex, "Failed to decrypt saved Audiobookshelf API token");
+                return null;
+            }
+        }
+    }
+}

--- a/listenarr.application/Configuration/Core/ConfigurationService.Prowlarr.cs
+++ b/listenarr.application/Configuration/Core/ConfigurationService.Prowlarr.cs
@@ -1,0 +1,106 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Application.Configuration.Core
+{
+    public partial class ConfigurationService
+    {
+        public async Task<ProwlarrImportConnectionSettings> GetProwlarrImportSettingsAsync(bool includeSecret = false)
+        {
+            try
+            {
+                var settings = await settingsRepository.GetAsync();
+
+                if (settings == null)
+                {
+                    return new ProwlarrImportConnectionSettings();
+                }
+
+                var result = new ProwlarrImportConnectionSettings
+                {
+                    Url = settings.ProwlarrUrl?.Trim() ?? string.Empty,
+                    Port = settings.ProwlarrPort,
+                    TagFilter = settings.ProwlarrTagFilter?.Trim(),
+                    HasSavedApiKey = !string.IsNullOrWhiteSpace(settings.ProwlarrApiKeyEncrypted),
+                };
+
+                if (includeSecret && result.HasSavedApiKey)
+                {
+                    result.ApiKey = TryUnprotectProwlarrApiKey(settings.ProwlarrApiKeyEncrypted);
+                    if (string.IsNullOrWhiteSpace(result.ApiKey))
+                    {
+                        result.HasSavedApiKey = false;
+                    }
+                }
+
+                return result;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                logger.LogError(ex, "Error loading saved Prowlarr import settings");
+                return new ProwlarrImportConnectionSettings();
+            }
+        }
+
+        public async Task<ProwlarrImportConnectionSettings> SaveProwlarrImportSettingsAsync(ProwlarrImportConnectionSettings settings)
+        {
+            try
+            {
+                var existing = await settingsRepository.GetAsync() ?? new ApplicationSettings { Id = 1 };
+
+                existing.ProwlarrUrl = string.IsNullOrWhiteSpace(settings.Url) ? string.Empty : settings.Url.Trim();
+                existing.ProwlarrPort = settings.Port;
+                existing.ProwlarrTagFilter = string.IsNullOrWhiteSpace(settings.TagFilter) ? null : settings.TagFilter.Trim();
+
+                if (!string.IsNullOrWhiteSpace(settings.ApiKey)
+                    && !string.Equals(settings.ApiKey, ApiResponseRedactor.RedactedValue, StringComparison.Ordinal))
+                {
+                    existing.ProwlarrApiKeyEncrypted = secretProtector.Protect(settings.ApiKey.Trim());
+                }
+
+                await settingsRepository.SaveAsync(existing);
+                return await GetProwlarrImportSettingsAsync();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                logger.LogError(ex, "Error saving Prowlarr import settings");
+                throw;
+            }
+        }
+
+        private string? TryUnprotectProwlarrApiKey(string? encryptedApiKey)
+        {
+            if (string.IsNullOrWhiteSpace(encryptedApiKey))
+            {
+                return null;
+            }
+
+            try
+            {
+                return secretProtector.Unprotect(encryptedApiKey);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                logger.LogWarning(ex, "Failed to decrypt saved Prowlarr import API key");
+                return null;
+            }
+        }
+    }
+}

--- a/listenarr.application/Configuration/Core/ConfigurationService.cs
+++ b/listenarr.application/Configuration/Core/ConfigurationService.cs
@@ -21,16 +21,37 @@ using Microsoft.Extensions.Logging;
 
 namespace Listenarr.Application.Configuration.Core
 {
-    public class ConfigurationService(
-        IApplicationSettingsRepository settingsRepository,
-        IApiConfigurationRepository apiConfigRepository,
-        IDownloadClientConfigurationRepository downloadClientRepository,
-        ILogger<ConfigurationService> logger,
-        IUserService userService,
-        IStartupConfigService startupConfigService,
-        IRootFolderRepository rootFolderRepository,
-        ISecretProtector secretProtector) : IConfigurationService
+    public partial class ConfigurationService : IConfigurationService
     {
+        private readonly IApplicationSettingsRepository settingsRepository;
+        private readonly IApiConfigurationRepository apiConfigRepository;
+        private readonly IDownloadClientConfigurationRepository downloadClientRepository;
+        private readonly ILogger<ConfigurationService> logger;
+        private readonly IUserService userService;
+        private readonly IStartupConfigService startupConfigService;
+        private readonly IRootFolderRepository rootFolderRepository;
+        private readonly ISecretProtector secretProtector;
+
+        public ConfigurationService(
+            IApplicationSettingsRepository settingsRepository,
+            IApiConfigurationRepository apiConfigRepository,
+            IDownloadClientConfigurationRepository downloadClientRepository,
+            ILogger<ConfigurationService> logger,
+            IUserService userService,
+            IStartupConfigService startupConfigService,
+            IRootFolderRepository rootFolderRepository,
+            ISecretProtector secretProtector)
+        {
+            this.settingsRepository = settingsRepository;
+            this.apiConfigRepository = apiConfigRepository;
+            this.downloadClientRepository = downloadClientRepository;
+            this.logger = logger;
+            this.userService = userService;
+            this.startupConfigService = startupConfigService;
+            this.rootFolderRepository = rootFolderRepository;
+            this.secretProtector = secretProtector;
+        }
+
         // API Configuration methods
         public async Task<List<ApiConfiguration>> GetApiConfigurationsAsync()
         {
@@ -205,6 +226,17 @@ namespace Listenarr.Application.Configuration.Core
                     {
                         settings.ProwlarrApiKeyEncrypted = existing.ProwlarrApiKeyEncrypted;
                     }
+                    if (settings.AudiobookshelfUrl == null)
+                        settings.AudiobookshelfUrl = existing.AudiobookshelfUrl;
+                    if (settings.AudiobookshelfLibraryId == null)
+                        settings.AudiobookshelfLibraryId = existing.AudiobookshelfLibraryId;
+                    if (settings.AudiobookshelfNotifyOnImport == null)
+                        settings.AudiobookshelfNotifyOnImport = existing.AudiobookshelfNotifyOnImport;
+                    if (string.IsNullOrWhiteSpace(settings.AudiobookshelfApiKeyEncrypted)
+                        || string.Equals(settings.AudiobookshelfApiKeyEncrypted, ApiResponseRedactor.RedactedValue, StringComparison.Ordinal))
+                    {
+                        settings.AudiobookshelfApiKeyEncrypted = existing.AudiobookshelfApiKeyEncrypted;
+                    }
                     if (settings.EnabledNotificationTriggers == null)
                         settings.EnabledNotificationTriggers = existing.EnabledNotificationTriggers;
                     if (settings.Webhooks == null)
@@ -278,87 +310,6 @@ namespace Listenarr.Application.Configuration.Core
             {
                 logger.LogError(ex, "Error saving application settings to database (no runtime ALTERs will be attempted)");
                 throw;
-            }
-        }
-
-        public async Task<ProwlarrImportConnectionSettings> GetProwlarrImportSettingsAsync(bool includeSecret = false)
-        {
-            try
-            {
-                var settings = await settingsRepository.GetAsync();
-
-                if (settings == null)
-                {
-                    return new ProwlarrImportConnectionSettings();
-                }
-
-                var result = new ProwlarrImportConnectionSettings
-                {
-                    Url = settings.ProwlarrUrl?.Trim() ?? string.Empty,
-                    Port = settings.ProwlarrPort,
-                    TagFilter = settings.ProwlarrTagFilter?.Trim(),
-                    HasSavedApiKey = !string.IsNullOrWhiteSpace(settings.ProwlarrApiKeyEncrypted),
-                };
-
-                if (includeSecret && result.HasSavedApiKey)
-                {
-                    result.ApiKey = TryUnprotectProwlarrApiKey(settings.ProwlarrApiKeyEncrypted);
-                    if (string.IsNullOrWhiteSpace(result.ApiKey))
-                    {
-                        result.HasSavedApiKey = false;
-                    }
-                }
-
-                return result;
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
-            {
-                logger.LogError(ex, "Error loading saved Prowlarr import settings");
-                return new ProwlarrImportConnectionSettings();
-            }
-        }
-
-        public async Task<ProwlarrImportConnectionSettings> SaveProwlarrImportSettingsAsync(ProwlarrImportConnectionSettings settings)
-        {
-            try
-            {
-                var existing = await settingsRepository.GetAsync() ?? new ApplicationSettings { Id = 1 };
-
-                existing.ProwlarrUrl = string.IsNullOrWhiteSpace(settings.Url) ? string.Empty : settings.Url.Trim();
-                existing.ProwlarrPort = settings.Port;
-                existing.ProwlarrTagFilter = string.IsNullOrWhiteSpace(settings.TagFilter) ? null : settings.TagFilter.Trim();
-
-                if (!string.IsNullOrWhiteSpace(settings.ApiKey)
-                    && !string.Equals(settings.ApiKey, ApiResponseRedactor.RedactedValue, StringComparison.Ordinal))
-                {
-                    existing.ProwlarrApiKeyEncrypted = secretProtector.Protect(settings.ApiKey.Trim());
-                }
-
-                await settingsRepository.SaveAsync(existing);
-                return await GetProwlarrImportSettingsAsync();
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
-            {
-                logger.LogError(ex, "Error saving Prowlarr import settings");
-                throw;
-            }
-        }
-
-        private string? TryUnprotectProwlarrApiKey(string? encryptedApiKey)
-        {
-            if (string.IsNullOrWhiteSpace(encryptedApiKey))
-            {
-                return null;
-            }
-
-            try
-            {
-                return secretProtector.Unprotect(encryptedApiKey);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
-            {
-                logger.LogWarning(ex, "Failed to decrypt saved Prowlarr import API key");
-                return null;
             }
         }
 

--- a/listenarr.application/GlobalUsings.cs
+++ b/listenarr.application/GlobalUsings.cs
@@ -48,6 +48,7 @@ global using Listenarr.Domain.Audiobooks.Rules;
 global using Listenarr.Domain.Configuration;
 global using Listenarr.Domain.Downloads;
 global using Listenarr.Domain.Identity;
+global using Listenarr.Domain.Integrations;
 global using Listenarr.Domain.Search;
 global using Listenarr.Domain.SystemDiagnostics;
 global using Listenarr.Domain.SystemDiagnostics.Exceptions;

--- a/listenarr.application/Integrations/Audiobookshelf/Contracts/IAudiobookshelfScanScheduler.cs
+++ b/listenarr.application/Integrations/Audiobookshelf/Contracts/IAudiobookshelfScanScheduler.cs
@@ -1,0 +1,29 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace Listenarr.Application.Integrations.Audiobookshelf.Contracts
+{
+    /// <summary>
+    /// Debounced post-import Audiobookshelf scan requests. Signalling is cheap and
+    /// never throws; whether a scan is actually sent is decided by the scheduler
+    /// (integration configured, notify-on-import enabled) when the debounce window closes.
+    /// </summary>
+    public interface IAudiobookshelfScanScheduler
+    {
+        void RequestScan(string reason);
+    }
+}

--- a/listenarr.application/Integrations/Audiobookshelf/Contracts/IAudiobookshelfService.cs
+++ b/listenarr.application/Integrations/Audiobookshelf/Contracts/IAudiobookshelfService.cs
@@ -1,0 +1,42 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Application.Integrations.Audiobookshelf.Models;
+
+namespace Listenarr.Application.Integrations.Audiobookshelf.Contracts
+{
+    public interface IAudiobookshelfService
+    {
+        /// <summary>
+        /// Verifies connectivity by listing libraries. Falls back to the saved URL and/or
+        /// API token when the supplied values are blank or redacted.
+        /// </summary>
+        Task<AudiobookshelfActionResult> TestConnectionAsync(string? url, string? apiKey, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists libraries from the configured Audiobookshelf server.
+        /// </summary>
+        Task<AudiobookshelfActionResult> GetLibrariesAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Requests a scan of the configured library (or of every book library when
+        /// no library id is configured).
+        /// </summary>
+        Task<AudiobookshelfActionResult> TriggerScanAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/listenarr.application/Integrations/Audiobookshelf/Models/AudiobookshelfModels.cs
+++ b/listenarr.application/Integrations/Audiobookshelf/Models/AudiobookshelfModels.cs
@@ -1,0 +1,28 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace Listenarr.Application.Integrations.Audiobookshelf.Models
+{
+    public sealed record AudiobookshelfLibrary(string Id, string Name, string MediaType);
+
+    /// <summary>
+    /// Outcome of an Audiobookshelf API operation. Failures are reported through
+    /// <see cref="Success"/> and <see cref="Message"/> rather than exceptions so
+    /// callers (controllers, background workers) need no broad catch blocks.
+    /// </summary>
+    public sealed record AudiobookshelfActionResult(bool Success, string Message, List<AudiobookshelfLibrary>? Libraries = null);
+}

--- a/listenarr.application/Security/Redaction/ApiResponseRedactor.cs
+++ b/listenarr.application/Security/Redaction/ApiResponseRedactor.cs
@@ -75,6 +75,11 @@ public static class ApiResponseRedactor
             clone.ProwlarrApiKeyEncrypted = RedactedValue;
         }
 
+        if (!string.IsNullOrWhiteSpace(clone.AudiobookshelfApiKeyEncrypted))
+        {
+            clone.AudiobookshelfApiKeyEncrypted = RedactedValue;
+        }
+
         if (clone.Webhooks != null)
         {
             foreach (var webhook in clone.Webhooks.Where(w => !string.IsNullOrWhiteSpace(w.Url)))

--- a/listenarr.domain/Configuration/ApplicationSettings.cs
+++ b/listenarr.domain/Configuration/ApplicationSettings.cs
@@ -200,6 +200,27 @@ namespace Listenarr.Domain.Configuration
         public string? ProwlarrTagFilter { get; set; }
 
         /// <summary>
+        /// Saved Audiobookshelf server URL used by the Audiobookshelf integration.
+        /// </summary>
+        public string? AudiobookshelfUrl { get; set; }
+
+        /// <summary>
+        /// Encrypted Audiobookshelf API token used by the Audiobookshelf integration.
+        /// </summary>
+        public string? AudiobookshelfApiKeyEncrypted { get; set; }
+
+        /// <summary>
+        /// Optional Audiobookshelf library id to scan. When empty, all book libraries are scanned.
+        /// </summary>
+        public string? AudiobookshelfLibraryId { get; set; }
+
+        /// <summary>
+        /// When true, an Audiobookshelf scan is requested automatically after imports.
+        /// Nullable so partial settings payloads preserve the saved value.
+        /// </summary>
+        public bool? AudiobookshelfNotifyOnImport { get; set; }
+
+        /// <summary>
         /// Primary command group name (e.g. "request"). We'll create a slash command with this group and
         /// a subcommand for specific request types (e.g. "audiobook").
         /// </summary>

--- a/listenarr.domain/Integrations/AudiobookshelfConnectionSettings.cs
+++ b/listenarr.domain/Integrations/AudiobookshelfConnectionSettings.cs
@@ -1,0 +1,39 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace Listenarr.Domain.Integrations
+{
+    public class AudiobookshelfConnectionSettings
+    {
+        public string Url { get; set; } = string.Empty;
+        public string? ApiKey { get; set; }
+
+        /// <summary>
+        /// Optional Audiobookshelf library id to scan. When empty, every library
+        /// with mediaType "book" is scanned.
+        /// </summary>
+        public string? LibraryId { get; set; }
+
+        /// <summary>
+        /// When true, Listenarr requests an Audiobookshelf scan automatically after
+        /// files are imported into the library (downloads and manual uploads alike).
+        /// </summary>
+        public bool NotifyOnImport { get; set; }
+
+        public bool HasSavedApiKey { get; set; }
+    }
+}

--- a/listenarr.infrastructure/DependencyInjection/AppServiceRegistrationExtensions.cs
+++ b/listenarr.infrastructure/DependencyInjection/AppServiceRegistrationExtensions.cs
@@ -8,6 +8,7 @@
  * (at your option) any later version.
  */
 using Listenarr.Infrastructure.DependencyInjection.Downloads;
+using Listenarr.Infrastructure.DependencyInjection.Integrations;
 using Listenarr.Infrastructure.DependencyInjection.Library;
 using Listenarr.Infrastructure.DependencyInjection.Metadata;
 using Listenarr.Infrastructure.DependencyInjection.Notifications;
@@ -34,6 +35,7 @@ public static class AppServiceRegistrationExtensions
         services.AddLibraryServices();
         services.AddDownloadServices(configuration);
         services.AddNotificationAndRealtimeServices();
+        services.AddIntegrationServices();
         services.AddSystemDiagnosticServices();
         return services;
     }

--- a/listenarr.infrastructure/DependencyInjection/Integrations/IntegrationRegistrationExtensions.cs
+++ b/listenarr.infrastructure/DependencyInjection/Integrations/IntegrationRegistrationExtensions.cs
@@ -1,0 +1,40 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+using System.Net;
+using Listenarr.Application.Integrations.Audiobookshelf.Contracts;
+using Listenarr.Infrastructure.Integrations.Audiobookshelf;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Listenarr.Infrastructure.DependencyInjection.Integrations;
+
+internal static class IntegrationRegistrationExtensions
+{
+    public static IServiceCollection AddIntegrationServices(this IServiceCollection services)
+    {
+        // Redirects are validated hop-by-hop via OutboundRequestSecurity, so the
+        // handler must not follow them on its own.
+        services.AddHttpClient<AudiobookshelfService>(client => client.Timeout = TimeSpan.FromSeconds(30))
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.All,
+                UseProxy = false,
+                AllowAutoRedirect = false
+            });
+        services.AddTransient<IAudiobookshelfService>(provider =>
+            provider.GetRequiredService<AudiobookshelfService>());
+
+        services.AddSingleton<AudiobookshelfScanScheduler>();
+        services.AddSingleton<IAudiobookshelfScanScheduler>(provider =>
+            provider.GetRequiredService<AudiobookshelfScanScheduler>());
+        services.AddHostedService(provider => provider.GetRequiredService<AudiobookshelfScanScheduler>());
+        return services;
+    }
+}

--- a/listenarr.infrastructure/Integrations/Audiobookshelf/AudiobookshelfScanScheduler.cs
+++ b/listenarr.infrastructure/Integrations/Audiobookshelf/AudiobookshelfScanScheduler.cs
@@ -1,0 +1,114 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Application.Integrations.Audiobookshelf.Contracts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Infrastructure.Integrations.Audiobookshelf;
+
+/// <summary>
+/// Coalesces post-import scan requests into a single Audiobookshelf scan.
+/// Imports often arrive in bursts (multi-book grabs, bulk manual imports); the
+/// trailing-edge debounce waits for a quiet period so one scan covers the whole
+/// burst, and the max-delay cap keeps a long steady trickle from deferring the
+/// scan forever.
+/// </summary>
+public sealed class AudiobookshelfScanScheduler : BackgroundService, IAudiobookshelfScanScheduler
+{
+    private static readonly TimeSpan QuietWindow = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan MaxDelay = TimeSpan.FromMinutes(2);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<AudiobookshelfScanScheduler> _logger;
+    private readonly SemaphoreSlim _signal = new(0);
+
+    public AudiobookshelfScanScheduler(IServiceScopeFactory scopeFactory, ILogger<AudiobookshelfScanScheduler> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public void RequestScan(string reason)
+    {
+        _logger.LogDebug("Audiobookshelf scan requested: {Reason}", reason);
+        _signal.Release();
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await _signal.WaitAsync(stoppingToken);
+
+                // Trailing-edge debounce: each further request restarts the quiet
+                // window, up to MaxDelay from the first request.
+                var deadline = DateTime.UtcNow + MaxDelay;
+                while (DateTime.UtcNow < deadline)
+                {
+                    var moreRequests = await _signal.WaitAsync(QuietWindow, stoppingToken);
+                    if (!moreRequests)
+                    {
+                        break;
+                    }
+                }
+
+                await TriggerScanIfEnabledAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+        }
+    }
+
+    private async Task TriggerScanIfEnabledAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var configurationService = scope.ServiceProvider.GetRequiredService<IConfigurationService>();
+            var settings = await configurationService.GetAudiobookshelfSettingsAsync();
+            if (!settings.NotifyOnImport || string.IsNullOrWhiteSpace(settings.Url) || !settings.HasSavedApiKey)
+            {
+                _logger.LogDebug("Skipping Audiobookshelf post-import scan; integration disabled or not configured");
+                return;
+            }
+
+            var audiobookshelfService = scope.ServiceProvider.GetRequiredService<IAudiobookshelfService>();
+            var result = await audiobookshelfService.TriggerScanAsync(cancellationToken);
+            if (!result.Success)
+            {
+                _logger.LogWarning("Audiobookshelf post-import scan failed: {Message}", result.Message);
+            }
+        }
+        catch (Exception exception) when (exception is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
+        {
+            _logger.LogWarning(exception, "Audiobookshelf post-import scan failed unexpectedly");
+        }
+    }
+
+    public override void Dispose()
+    {
+        _signal.Dispose();
+        base.Dispose();
+    }
+}

--- a/listenarr.infrastructure/Integrations/Audiobookshelf/AudiobookshelfService.cs
+++ b/listenarr.infrastructure/Integrations/Audiobookshelf/AudiobookshelfService.cs
@@ -1,0 +1,249 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Listenarr.Application.Integrations.Audiobookshelf.Contracts;
+using Listenarr.Application.Integrations.Audiobookshelf.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Infrastructure.Integrations.Audiobookshelf;
+
+/// <summary>
+/// Client for the Audiobookshelf server API (https://api.audiobookshelf.org/).
+/// Used to verify connectivity, enumerate libraries, and request library scans so
+/// Audiobookshelf picks up files imported by Listenarr without a manual scan.
+/// </summary>
+public class AudiobookshelfService : IAudiobookshelfService
+{
+    private readonly HttpClient _httpClientNoRedirect;
+    private readonly IConfigurationService _configurationService;
+    private readonly ILogger<AudiobookshelfService> _logger;
+
+    public AudiobookshelfService(
+        HttpClient httpClient,
+        IConfigurationService configurationService,
+        ILogger<AudiobookshelfService> logger)
+    {
+        _httpClientNoRedirect = httpClient;
+        _configurationService = configurationService;
+        _logger = logger;
+    }
+
+    public async Task<AudiobookshelfActionResult> TestConnectionAsync(string? url, string? apiKey, CancellationToken cancellationToken = default)
+    {
+        var saved = await _configurationService.GetAudiobookshelfSettingsAsync(includeSecret: true);
+        var effectiveUrl = string.IsNullOrWhiteSpace(url) ? saved.Url : url.Trim();
+        var effectiveApiKey = string.IsNullOrWhiteSpace(apiKey) || string.Equals(apiKey, ApiResponseRedactor.RedactedValue, StringComparison.Ordinal)
+            ? saved.ApiKey
+            : apiKey.Trim();
+
+        return await FetchLibrariesAsync(effectiveUrl, effectiveApiKey, cancellationToken);
+    }
+
+    public async Task<AudiobookshelfActionResult> GetLibrariesAsync(CancellationToken cancellationToken = default)
+    {
+        var saved = await _configurationService.GetAudiobookshelfSettingsAsync(includeSecret: true);
+        return await FetchLibrariesAsync(saved.Url, saved.ApiKey, cancellationToken);
+    }
+
+    public async Task<AudiobookshelfActionResult> TriggerScanAsync(CancellationToken cancellationToken = default)
+    {
+        var saved = await _configurationService.GetAudiobookshelfSettingsAsync(includeSecret: true);
+        var librariesResult = await FetchLibrariesAsync(saved.Url, saved.ApiKey, cancellationToken);
+        if (!librariesResult.Success || librariesResult.Libraries == null)
+        {
+            return librariesResult;
+        }
+
+        var targets = string.IsNullOrWhiteSpace(saved.LibraryId)
+            ? librariesResult.Libraries.Where(l => string.Equals(l.MediaType, "book", StringComparison.OrdinalIgnoreCase)).ToList()
+            : librariesResult.Libraries.Where(l => string.Equals(l.Id, saved.LibraryId.Trim(), StringComparison.Ordinal)).ToList();
+
+        if (targets.Count == 0)
+        {
+            return new AudiobookshelfActionResult(false, string.IsNullOrWhiteSpace(saved.LibraryId)
+                ? "No book libraries found on the Audiobookshelf server"
+                : "The configured Audiobookshelf library no longer exists");
+        }
+
+        var baseUrl = NormalizeBaseUrl(saved.Url);
+        var scanned = new List<string>();
+        var failed = new List<string>();
+
+        foreach (var library in targets)
+        {
+            var scanUrl = $"{baseUrl}/api/libraries/{Uri.EscapeDataString(library.Id)}/scan";
+            try
+            {
+                using var response = await SendAsync(HttpMethod.Post, scanUrl, saved.ApiKey!, cancellationToken);
+                if (response.IsSuccessStatusCode)
+                {
+                    scanned.Add(library.Name);
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "Audiobookshelf scan request for library {LibraryName} returned {StatusCode}",
+                        library.Name,
+                        (int)response.StatusCode);
+                    failed.Add($"{library.Name} (HTTP {(int)response.StatusCode})");
+                }
+            }
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or UriFormatException or InvalidOperationException)
+            {
+                _logger.LogWarning(ex, "Failed to request Audiobookshelf scan for library {LibraryName}", library.Name);
+                failed.Add(library.Name);
+            }
+        }
+
+        if (scanned.Count == 0)
+        {
+            return new AudiobookshelfActionResult(false, $"Audiobookshelf scan failed for {string.Join(", ", failed)}");
+        }
+
+        var message = failed.Count == 0
+            ? $"Audiobookshelf scan started for {string.Join(", ", scanned)}"
+            : $"Audiobookshelf scan started for {string.Join(", ", scanned)}; failed for {string.Join(", ", failed)}";
+        _logger.LogInformation("{Message}", message);
+        return new AudiobookshelfActionResult(true, message, librariesResult.Libraries);
+    }
+
+    private async Task<AudiobookshelfActionResult> FetchLibrariesAsync(string? url, string? apiKey, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return new AudiobookshelfActionResult(false, "Audiobookshelf URL is not configured");
+        }
+
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            return new AudiobookshelfActionResult(false, "Audiobookshelf API token is not configured");
+        }
+
+        var baseUrl = NormalizeBaseUrl(url);
+        if (!OutboundRequestSecurity.TryValidateExternalHttpUrl(baseUrl, out var blockedReason, allowPrivateTargets: true))
+        {
+            return new AudiobookshelfActionResult(false, $"Blocked Audiobookshelf target: {blockedReason}");
+        }
+
+        try
+        {
+            using var response = await SendAsync(HttpMethod.Get, $"{baseUrl}/api/libraries", apiKey, cancellationToken);
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (response.StatusCode is System.Net.HttpStatusCode.Unauthorized or System.Net.HttpStatusCode.Forbidden)
+            {
+                return new AudiobookshelfActionResult(false, "Audiobookshelf rejected the API token");
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Audiobookshelf API at {Url} returned {StatusCode}",
+                    LogRedaction.SanitizeUrl(baseUrl),
+                    (int)response.StatusCode);
+                return new AudiobookshelfActionResult(false, $"Audiobookshelf API error (HTTP {(int)response.StatusCode})");
+            }
+
+            var libraries = ParseLibraries(body);
+            if (libraries == null)
+            {
+                return new AudiobookshelfActionResult(false, "Unexpected response from Audiobookshelf; is the URL an Audiobookshelf server?");
+            }
+
+            return new AudiobookshelfActionResult(true, $"Connected; found {libraries.Count} libraries", libraries);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or UriFormatException or InvalidOperationException or JsonException)
+        {
+            _logger.LogWarning(ex, "Failed to reach Audiobookshelf at {Url}", LogRedaction.SanitizeUrl(baseUrl));
+            return new AudiobookshelfActionResult(false, $"Failed to reach Audiobookshelf: {ex.Message}");
+        }
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(HttpMethod method, string url, string apiKey, CancellationToken cancellationToken)
+    {
+        var (response, _) = await OutboundRequestSecurity.SendWithValidatedRedirectsAsync(
+            currentUri =>
+            {
+                var request = new HttpRequestMessage(method, currentUri);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+                return request;
+            },
+            new Uri(url),
+            _httpClientNoRedirect,
+            _logger,
+            allowPrivateTargets: true,
+            cancellationToken: cancellationToken);
+        return response;
+    }
+
+    private static List<AudiobookshelfLibrary>? ParseLibraries(string payload)
+    {
+        using var doc = JsonDocument.Parse(payload);
+
+        // Current servers return { "libraries": [...] }; very old ones returned a bare array.
+        var root = doc.RootElement;
+        JsonElement array;
+        if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("libraries", out var librariesProp) && librariesProp.ValueKind == JsonValueKind.Array)
+        {
+            array = librariesProp;
+        }
+        else if (root.ValueKind == JsonValueKind.Array)
+        {
+            array = root;
+        }
+        else
+        {
+            return null;
+        }
+
+        var result = new List<AudiobookshelfLibrary>();
+        foreach (var element in array.EnumerateArray())
+        {
+            if (element.ValueKind != JsonValueKind.Object
+                || !element.TryGetProperty("id", out var idProp)
+                || idProp.ValueKind != JsonValueKind.String)
+            {
+                continue;
+            }
+
+            var name = element.TryGetProperty("name", out var nameProp) && nameProp.ValueKind == JsonValueKind.String
+                ? nameProp.GetString() ?? string.Empty
+                : string.Empty;
+            var mediaType = element.TryGetProperty("mediaType", out var mediaTypeProp) && mediaTypeProp.ValueKind == JsonValueKind.String
+                ? mediaTypeProp.GetString() ?? string.Empty
+                : string.Empty;
+
+            result.Add(new AudiobookshelfLibrary(idProp.GetString()!, name, mediaType));
+        }
+
+        return result;
+    }
+
+    private static string NormalizeBaseUrl(string url)
+    {
+        var trimmed = url.Trim().TrimEnd('/');
+        if (!trimmed.Contains("://", StringComparison.Ordinal))
+        {
+            trimmed = $"http://{trimmed}";
+        }
+
+        return trimmed;
+    }
+}

--- a/listenarr.infrastructure/Library/Scanning/ScanJobProcessor.Audiobookshelf.cs
+++ b/listenarr.infrastructure/Library/Scanning/ScanJobProcessor.Audiobookshelf.cs
@@ -1,0 +1,34 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ */
+using Listenarr.Application.Integrations.Audiobookshelf.Contracts;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Infrastructure.Library.Scanning;
+
+public partial class ScanJobProcessor
+{
+    private void RequestAudiobookshelfScan(Audiobook audiobook, int createdFiles)
+    {
+        if (createdFiles <= 0)
+        {
+            return;
+        }
+
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var scheduler = scope.ServiceProvider.GetService<IAudiobookshelfScanScheduler>();
+            scheduler?.RequestScan($"imported {createdFiles} file(s) for audiobook {audiobook.Id}");
+        }
+        catch (Exception exception) when (exception is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
+        {
+            _logger.LogWarning(
+                exception,
+                "Failed to request Audiobookshelf scan for audiobook {AudiobookId} in background scan",
+                audiobook.Id);
+        }
+    }
+}

--- a/listenarr.infrastructure/Library/Scanning/ScanJobProcessor.cs
+++ b/listenarr.infrastructure/Library/Scanning/ScanJobProcessor.cs
@@ -401,6 +401,7 @@ namespace Listenarr.Infrastructure.Library.Scanning
                 }
 
                 await NotifyAvailableAsync(audiobook, createdFiles);
+                RequestAudiobookshelfScan(audiobook, createdFiles);
 
                 var updated = await audiobookRepository.GetByIdAsync(audiobook.Id);
                 if (updated != null)

--- a/listenarr.infrastructure/Persistence/Migrations/20260809100000_AddAudiobookshelfSettingsToApplicationSettings.Designer.cs
+++ b/listenarr.infrastructure/Persistence/Migrations/20260809100000_AddAudiobookshelfSettingsToApplicationSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Listenarr.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Listenarr.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ListenArrDbContext))]
-    partial class ListenArrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260809100000_AddAudiobookshelfSettingsToApplicationSettings")]
+    partial class AddAudiobookshelfSettingsToApplicationSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/listenarr.infrastructure/Persistence/Migrations/20260809100000_AddAudiobookshelfSettingsToApplicationSettings.cs
+++ b/listenarr.infrastructure/Persistence/Migrations/20260809100000_AddAudiobookshelfSettingsToApplicationSettings.cs
@@ -1,0 +1,75 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Listenarr.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAudiobookshelfSettingsToApplicationSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AudiobookshelfApiKeyEncrypted",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AudiobookshelfLibraryId",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "AudiobookshelfNotifyOnImport",
+                table: "ApplicationSettings",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AudiobookshelfUrl",
+                table: "ApplicationSettings",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AudiobookshelfApiKeyEncrypted",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "AudiobookshelfLibraryId",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "AudiobookshelfNotifyOnImport",
+                table: "ApplicationSettings");
+
+            migrationBuilder.DropColumn(
+                name: "AudiobookshelfUrl",
+                table: "ApplicationSettings");
+        }
+    }
+}

--- a/tests/Features/Application/Configuration/Core/ConfigurationServiceAudiobookshelfTests.cs
+++ b/tests/Features/Application/Configuration/Core/ConfigurationServiceAudiobookshelfTests.cs
@@ -1,0 +1,133 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Domain.Integrations;
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Application.Configuration.Core
+{
+    [Trait("Name", "ConfigurationServiceAudiobookshelfTests")]
+    [Trait("Category", "ConfigurationService")]
+    public class ConfigurationServiceAudiobookshelfTests : BaseTests
+    {
+        [Fact]
+        public async Task SaveAudiobookshelfSettings_RoundTripsAndProtectsApiKey()
+        {
+            var svc = _provider.GetRequiredService<IConfigurationService>();
+
+            var saved = await svc.SaveAudiobookshelfSettingsAsync(new AudiobookshelfConnectionSettings
+            {
+                Url = "http://abs.local:13378",
+                ApiKey = "secret-token",
+                LibraryId = "lib_123",
+                NotifyOnImport = true,
+            });
+
+            Assert.Equal("http://abs.local:13378", saved.Url);
+            Assert.Equal("lib_123", saved.LibraryId);
+            Assert.True(saved.NotifyOnImport);
+            Assert.True(saved.HasSavedApiKey);
+            Assert.Null(saved.ApiKey);
+
+            // The token is stored encrypted, never verbatim
+            var raw = await _applicationSettingsRepository.GetAsync();
+            Assert.NotNull(raw!.AudiobookshelfApiKeyEncrypted);
+            Assert.NotEqual("secret-token", raw.AudiobookshelfApiKeyEncrypted);
+
+            var withSecret = await svc.GetAudiobookshelfSettingsAsync(includeSecret: true);
+            Assert.Equal("secret-token", withSecret.ApiKey);
+        }
+
+        [Fact]
+        public async Task SaveAudiobookshelfSettings_BlankOrRedactedApiKey_KeepsSavedToken()
+        {
+            var svc = _provider.GetRequiredService<IConfigurationService>();
+
+            await svc.SaveAudiobookshelfSettingsAsync(new AudiobookshelfConnectionSettings
+            {
+                Url = "http://abs.local:13378",
+                ApiKey = "secret-token",
+            });
+
+            await svc.SaveAudiobookshelfSettingsAsync(new AudiobookshelfConnectionSettings
+            {
+                Url = "http://abs.local:13378",
+                ApiKey = null,
+                NotifyOnImport = true,
+            });
+
+            await svc.SaveAudiobookshelfSettingsAsync(new AudiobookshelfConnectionSettings
+            {
+                Url = "http://abs.local:13378",
+                ApiKey = ApiResponseRedactor.RedactedValue,
+                NotifyOnImport = true,
+            });
+
+            var result = await svc.GetAudiobookshelfSettingsAsync(includeSecret: true);
+            Assert.True(result.HasSavedApiKey);
+            Assert.Equal("secret-token", result.ApiKey);
+            Assert.True(result.NotifyOnImport);
+        }
+
+        [Fact]
+        public async Task SaveApplicationSettings_PartialPayload_PreservesAudiobookshelfSettings()
+        {
+            var svc = _provider.GetRequiredService<IConfigurationService>();
+
+            await svc.SaveAudiobookshelfSettingsAsync(new AudiobookshelfConnectionSettings
+            {
+                Url = "http://abs.local:13378",
+                ApiKey = "secret-token",
+                LibraryId = "lib_123",
+                NotifyOnImport = true,
+            });
+
+            // Simulate a settings save from a UI payload that omits the Audiobookshelf fields
+            await svc.SaveApplicationSettingsAsync(new ApplicationSettings
+            {
+                Id = 1,
+                OutputPath = FileUtils.GetAbsolutePath("partial-update"),
+            });
+
+            var result = await svc.GetAudiobookshelfSettingsAsync(includeSecret: true);
+            Assert.Equal("http://abs.local:13378", result.Url);
+            Assert.Equal("lib_123", result.LibraryId);
+            Assert.True(result.NotifyOnImport);
+            Assert.Equal("secret-token", result.ApiKey);
+        }
+
+        [Fact]
+        public async Task SaveAudiobookshelfSettings_ClearingUrl_DropsSavedToken()
+        {
+            var svc = _provider.GetRequiredService<IConfigurationService>();
+
+            await svc.SaveAudiobookshelfSettingsAsync(new AudiobookshelfConnectionSettings
+            {
+                Url = "http://abs.local:13378",
+                ApiKey = "secret-token",
+            });
+
+            var cleared = await svc.SaveAudiobookshelfSettingsAsync(new AudiobookshelfConnectionSettings
+            {
+                Url = string.Empty,
+            });
+
+            Assert.Equal(string.Empty, cleared.Url);
+            Assert.False(cleared.HasSavedApiKey);
+        }
+    }
+}

--- a/tests/Features/Infrastructure/Integrations/Audiobookshelf/AudiobookshelfServiceTests.cs
+++ b/tests/Features/Infrastructure/Integrations/Audiobookshelf/AudiobookshelfServiceTests.cs
@@ -1,0 +1,173 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Net;
+using System.Text;
+using Listenarr.Domain.Integrations;
+using Listenarr.Infrastructure.Integrations.Audiobookshelf;
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Infrastructure.Integrations.Audiobookshelf
+{
+    [Trait("Name", "AudiobookshelfServiceTests")]
+    [Trait("Category", "Audiobookshelf")]
+    public class AudiobookshelfServiceTests : BaseTests
+    {
+        private const string LibrariesPayload = """
+            {
+              "libraries": [
+                { "id": "lib_books", "name": "Audiobooks", "mediaType": "book" },
+                { "id": "lib_books2", "name": "More Audiobooks", "mediaType": "book" },
+                { "id": "lib_pods", "name": "Podcasts", "mediaType": "podcast" }
+              ]
+            }
+            """;
+
+        private AudiobookshelfService CreateService(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            var httpClient = new HttpClient(new DelegatingHandlerMock(handler));
+            return new AudiobookshelfService(
+                httpClient,
+                _provider.GetRequiredService<IConfigurationService>(),
+                _provider.GetRequiredService<ILogger<AudiobookshelfService>>());
+        }
+
+        private async Task SaveConnectionAsync(string? libraryId = null)
+        {
+            var svc = _provider.GetRequiredService<IConfigurationService>();
+            await svc.SaveAudiobookshelfSettingsAsync(new AudiobookshelfConnectionSettings
+            {
+                Url = "http://localhost:13378",
+                ApiKey = "abs-token",
+                LibraryId = libraryId,
+            });
+        }
+
+        private static HttpResponseMessage Json(string payload) => new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+        };
+
+        [Fact]
+        public async Task TestConnection_ParsesLibraries_AndSendsBearerToken()
+        {
+            await SaveConnectionAsync();
+            var requests = new List<HttpRequestMessage>();
+            var service = CreateService((request, _) =>
+            {
+                requests.Add(request);
+                return Task.FromResult(Json(LibrariesPayload));
+            });
+
+            var result = await service.TestConnectionAsync(null, null);
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.Libraries);
+            Assert.Equal(3, result.Libraries!.Count);
+            Assert.Equal("Audiobooks", result.Libraries[0].Name);
+
+            var request = Assert.Single(requests);
+            Assert.Equal("/api/libraries", request.RequestUri!.AbsolutePath);
+            Assert.Equal("Bearer", request.Headers.Authorization?.Scheme);
+            Assert.Equal("abs-token", request.Headers.Authorization?.Parameter);
+        }
+
+        [Fact]
+        public async Task TestConnection_Unauthorized_ReportsRejectedToken()
+        {
+            await SaveConnectionAsync();
+            var service = CreateService((_, _) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.Unauthorized)));
+
+            var result = await service.TestConnectionAsync(null, null);
+
+            Assert.False(result.Success);
+            Assert.Contains("rejected", result.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task TestConnection_WithoutConfiguration_Fails()
+        {
+            var service = CreateService((_, _) => Task.FromResult(Json(LibrariesPayload)));
+
+            var result = await service.TestConnectionAsync(null, null);
+
+            Assert.False(result.Success);
+        }
+
+        [Fact]
+        public async Task TriggerScan_ScansOnlyConfiguredLibrary()
+        {
+            await SaveConnectionAsync(libraryId: "lib_books2");
+            var scanRequests = new List<string>();
+            var service = CreateService((request, _) =>
+            {
+                if (request.Method == HttpMethod.Post)
+                {
+                    scanRequests.Add(request.RequestUri!.AbsolutePath);
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+                }
+
+                return Task.FromResult(Json(LibrariesPayload));
+            });
+
+            var result = await service.TriggerScanAsync();
+
+            Assert.True(result.Success);
+            Assert.Equal(["/api/libraries/lib_books2/scan"], scanRequests);
+            Assert.Contains("More Audiobooks", result.Message);
+        }
+
+        [Fact]
+        public async Task TriggerScan_WithoutConfiguredLibrary_ScansAllBookLibraries()
+        {
+            await SaveConnectionAsync();
+            var scanRequests = new List<string>();
+            var service = CreateService((request, _) =>
+            {
+                if (request.Method == HttpMethod.Post)
+                {
+                    scanRequests.Add(request.RequestUri!.AbsolutePath);
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+                }
+
+                return Task.FromResult(Json(LibrariesPayload));
+            });
+
+            var result = await service.TriggerScanAsync();
+
+            Assert.True(result.Success);
+            Assert.Equal(["/api/libraries/lib_books/scan", "/api/libraries/lib_books2/scan"], scanRequests);
+            // Podcast libraries are not scanned
+            Assert.DoesNotContain("/api/libraries/lib_pods/scan", scanRequests);
+        }
+
+        [Fact]
+        public async Task TriggerScan_AllScanRequestsFail_ReportsFailure()
+        {
+            await SaveConnectionAsync(libraryId: "lib_books");
+            var service = CreateService((request, _) =>
+                Task.FromResult(request.Method == HttpMethod.Post
+                    ? new HttpResponseMessage(HttpStatusCode.InternalServerError)
+                    : Json(LibrariesPayload)));
+
+            var result = await service.TriggerScanAsync();
+
+            Assert.False(result.Success);
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds an Audiobookshelf integration so Audiobookshelf picks up books imported by Listenarr without a manual library scan.

- **Settings → Audiobookshelf**: server URL, API token (encrypted at rest via `ISecretProtector`, redacted in API responses), target library picker (or "all book libraries"), Test Connection, Scan Now
- **"Update Audiobookshelf" action** on the book detail view and series collection view — calls `POST /api/libraries/{id}/scan` on the Audiobookshelf server
- **Optional automatic scan after import**: both import paths (download-client and manual upload) converge on `ScanJobProcessor`, which signals a debounced scheduler (15 s trailing-edge quiet window, 2 min cap) so a bulk import produces one scan instead of dozens

## Why

Audiobookshelf's folder watcher relies on filesystem events (inotify). When the library sits on a network share or the two apps run on different hosts, those events never arrive and newly imported books stay invisible until a full manual scan. The Audiobookshelf API's library-scan endpoint is the reliable alternative ([watcher-update is flaky](https://github.com/advplyr/audiobookshelf/issues/3018), [partial scan doesn't exist](https://github.com/advplyr/audiobookshelf/issues/2653)).

## Notes

- Outbound requests validate targets and follow redirects hop-by-hop via `OutboundRequestSecurity` (`allowPrivateTargets: true`), matching the Prowlarr import flow
- New EF migration `AddAudiobookshelfSettingsToApplicationSettings` (4 nullable columns on `ApplicationSettings`)
- `ConfigurationService`'s Prowlarr methods moved verbatim to a `ConfigurationService.Prowlarr.cs` partial to stay under the 500-line architecture cap
- Tests: 10 new (settings round-trip/secret preservation, HTTP client behavior incl. Bearer auth, library targeting, failure surfaces); full suite 1199 passing, frontend 392 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)