### PR TITLE
Fix ArgumentException on NZB titles containing quote characters

### DIFF
--- a/listenarr.infrastructure/Downloads/Submission/GenericUsenetSourceResolver.cs
+++ b/listenarr.infrastructure/Downloads/Submission/GenericUsenetSourceResolver.cs
@@ -48,7 +48,15 @@ public sealed class GenericUsenetSourceResolver(
             candidate.SourceDescriptor.FileName ?? $"{SanitizeFileName(candidate.Title)}.nzb");
     }
 
+    // Beyond filesystem-invalid characters, '"' and '\\' must also be stripped: this
+    // filename is later passed as the multipart Content-Disposition "filename" parameter
+    // when submitting to a download client (e.g. SABnzbd), and both characters are valid
+    // on Linux/macOS filesystems but break .NET's ContentDispositionHeaderValue quoting,
+    // throwing ArgumentException and silently failing the whole download. See
+    // https://github.com/Listenarrs/Listenarr/issues/808.
     private static string SanitizeFileName(string value)
         => string.Concat(value.Select(character =>
-            Path.GetInvalidFileNameChars().Contains(character) ? '_' : character));
+            Path.GetInvalidFileNameChars().Contains(character) || character is '"' or '\\'
+                ? '_'
+                : character));
 }

--- a/tests/Features/Infrastructure/DownloadClients/Sabnzbd/SabnzbdAdapterTests.cs
+++ b/tests/Features/Infrastructure/DownloadClients/Sabnzbd/SabnzbdAdapterTests.cs
@@ -43,6 +43,50 @@ namespace Listenarr.Tests.Features.Infrastructure.DownloadClients.Sabnzbd
                 .Build());
         }
 
+        /// <summary>
+        /// Regression test for https://github.com/Listenarrs/Listenarr/issues/808
+        /// Release titles containing '"' (common in usenet subject lines) crashed
+        /// AddAsync with an ArgumentException from ContentDispositionHeaderValue
+        /// before the request ever reached SABnzbd.
+        /// </summary>
+        [Fact]
+        public async Task AddAsync_TitleContainsQuotesAndCommas_SendsNzbWithoutHeaderEncodingError()
+        {
+            // Given: a real-world release title (from DrunkenSlug/NZBgeek) with embedded
+            // quotes and a comma-decimal size, resolved the way the production pipeline does
+            var title = "DBS #0762 \"J.K. Rowling - Harry Potter 1-7 Audio Book (english)\" - " +
+                "\"Audio book - Harry Potter And The Deathly Hallows - J.K. Rowling.part01.rar\" (02_22) - 672,05 MB";
+            var candidate = new TrustedDownloadCandidate(
+                "release-1",
+                title,
+                "J.K. Rowling",
+                "Harry Potter",
+                "DrunkenSlug (Prowlarr)",
+                "MP3",
+                "en",
+                700_000_000,
+                null,
+                new DownloadSourceDescriptor(
+                    IndexerId: null,
+                    IndexerImplementation: "Newznab",
+                    Protocol: DownloadProtocol.Usenet,
+                    Locators: [new DownloadSourceLocator(DownloadSourceLocatorKind.NzbUrl, "https://indexer.example/nzb/1")]));
+            var downloader = new Mock<INzbFileDownloader>();
+            downloader
+                .Setup(d => d.DownloadAsync(It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync([1, 2, 3]);
+            var resolver = new GenericUsenetSourceResolver(downloader.Object);
+
+            // When: the title is resolved into a prepared submission and sent to SABnzbd
+            var submission = await resolver.ResolveAsync(candidate, provisionalDownloadId: null, CancellationToken.None);
+            var adapter = MockUtils.CreateSabnzbdAdapter(_provider);
+            var result = await adapter.AddAsync(_client, submission);
+
+            // Then: no ArgumentException, and SABnzbd actually received the addfile request
+            Assert.Equal("SABnzbd_nzo_addfile_test", result.ExternalId);
+            Assert.Single(sabnzbdApiMock.AddFileRequests);
+        }
+
         [Fact]
         public async Task TestConnectionAsync_NormalizesHostWithSchemeAndPath()
         {

--- a/tests/Mocks/Api/SabnzbdApiMock.cs
+++ b/tests/Mocks/Api/SabnzbdApiMock.cs
@@ -14,10 +14,12 @@ namespace Listenarr.Tests.Mocks.Api
         public System.Net.HttpStatusCode HistoryStatusCode { get; set; } = System.Net.HttpStatusCode.OK;
         public string? HistoryResponseOverride { get; set; }
         public List<Uri> RemovalRequests { get; } = [];
+        public List<Uri> AddFileRequests { get; } = [];
 
         public SabnzbdApiMock()
         {
             AddRoute("api", ProcessRequest, HttpMethod.Get);
+            AddRoute("api", ProcessRequest, HttpMethod.Post);
         }
 
         public async Task<HttpResponseMessage> GetHistory(HttpRequestMessage request, CancellationToken ct)
@@ -101,6 +103,17 @@ namespace Listenarr.Tests.Mocks.Api
             """);
         }
 
+        public async Task<HttpResponseMessage> AddFile(HttpRequestMessage request, CancellationToken ct)
+        {
+            AddFileRequests.Add(request.RequestUri!);
+            return MockUtils.GetCannedResponse("""
+            {
+                "status": true,
+                "nzo_ids": ["SABnzbd_nzo_addfile_test"]
+            }
+            """);
+        }
+
         public async Task<HttpResponseMessage> ProcessRequest(HttpRequestMessage request, CancellationToken ct)
         {
             var query = HttpUtility.ParseQueryString(request.RequestUri.Query);
@@ -109,6 +122,10 @@ namespace Listenarr.Tests.Mocks.Api
             if (string.Equals("version", mode))
             {
                 return await GetVersion(request, ct);
+            }
+            else if (string.Equals("addfile", mode))
+            {
+                return await AddFile(request, ct);
             }
             else if (string.Equals("history", mode))
             {


### PR DESCRIPTION
## Summary

Fixes #808.

Release titles containing `"` (very common in usenet subject lines — embedded sub-titles, part numbers, etc.) crash the SABnzbd add-file submission with `System.ArgumentException` thrown from `ContentDispositionHeaderValue.EncodeAndQuoteMime`, before the request ever reaches SABnzbd. The download silently disappears (the provisional download record is removed on submission failure).

**Root cause:** `GenericUsenetSourceResolver.SanitizeFileName()` only strips characters invalid for a *filesystem* filename (`Path.GetInvalidFileNameChars()` — on Linux/macOS this is essentially just `/`). `"` and `\` are valid filesystem characters there, so they pass through untouched, but this filename is then used as the multipart `Content-Disposition` `filename` parameter when POSTing to SABnzbd's `addfile` endpoint (`SabnzbdAddWorkflow.AddAsync`), and .NET's header-value quoting can't safely encode an unescaped `"`.

Note SABnzbd's actual displayed title comes from the separate `nzbname` query parameter (`SabnzbdAddRequestPlanner.BuildFileQueryParams`), not from this multipart filename, so sanitizing it further has no user-visible effect beyond fixing the crash.

## Changes

### Fixed
- `GenericUsenetSourceResolver.SanitizeFileName()` now also replaces `"` and `\` with `_`, alongside the existing filesystem-invalid-character check.

### Added
- Regression test `AddAsync_TitleContainsQuotesAndCommas_SendsNzbWithoutHeaderEncodingError` in `SabnzbdAdapterTests.cs`, using the real-world failing title from #808/production logs, asserting the full resolve → submit pipeline succeeds.
- An `addfile` mode handler on `SabnzbdApiMock` (previously only `version`/`history`/`queue` were handled; nothing exercised the add-file submission path via the shared mock).

## Testing

I couldn't get a clean local `dotnet test` run for this test class — **on this environment**, every test in `SabnzbdAdapterTests` (18/18, including unrelated pre-existing ones) fails at `InitializeAsync` → `AddAuthorizedRootAsync` with `PathIdentityState` `Expected: Valid, Actual: Unavailable`, when run inside a stock `mcr.microsoft.com/dotnet/sdk:10.0` container (tried both a plain `docker run` and one with `--cap-add SYS_ADMIN --security-opt seccomp=unconfined`; same result either way). I confirmed this is pre-existing and unrelated to this change by running the identical test file against unmodified `canary` HEAD in the same container — 17/17 fail the same way there too. Per `.github/AGENTS.md`'s own guidance ("a test skipped on the current host does not validate that platform... confirmed by the authoritative native Linux CI run"), I'm relying on CI for this test class rather than trying to fix an unrelated sandboxing limitation in this PR.

To still get direct proof the actual fix works, I wrote a standalone throwaway console app (not part of this PR) that calls `GenericUsenetSourceResolver.ResolveAsync` with the exact failing title from #808 and then performs the same `MultipartFormDataContent.Add(fileContent, "name", submission.FileName)` call `SabnzbdAddWorkflow` makes:

- Against unmodified `canary` HEAD: reproduces the exact reported exception verbatim —
  `ArgumentException: The format of value 'DBS #0762 "J.K. Rowling - Harry Potter 1-7 Audio Book (english)" - "Audio book - Harry Potter And The Deathly Hallows - J.K. Rowling.part01.rar" (02_22) - 672,05 MB.nzb' is invalid.`
- Against this branch: `Resolved FileName: DBS #0762 _J.K. Rowling - Harry Potter 1-7 Audio Book (english)_ - _Audio book - Harry Potter And The Deathly Hallows - J.K. Rowling.part01.rar_ (02_22) - 672,05 MB.nzb` → `PASS: MultipartFormDataContent.Add did not throw.`

- `dotnet build listenarr.slnx` — clean, 0 errors.
- `dotnet format listenarr.slnx --no-restore --verify-no-changes --include <the 3 changed files>` — clean, no formatting changes needed.

## Review coverage (per `.github/AGENTS.md`)

- Composition/DI: N/A — no service registrations, constructors, or lifetimes touched.
- Persistence/migrations: N/A — no EF/schema changes.
- Concurrency/cancellation: N/A — pure synchronous string transform, no new async paths.
- Filesystem/security boundaries: reviewed — this *tightens* the boundary (more characters rejected before reaching an HTTP header), doesn't relax anything.
- Serialization/identity: N/A.
- Recovery/restart: N/A.
- Frontend/backend contracts: N/A — backend-only, no API surface change.
- Platform behavior: reviewed — `Path.GetInvalidFileNameChars()` already differs between Windows and Unix; the two added characters (`"`, `\`) are additionally unsafe on both because the failure mode is in the HTTP header layer, not the filesystem layer, so this fix is platform-independent by construction.
- Tests: added (see above).