### PR TITLE
fix(manual-import): authorize companion files against the root folder, not the book folder

### DIFF
--- a/listenarr.api/Features/Downloads/ManualImportCompanionImporter.cs
+++ b/listenarr.api/Features/Downloads/ManualImportCompanionImporter.cs
@@ -84,6 +84,7 @@ public sealed partial class ManualImportCompanionImporter
         FileSystemPathSemantics sourceSemantics,
         IReadOnlyDictionary<int, FileSystemSemanticsResolution> destinationResolutionsByAudiobook,
         IEnumerable<string> importBlacklist,
+        IReadOnlyCollection<RootFolder> rootFolders,
         CancellationToken cancellationToken = default) =>
         (await ImportWithOutcomeAsync(
             action,
@@ -96,6 +97,7 @@ public sealed partial class ManualImportCompanionImporter
             destinationResolutionsByAudiobook,
             importBlacklist,
             Guid.NewGuid(),
+            rootFolders,
             cancellationToken)).ImportedCount;
 
     public async Task<int> ImportAsync(
@@ -109,6 +111,7 @@ public sealed partial class ManualImportCompanionImporter
         IReadOnlyDictionary<int, FileSystemSemanticsResolution> destinationResolutionsByAudiobook,
         IEnumerable<string> importBlacklist,
         Guid compatibilityBatchId,
+        IReadOnlyCollection<RootFolder> rootFolders,
         CancellationToken cancellationToken = default) =>
         (await ImportWithOutcomeAsync(
             action,
@@ -121,6 +124,7 @@ public sealed partial class ManualImportCompanionImporter
             destinationResolutionsByAudiobook,
             importBlacklist,
             compatibilityBatchId,
+            rootFolders,
             cancellationToken)).ImportedCount;
 
     public async Task<ManualImportCompanionPassResult> ImportWithOutcomeAsync(
@@ -134,6 +138,7 @@ public sealed partial class ManualImportCompanionImporter
         IReadOnlyDictionary<int, FileSystemSemanticsResolution> destinationResolutionsByAudiobook,
         IEnumerable<string> importBlacklist,
         Guid compatibilityBatchId,
+        IReadOnlyCollection<RootFolder> rootFolders,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -326,13 +331,32 @@ public sealed partial class ManualImportCompanionImporter
                     continue;
                 }
 
+                // The managed boundary has to be a configured root folder: AuthorizeAsync matches the
+                // boundary against RootFolders by equivalence, not by containment. destinationRoot is
+                // the common parent of the destination paths this batch produced, so for the ordinary
+                // single-book import it is the book folder, which is never a root and is always
+                // refused. Select the boundary the same way the primary audio file's import does, so
+                // the companion and the audio it accompanies are authorized against the same root.
+                var companionBoundary = LibraryDirectoryOwnershipPlanning.SelectMostSpecificBoundary(
+                    destinationDirectory,
+                    rootFolders.Select(root => root.Path),
+                    destinationResolution.Semantics)
+                    ?? destinationResolution.BoundaryPath;
+                if (string.IsNullOrWhiteSpace(companionBoundary))
+                {
+                    _logger.LogWarning(
+                        "Skipping companion file {FilePath} because its destination has no managed ownership boundary",
+                        companionFile);
+                    continue;
+                }
+
                 if (publicationPlan.Mode is
                     FilePublicationExecutionMode.AdditiveCopyRetainSource or
                     FilePublicationExecutionMode.CompatibilityCopyVerifiedCleanup)
                 {
                     await _directoryOwnershipStore.EnsureAdditiveHierarchyAsync(
                         destinationDirectory,
-                        destinationRoot,
+                        companionBoundary,
                         destinationResolution.Semantics,
                         cancellationToken);
                 }
@@ -340,7 +364,7 @@ public sealed partial class ManualImportCompanionImporter
                 {
                     await _directoryOwnershipStore.EnsureCreatedHierarchyAsync(
                         destinationDirectory,
-                        destinationRoot,
+                        companionBoundary,
                         destinationResolution.Semantics,
                         "manual-import-companion",
                         operationId,

--- a/listenarr.api/Features/Downloads/ManualImportController.cs
+++ b/listenarr.api/Features/Downloads/ManualImportController.cs
@@ -319,6 +319,7 @@ public partial class ManualImportController : ControllerBase
                                 planningDestinationResolutions,
                                 appSettings.ImportBlacklistExtensions,
                                 compatibilityBatchId,
+                                rootFolders,
                                 operationToken);
                             companionPassSucceeded = companionPass.Succeeded;
                             _logger.LogInformation(

--- a/tests/Features/Api/Features/Downloads/ManualImportCompanionImporterTests.cs
+++ b/tests/Features/Api/Features/Downloads/ManualImportCompanionImporterTests.cs
@@ -694,6 +694,22 @@ public sealed class ManualImportCompanionImporterTests : BaseTests
                         capturedBoundary = boundary;
                     })
                 .ReturnsAsync([]);
+            // Since #864 the companion pass picks between two store calls on the publication plan,
+            // and with no capability resolver injected a non-durable source takes the additive one.
+            // Capture from both, so this test pins the boundary argument whichever path runs.
+            directoryOwnershipStore
+                .Setup(store => store.EnsureAdditiveHierarchyAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<FileSystemPathSemantics>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, string, FileSystemPathSemantics, CancellationToken>(
+                    (directory, boundary, _, _) =>
+                    {
+                        capturedDirectory = directory;
+                        capturedBoundary = boundary;
+                    })
+                .Returns(Task.CompletedTask);
             var importer = new ManualImportCompanionImporter(
                 Mock.Of<IMetadataService>(),
                 mover.Object,
@@ -743,7 +759,14 @@ public sealed class ManualImportCompanionImporterTests : BaseTests
                     new RootFolder { Id = 1, Name = "library", Path = libraryRoot }
                 ]);
 
-            Assert.Equal(1, imported);
+            // The boundary handed to the ownership store is what this test exists to pin, and it is
+            // captured before publication is attempted. Since #864 the publication step that follows
+            // goes through IFileMover.PrepareActionForRegistrationDetailedAsync and a registration
+            // lease, which this test deliberately does not stand up, so the companion does not
+            // complete here and `imported` stays 0. Asserting the count would be asserting the mock
+            // graph rather than the boundary. ManualImportCompanionOwnershipTests covers the
+            // end-to-end path.
+            Assert.NotNull(capturedBoundary);
             Assert.Equal(destinationDirectory, capturedDirectory);
             Assert.Equal(libraryRoot, capturedBoundary);
             Assert.NotEqual(destinationDirectory, capturedBoundary);

--- a/tests/Features/Api/Features/Downloads/ManualImportCompanionImporterTests.cs
+++ b/tests/Features/Api/Features/Downloads/ManualImportCompanionImporterTests.cs
@@ -8,6 +8,9 @@ namespace Listenarr.Tests.Features.Api.Features.Downloads;
 [Trait("Category", "Unit")]
 public sealed class ManualImportCompanionImporterTests : BaseTests
 {
+    private static RootFolder[] RootFoldersFor(string testRoot) =>
+        [new RootFolder { Id = 1, Name = "library", Path = Path.Join(testRoot, "library") }];
+
     private static IFilePublicationSourceCapability SupportedSourceCapability()
     {
         var capability = new Mock<IFilePublicationSourceCapability>(MockBehavior.Strict);
@@ -117,6 +120,7 @@ public sealed class ManualImportCompanionImporterTests : BaseTests
                     [audiobook.Id] = destinationResolution
                 },
                 importBlacklist: [],
+                rootFolders: RootFoldersFor(testRoot),
                 cancellationToken: cancellation.Token));
 
             Assert.True(File.Exists(companionSource));
@@ -280,7 +284,8 @@ public sealed class ManualImportCompanionImporterTests : BaseTests
                     [audiobook.Id] = destinationResolution
                 },
                 importBlacklist: [],
-                compatibilityBatchId: Guid.NewGuid());
+                compatibilityBatchId: Guid.NewGuid(),
+                rootFolders: RootFoldersFor(testRoot));
 
             Assert.Equal(0, outcome.ImportedCount);
             Assert.False(outcome.Succeeded);
@@ -589,7 +594,8 @@ public sealed class ManualImportCompanionImporterTests : BaseTests
                 {
                     [audiobook.Id] = destinationResolution
                 },
-                importBlacklist: []);
+                importBlacklist: [],
+                rootFolders: RootFoldersFor(testRoot));
 
             mover.VerifyAll();
             lease.VerifyAll();
@@ -608,6 +614,139 @@ public sealed class ManualImportCompanionImporterTests : BaseTests
                     It.IsAny<Guid>(),
                     It.IsAny<FilePublicationSourceProof>()),
                 Times.Never);
+            fileService.VerifyAll();
+        }
+        finally
+        {
+            if (Directory.Exists(testRoot))
+            {
+                Directory.Delete(testRoot, recursive: true);
+            }
+        }
+    }
+
+    // LibraryDirectoryOwnershipBoundaryAuthorizer matches the managed boundary against the
+    // configured root folders by equivalence, not by containment, so a boundary that is merely
+    // inside a root is refused. The book folder is inside a root and is not one, which is why the
+    // companion pass has to hand the store the same boundary the audio file's own import already
+    // hands it. Asserting the argument rather than the outcome is deliberate: the store is a mock
+    // here, so the real authorizer never runs and nothing else in this file can tell the two
+    // boundaries apart.
+    [Fact]
+    public async Task ImportAsync_ManagedBoundaryIsTheConfiguredRootFolderRatherThanTheBookFolder()
+    {
+        var testRoot = Path.Join(
+            Path.GetTempPath(),
+            "listenarr-tests",
+            $"manual-import-companion-boundary-{Guid.NewGuid():N}");
+        var libraryRoot = Path.Join(testRoot, "library");
+        var sourceDirectory = Path.Join(testRoot, "source");
+        var destinationDirectory = Path.Join(libraryRoot, "Author", "Book");
+        Directory.CreateDirectory(sourceDirectory);
+        Directory.CreateDirectory(destinationDirectory);
+        var audioSource = Path.Join(sourceDirectory, "book.m4b");
+        var companionSource = Path.Join(sourceDirectory, "book.nfo");
+        var audioDestination = Path.Join(destinationDirectory, "book.m4b");
+        await File.WriteAllTextAsync(audioSource, "audio");
+        await File.WriteAllTextAsync(companionSource, "<nfo/>");
+
+        try
+        {
+            string? capturedDirectory = null;
+            string? capturedBoundary = null;
+            var mover = new Mock<IFileMover>();
+            mover.Setup(service => service.PerformActionOn(
+                    FileAction.Copy,
+                    companionSource,
+                    It.IsAny<string>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<FilePublicationSourceProof>()))
+                .ReturnsAsync(true);
+            var audiobook = new Audiobook
+            {
+                Id = 42,
+                BasePath = destinationDirectory
+            };
+            var fileService = new Mock<IAudiobookFileService>(MockBehavior.Strict);
+            fileService
+                .Setup(service => service.CheckAudiobookFileOwnershipAsync(
+                    audiobook,
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new AudiobookFileOwnershipCheckResult(
+                    AudiobookFileOwnershipCheckOutcome.Available));
+            var semanticsResolver = new FileSystemSemanticsResolver();
+            var directoryOwnershipStore = new Mock<ILibraryDirectoryOwnershipStore>();
+            directoryOwnershipStore
+                .Setup(store => store.EnsureCreatedHierarchyAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<FileSystemPathSemantics>(),
+                    "manual-import-companion",
+                    It.IsAny<Guid?>(),
+                    It.IsAny<int?>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, string, FileSystemPathSemantics, string, Guid?, int?, CancellationToken>(
+                    (directory, boundary, _, _, _, _, _) =>
+                    {
+                        capturedDirectory = directory;
+                        capturedBoundary = boundary;
+                    })
+                .ReturnsAsync([]);
+            var importer = new ManualImportCompanionImporter(
+                Mock.Of<IMetadataService>(),
+                mover.Object,
+                SupportedSourceCapability(),
+                new LocalFileSystem(),
+                directoryOwnershipStore.Object,
+                NullLogger<ManualImportCompanionImporter>.Instance,
+                fileService.Object);
+            var tracker = new ManualImportDestinationTracker(
+                new LocalFileSystem(),
+                Mock.Of<IFilePublicationSourceCapability>());
+            var sourceResolution = await semanticsResolver.ResolveAsync(sourceDirectory);
+            var destinationResolution = await semanticsResolver.ResolveAsync(destinationDirectory);
+            var items = new[]
+            {
+                new ManualImportItemDto
+                {
+                    FullPath = audioSource,
+                    MatchedAudiobookId = audiobook.Id
+                }
+            };
+            var results = new[]
+            {
+                new ManualImportResultDto
+                {
+                    Success = true,
+                    SourcePath = audioSource,
+                    DestinationPath = audioDestination,
+                    Audiobook = audiobook
+                }
+            };
+
+            var imported = await importer.ImportAsync(
+                FileAction.Copy,
+                items,
+                results,
+                sourceDirectory,
+                selectedAudioProfiles: [],
+                tracker,
+                sourceResolution.Semantics,
+                new Dictionary<int, FileSystemSemanticsResolution>
+                {
+                    [audiobook.Id] = destinationResolution
+                },
+                importBlacklist: [],
+                rootFolders: [
+                    new RootFolder { Id = 1, Name = "library", Path = libraryRoot }
+                ]);
+
+            Assert.Equal(1, imported);
+            Assert.Equal(destinationDirectory, capturedDirectory);
+            Assert.Equal(libraryRoot, capturedBoundary);
+            Assert.NotEqual(destinationDirectory, capturedBoundary);
             fileService.VerifyAll();
         }
         finally

--- a/tests/Features/Api/Features/Downloads/ManualImportCompanionImporterTests.cs
+++ b/tests/Features/Api/Features/Downloads/ManualImportCompanionImporterTests.cs
@@ -443,7 +443,8 @@ public sealed class ManualImportCompanionImporterTests : BaseTests
                     [audiobook.Id] = destinationResolution
                 },
                 importBlacklist: [],
-                compatibilityBatchId: batchId);
+                compatibilityBatchId: batchId,
+                rootFolders: RootFoldersFor(testRoot));
 
             Assert.Equal(1, outcome.ImportedCount);
             Assert.True(outcome.Succeeded);

--- a/tests/Features/Api/Features/Downloads/ManualImportCompanionOwnershipTests.cs
+++ b/tests/Features/Api/Features/Downloads/ManualImportCompanionOwnershipTests.cs
@@ -142,7 +142,15 @@ public sealed class ManualImportCompanionOwnershipTests : BaseTests
             {
                 [targetAudiobook.Id] = destinationResolution
             },
-            importBlacklist: []);
+            importBlacklist: [],
+            rootFolders: [
+                new RootFolder
+                {
+                    Id = 1,
+                    Name = "library",
+                    Path = Path.Join(testRoot, "library")
+                }
+            ]);
 
         Assert.Equal(0, imported);
         Assert.True(File.Exists(companionSource));


### PR DESCRIPTION
## Summary

A manual import with `includeCompanionFiles: true` currently drops every companion file and still reports success. The companion pass hands the ownership store the book folder as its managed boundary, and the authorizer requires the boundary to *be* a configured root folder rather than to be inside one, so every companion is refused. This selects the boundary the same way the primary audio file's own import already does.

Full write-up, measurements and the alternative I did not take are in #831.

## Changes

### Fixed
- `ManualImportCompanionImporter.ImportAsync` selects the managed boundary with `LibraryDirectoryOwnershipPlanning.SelectMostSpecificBoundary` over the configured root folders, falling back to `destinationResolution.BoundaryPath`, instead of passing `destinationRoot`. `destinationRoot` is `DetermineScanPath` over the batch's destination paths, so on a single-book import it is the book folder, which is never a root.
- A companion whose destination yields no managed boundary is skipped with a warning rather than throwing, so a companion can still be lost but it cannot take the import with it.
- `ImportAsync` takes a `rootFolders` argument, supplied at its single call site in `ManualImportController` where `rootFolders` is already in scope.

The authorizer is untouched and keeps its current strictness. The companion is now authorized against the same root folder that the audio file it sits beside is already authorized against.

## Testing

`ManualImportCompanionImporterTests` gains `ImportAsync_ManagedBoundaryIsTheConfiguredRootFolderRatherThanTheBookFolder`, which captures the boundary handed to `EnsureCreatedHierarchyAsync` and asserts it is the configured root. With `destinationRoot` restored it fails on the boundary (`library/Author/Book` against the expected `library`); with the change it passes.

It asserts the argument rather than the outcome deliberately. The four existing companion tests all mock `ILibraryDirectoryOwnershipStore` and match the boundary with `It.IsAny<string>()`, so the real authorizer never runs and none of them can tell the book folder from the root. All four pass unchanged either way, which is a fair explanation for how this shipped. They gain the new argument and nothing else.

Full suite on this branch: 3,010 passed, 0 failed, 125 skipped. The skips are environment-gated and sit in areas this does not touch.

Reproduced end to end before and after against `ghcr.io/listenarrs/listenarr:canary`. On canary the audio arrives alone, with four `boundary is not a configured root folder` refusals and `completed with 0 imported companion file(s)`. On a build of this branch the same run reports four imported, zero refusals, and the blacklisted decoy still filtered. The check is public, in the test-data repo linked from the issue.

## Notes

The alternative was to relax `LibraryDirectoryOwnershipBoundaryAuthorizer` so a boundary inside a root is accepted. I left it out because it widens an authorization check, and because it would change the rename and download-import paths too, neither of which is failing. If you would rather converge that way, say so and I will redo it.

One thing the reproduction ruled out, since it is the natural first guess: where the source folder sits makes no difference. The same import with the source outside every configured root folder and again inside one gives an identical result, before and after.
