### PR TITLE
Fix Unix open flags on released architectures

### DIFF
--- a/listenarr.infrastructure/FileSystem/FileMover.RegularFileIdentity.cs
+++ b/listenarr.infrastructure/FileSystem/FileMover.RegularFileIdentity.cs
@@ -170,9 +170,7 @@ public partial class FileMover
 
     private static SafeFileHandle OpenRegularFileIdentityHandleUnix(string path)
     {
-        var flags = OperatingSystem.IsMacOS()
-            ? 0x4 | 0x100 | 0x1000000
-            : 0x800 | 0x20000 | 0x80000;
+        var flags = UnixOpenFlags.OpenReadNoFollow();
         var descriptor = OpenRegularFileIdentityUnix(path, flags);
         if (descriptor >= 0)
         {

--- a/listenarr.infrastructure/FileSystem/FileSystemSemanticsResolver.cs
+++ b/listenarr.infrastructure/FileSystem/FileSystemSemanticsResolver.cs
@@ -17,9 +17,6 @@ public sealed partial class FileSystemSemanticsResolver : IFileSystemSemanticsRe
     private const int FileCaseSensitiveInfo = 23;
     private const uint FileCsFlagCaseSensitiveDir = 0x00000001;
 
-    private const int OpenReadOnly = 0;
-    private const int OpenDirectory = 0x10000;
-    private const int OpenCloseOnExec = 0x80000;
     private const ulong FsIocGetFlags64 = 0x80086601;
     private const ulong FsIocGetFlags32 = 0x80046601;
     private const int FsCasefoldFlag = 0x40000000;
@@ -230,7 +227,7 @@ public sealed partial class FileSystemSemanticsResolver : IFileSystemSemanticsRe
     {
         var descriptor = OpenUnix(
             boundary,
-            OpenReadOnly | OpenDirectory | OpenCloseOnExec);
+            UnixOpenFlags.Directory(noFollow: false));
         if (descriptor < 0)
         {
             return Unavailable(

--- a/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.FileMove.Native.cs
+++ b/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.FileMove.Native.cs
@@ -66,7 +66,7 @@ internal sealed partial class PinnedDirectoryCreation
         var fd = OpenAt(
             parentHandle.DangerousGetHandle().ToInt32(),
             fileName,
-            GetUnixReadWriteCreateFlags(),
+            UnixOpenFlags.CreateReadWriteExclusiveNoFollow(),
             UnixFileMode);
         if (fd >= 0)
         {
@@ -86,7 +86,7 @@ internal sealed partial class PinnedDirectoryCreation
         var fd = OpenAt(
             parentHandle.DangerousGetHandle().ToInt32(),
             fileName,
-            GetUnixReadFlags(),
+            UnixOpenFlags.OpenReadNoFollow(),
             mode: 0);
         if (fd >= 0)
         {
@@ -106,7 +106,7 @@ internal sealed partial class PinnedDirectoryCreation
         var fd = OpenAt(
             parentHandle.DangerousGetHandle().ToInt32(),
             fileName,
-            GetUnixWriteExistingFlags(),
+            UnixOpenFlags.OpenWriteNoFollow(),
             mode: 0);
         if (fd >= 0)
         {
@@ -139,16 +139,4 @@ internal sealed partial class PinnedDirectoryCreation
                 "A pinned file cannot be a symbolic link or reparse point.");
         }
     }
-
-    private static int GetUnixReadFlags() => OperatingSystem.IsMacOS()
-        ? 0x4 | 0x100 | 0x1000000
-        : 0x800 | 0x20000 | 0x80000;
-
-    private static int GetUnixReadWriteCreateFlags() => OperatingSystem.IsMacOS()
-        ? 0x2 | 0x200 | 0x800 | 0x100 | 0x1000000
-        : 0x2 | 0x40 | 0x80 | 0x20000 | 0x80000;
-
-    private static int GetUnixWriteExistingFlags() => OperatingSystem.IsMacOS()
-        ? 0x1 | 0x100 | 0x1000000
-        : 0x1 | 0x20000 | 0x80000;
 }

--- a/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.LockFiles.cs
+++ b/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.LockFiles.cs
@@ -216,9 +216,7 @@ internal sealed partial class PinnedDirectoryCreation
         SafeFileHandle directoryHandle,
         string fileName)
     {
-        var flags = OperatingSystem.IsMacOS()
-            ? 0x2 | 0x200 | 0x100 | 0x1000000
-            : 0x2 | 0x40 | 0x20000 | 0x80000;
+        var flags = UnixOpenFlags.OpenOrCreateReadWriteNoFollow();
         var fileDescriptor = OpenAt(
             directoryHandle.DangerousGetHandle().ToInt32(),
             fileName,

--- a/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.NativeOperations.Platform.cs
+++ b/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.NativeOperations.Platform.cs
@@ -176,22 +176,6 @@ internal sealed partial class PinnedDirectoryCreation
             $"Could not create '{child}' relative to '{parent}'.");
     }
 
-    private static int GetUnixDirectoryFlags(bool noFollow)
-    {
-        var flags = OperatingSystem.IsMacOS()
-            ? 0x100000 | 0x1000000
-            : 0x10000 | 0x80000;
-        if (noFollow)
-        {
-            flags |= OperatingSystem.IsMacOS() ? 0x100 : 0x20000;
-        }
-        return flags;
-    }
-
-    private static int GetUnixWriteFlags() => OperatingSystem.IsMacOS()
-        ? 0x1 | 0x200 | 0x800 | 0x100 | 0x1000000
-        : 0x1 | 0x40 | 0x80 | 0x20000 | 0x80000;
-
     private static void RemoveDirectoryAtUnix(
         SafeFileHandle parentHandle,
         string childName)

--- a/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.NativeOperations.cs
+++ b/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.NativeOperations.cs
@@ -61,7 +61,7 @@ internal sealed partial class PinnedDirectoryCreation
         string path,
         bool noFollow)
     {
-        var fd = OpenUnix(path, GetUnixDirectoryFlags(noFollow));
+        var fd = OpenUnix(path, UnixOpenFlags.Directory(noFollow));
         if (fd >= 0)
         {
             return new SafeFileHandle(new IntPtr(fd), ownsHandle: true);
@@ -79,7 +79,7 @@ internal sealed partial class PinnedDirectoryCreation
         var fd = OpenAt(
             parentHandle.DangerousGetHandle().ToInt32(),
             childName,
-            GetUnixDirectoryFlags(noFollow: true),
+            UnixOpenFlags.Directory(noFollow: true),
             mode: 0);
         if (fd >= 0)
         {

--- a/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.cs
+++ b/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.cs
@@ -285,7 +285,7 @@ internal sealed partial class PinnedDirectoryCreation : IDisposable
         SafeFileHandle directoryHandle,
         string fileName)
     {
-        var flags = GetUnixWriteFlags();
+        var flags = UnixOpenFlags.CreateWriteExclusiveNoFollow();
         var fd = OpenAt(
             directoryHandle.DangerousGetHandle().ToInt32(),
             fileName,

--- a/listenarr.infrastructure/FileSystem/UnixOpenFlags.cs
+++ b/listenarr.infrastructure/FileSystem/UnixOpenFlags.cs
@@ -1,0 +1,152 @@
+using System.Runtime.InteropServices;
+
+namespace Listenarr.Infrastructure.FileSystem;
+
+internal static class UnixOpenFlags
+{
+    private const int LinuxWriteOnly = 1 << 0;
+    private const int LinuxReadWrite = 1 << 1;
+    private const int LinuxCreate = 1 << 6;
+    private const int LinuxExclusive = 1 << 7;
+    private const int LinuxNonBlocking = 1 << 11;
+    private const int LinuxCloseOnExec = 1 << 19;
+
+    private const int MacWriteOnly = 0x1;
+    private const int MacReadWrite = 0x2;
+    private const int MacNonBlocking = 0x4;
+    private const int MacCreate = 0x200;
+    private const int MacExclusive = 0x800;
+    private const int MacNoFollow = 0x100;
+    private const int MacDirectory = 0x100000;
+    private const int MacCloseOnExec = 0x1000000;
+
+    internal static int Directory(bool noFollow)
+    {
+        if (IsMacOSHost())
+        {
+            return MacDirectory
+                | MacCloseOnExec
+                | (noFollow ? MacNoFollow : 0);
+        }
+
+        var (directory, noFollowFlag) = GetCurrentLinuxDirectorySafetyFlags();
+        return directory
+            | LinuxCloseOnExec
+            | (noFollow ? noFollowFlag : 0);
+    }
+
+    internal static int OpenReadNoFollow()
+    {
+        if (IsMacOSHost())
+        {
+            return MacNonBlocking | MacNoFollow | MacCloseOnExec;
+        }
+
+        var (_, noFollow) = GetCurrentLinuxDirectorySafetyFlags();
+        return LinuxNonBlocking | noFollow | LinuxCloseOnExec;
+    }
+
+    internal static int CreateReadWriteExclusiveNoFollow()
+    {
+        if (IsMacOSHost())
+        {
+            return MacReadWrite
+                | MacCreate
+                | MacExclusive
+                | MacNoFollow
+                | MacCloseOnExec;
+        }
+
+        var (_, noFollow) = GetCurrentLinuxDirectorySafetyFlags();
+        return LinuxReadWrite
+            | LinuxCreate
+            | LinuxExclusive
+            | noFollow
+            | LinuxCloseOnExec;
+    }
+
+    internal static int OpenWriteNoFollow()
+    {
+        if (IsMacOSHost())
+        {
+            return MacWriteOnly | MacNoFollow | MacCloseOnExec;
+        }
+
+        var (_, noFollow) = GetCurrentLinuxDirectorySafetyFlags();
+        return LinuxWriteOnly | noFollow | LinuxCloseOnExec;
+    }
+
+    internal static int CreateWriteExclusiveNoFollow()
+    {
+        if (IsMacOSHost())
+        {
+            return MacWriteOnly
+                | MacCreate
+                | MacExclusive
+                | MacNoFollow
+                | MacCloseOnExec;
+        }
+
+        var (_, noFollow) = GetCurrentLinuxDirectorySafetyFlags();
+        return LinuxWriteOnly
+            | LinuxCreate
+            | LinuxExclusive
+            | noFollow
+            | LinuxCloseOnExec;
+    }
+
+    internal static int OpenOrCreateReadWriteNoFollow()
+    {
+        if (IsMacOSHost())
+        {
+            return MacReadWrite | MacCreate | MacNoFollow | MacCloseOnExec;
+        }
+
+        var (_, noFollow) = GetCurrentLinuxDirectorySafetyFlags();
+        return LinuxReadWrite | LinuxCreate | noFollow | LinuxCloseOnExec;
+    }
+
+    private static bool IsMacOSHost()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return false;
+        }
+
+        EnsureMacOSArchitectureSupported(RuntimeInformation.ProcessArchitecture);
+        return true;
+    }
+
+    internal static void EnsureMacOSArchitectureSupported(Architecture architecture)
+    {
+        if (architecture != Architecture.X64)
+        {
+            throw new PlatformNotSupportedException(
+                $"Listenarr does not support macOS filesystem operations on process architecture '{architecture}'.");
+        }
+    }
+
+    private static (int Directory, int NoFollow) GetCurrentLinuxDirectorySafetyFlags()
+    {
+        if (!OperatingSystem.IsLinux())
+        {
+            throw new PlatformNotSupportedException(
+                "Unix open flags are supported only on released Linux and macOS targets.");
+        }
+
+        return GetLinuxDirectorySafetyFlags(RuntimeInformation.ProcessArchitecture);
+    }
+
+    internal static (int Directory, int NoFollow) GetLinuxDirectorySafetyFlags(
+        Architecture architecture) => architecture switch
+        {
+            // Listenarr distributes Linux only for x64 and arm64. Keep the
+            // supported process ABI set aligned with the release matrix instead
+            // of silently extending filesystem safety guarantees to architectures
+            // we do not build, test, or publish.
+            Architecture.Arm64 => (1 << 14, 1 << 15),
+            Architecture.X64 => (1 << 16, 1 << 17),
+            _ => throw new PlatformNotSupportedException(
+                $"Listenarr does not support Linux filesystem operations on process architecture '{architecture}'.")
+        };
+}

--- a/tests/Features/Infrastructure/FileSystem/UnixOpenFlagsTests.cs
+++ b/tests/Features/Infrastructure/FileSystem/UnixOpenFlagsTests.cs
@@ -1,0 +1,75 @@
+using Listenarr.Tests.Common;
+using RuntimeArchitecture = System.Runtime.InteropServices.Architecture;
+
+namespace Listenarr.Tests.Features.Infrastructure.FileSystem;
+
+[Trait("Name", "UnixOpenFlagsTests")]
+[Trait("Category", "Infrastructure")]
+public sealed class UnixOpenFlagsTests : BaseTests
+{
+    [Fact]
+    public void GetLinuxDirectorySafetyFlags_UsesArm64ReleaseValues()
+    {
+        // Given / When
+        var flags = UnixOpenFlags.GetLinuxDirectorySafetyFlags(
+            RuntimeArchitecture.Arm64);
+
+        // Then
+        Assert.Equal(0x4000, flags.Directory);
+        Assert.Equal(0x8000, flags.NoFollow);
+    }
+
+    [Fact]
+    public void GetLinuxDirectorySafetyFlags_UsesX64ReleaseValues()
+    {
+        // Given / When
+        var flags = UnixOpenFlags.GetLinuxDirectorySafetyFlags(
+            RuntimeArchitecture.X64);
+
+        // Then
+        Assert.Equal(0x10000, flags.Directory);
+        Assert.Equal(0x20000, flags.NoFollow);
+    }
+
+    [Theory]
+    [InlineData(RuntimeArchitecture.X86)]
+    [InlineData(RuntimeArchitecture.Arm)]
+    [InlineData(RuntimeArchitecture.Armv6)]
+    [InlineData(RuntimeArchitecture.Ppc64le)]
+    [InlineData(RuntimeArchitecture.S390x)]
+    [InlineData(RuntimeArchitecture.LoongArch64)]
+    [InlineData(RuntimeArchitecture.RiscV64)]
+    [InlineData(RuntimeArchitecture.Wasm)]
+    public void GetLinuxDirectorySafetyFlags_RejectsArchitecturesListenarrDoesNotRelease(
+        RuntimeArchitecture architecture)
+    {
+        // Given / When / Then
+        Assert.Throws<PlatformNotSupportedException>(() =>
+            UnixOpenFlags.GetLinuxDirectorySafetyFlags(architecture));
+    }
+
+    [Fact]
+    public void EnsureMacOSArchitectureSupported_AcceptsReleasedX64Target()
+    {
+        // Given / When / Then
+        UnixOpenFlags.EnsureMacOSArchitectureSupported(RuntimeArchitecture.X64);
+    }
+
+    [Theory]
+    [InlineData(RuntimeArchitecture.X86)]
+    [InlineData(RuntimeArchitecture.Arm)]
+    [InlineData(RuntimeArchitecture.Arm64)]
+    [InlineData(RuntimeArchitecture.Armv6)]
+    [InlineData(RuntimeArchitecture.Ppc64le)]
+    [InlineData(RuntimeArchitecture.S390x)]
+    [InlineData(RuntimeArchitecture.LoongArch64)]
+    [InlineData(RuntimeArchitecture.RiscV64)]
+    [InlineData(RuntimeArchitecture.Wasm)]
+    public void EnsureMacOSArchitectureSupported_RejectsArchitecturesListenarrDoesNotRelease(
+        RuntimeArchitecture architecture)
+    {
+        // Given / When / Then
+        Assert.Throws<PlatformNotSupportedException>(() =>
+            UnixOpenFlags.EnsureMacOSArchitectureSupported(architecture));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #827.

Linux `O_DIRECTORY` and `O_NOFOLLOW` are process-ABI dependent, but Listenarr was composing libc `open` / `openat` flags from duplicated asm-generic/x86 values. On ARM64, those bit positions mean different flags: directory opens can fail with `EINVAL` on filesystems that reject the accidental `O_DIRECT`, and pinned file opens can lose the intended `O_NOFOLLOW` symlink fence.

This fixes the root cause for the Unix platforms Listenarr actually releases. Unix open flag construction is centralized, Linux selects the correct values from `RuntimeInformation.ProcessArchitecture`, and architecture support is intentionally limited to the published targets: `linux-x64`, `linux-arm64`, and `osx-x64`. Any other Linux or macOS process architecture fails closed instead of receiving an untested native-open mapping.

## Changes

### Added
- `UnixOpenFlags` as the single source of truth for Unix `open` / `openat` flag composition.
- regression coverage for the released Unix architecture matrix and explicit rejection of non-released architectures.

### Changed
- all filesystem libc `open` / `openat` callers to use centralized flag construction.
- released Linux mappings:
  - ARM64: `O_DIRECTORY = 1 << 14`, `O_NOFOLLOW = 1 << 15`
  - x64: `O_DIRECTORY = 1 << 16`, `O_NOFOLLOW = 1 << 17`
- macOS retains the existing Darwin flag values, but only the released x64 process architecture is accepted.

### Fixed
- ARM64 directory opens no longer accidentally request unrelated flags such as `O_DIRECT`.
- pinned/no-follow file opens retain their symlink fence on ARM64.
- unsupported Linux and macOS architectures no longer inherit constants or imply a Listenarr support guarantee.

## Testing

- `dotnet format listenarr.slnx --no-restore --verify-no-changes`
- infrastructure build — 0 warnings, 0 errors
- full backend suite — 3,141 total; 2,985 passed; 156 platform-skipped; 0 failed
- ARM64 Linux .NET P/Invoke probe under Docker/QEMU:
  - corrected no-follow flags rejected a symlink with `ELOOP`
  - the previous x86_64 flags followed the symlink
  - corrected directory flags opened the directory normally
  - the previous x86_64 directory flags failed with `EINVAL`
- architecture tests verify released Linux x64/ARM64 mappings, accept released macOS x64, and reject non-released Linux/macOS process architectures.

The branch was rewritten after narrowing the support contract, so GitHub CI on the current head is the authoritative final executable validation.

## Notes

Listenarr currently publishes Linux for x64 and ARM64 and a macOS x64 artifact; this PR deliberately does not add native filesystem support for architectures that Listenarr does not publish. The separate CIFS limitation around durable generation identity is unchanged: storage that cannot provide the identity guarantees required for destructive mutation remains limited rather than being given a fallback identity assumption. There are no persistence, migration, API, serialization, or frontend contract changes in this PR.