### PR TITLE
Fix SABnzbd downloads completing with no path set (race between active queue and history)

### DIFF
--- a/listenarr.infrastructure/DownloadClients/Sabnzbd/SabnzbdResponseMapper.cs
+++ b/listenarr.infrastructure/DownloadClients/Sabnzbd/SabnzbdResponseMapper.cs
@@ -49,6 +49,17 @@ internal static class SabnzbdResponseMapper
         var mappedStatus = MapQueueStatus(status);
         var storagePath = GetString(slot, "storage");
         var explicitContentPath = string.IsNullOrWhiteSpace(storagePath) ? null : storagePath;
+
+        // SABnzbd reports an item as "Completed" in the active queue briefly before
+        // archiving it to history with the real storage path - active-queue slots don't
+        // reliably expose it (see comment below). Reporting completion here anyway lets
+        // QueueItemConverter mark the download Completed with no DownloadPath, which
+        // permanently blocks import. Excluding it instead makes the caller treat this
+        // download as missing from the active queue, which triggers a same-cycle history
+        // lookup - and history has the storage path by then.
+        if (mappedStatus == "completed" && explicitContentPath == null)
+            return null;
+
         var remotePath = explicitContentPath ?? (string.IsNullOrWhiteSpace(client.DownloadPath)
             ? null
             : client.DownloadPath);

--- a/tests/Features/Infrastructure/DownloadClients/Sabnzbd/SabnzbdResponseMapperTests.cs
+++ b/tests/Features/Infrastructure/DownloadClients/Sabnzbd/SabnzbdResponseMapperTests.cs
@@ -1,0 +1,119 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace Listenarr.Tests.Features.Infrastructure.DownloadClients.Sabnzbd
+{
+    [Trait("Name", "SabnzbdResponseMapperTests")]
+    [Trait("Category", "SabnzbdResponseMapper")]
+    public sealed class SabnzbdResponseMapperTests
+    {
+        /// <summary>
+        /// Regression test for https://github.com/Listenarrs/Listenarr/issues/839
+        /// SABnzbd reports an item as "Completed" in the active queue before it is
+        /// archived to history with a real storage path. Mapping that slot to a
+        /// completed QueueItem let downloads reach DownloadStatus.Completed with an
+        /// empty DownloadPath, permanently blocking import.
+        /// </summary>
+        [Fact]
+        public void MapQueueSlotToQueueItem_CompletedStatusWithoutStorage_ReturnsNull()
+        {
+            // Given: an active-queue slot reporting Completed with no storage field yet
+            var client = new DownloadClientConfiguration { DownloadPath = "/downloads" };
+            using var document = System.Text.Json.JsonDocument.Parse(
+                """
+                {
+                  "nzo_id": "sab-race-1",
+                  "filename": "Book",
+                  "status": "Completed",
+                  "percentage": "100",
+                  "mb": "100",
+                  "mbleft": "0"
+                }
+                """);
+
+            // When
+            var item = SabnzbdResponseMapper.MapQueueSlotToQueueItem(
+                client,
+                document.RootElement,
+                configuredCategory: string.Empty,
+                speed: 0);
+
+            // Then: excluded rather than reported as a pathless completion
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void MapQueueSlotToQueueItem_CompletedStatusWithStorage_ReturnsCompletedItem()
+        {
+            // Given: an active-queue slot reporting Completed with a real storage path
+            var client = new DownloadClientConfiguration { DownloadPath = "/downloads" };
+            using var document = System.Text.Json.JsonDocument.Parse(
+                """
+                {
+                  "nzo_id": "sab-race-2",
+                  "filename": "Book",
+                  "status": "Completed",
+                  "percentage": "100",
+                  "mb": "100",
+                  "mbleft": "0",
+                  "storage": "/downloads/complete/Book"
+                }
+                """);
+
+            // When
+            var item = SabnzbdResponseMapper.MapQueueSlotToQueueItem(
+                client,
+                document.RootElement,
+                configuredCategory: string.Empty,
+                speed: 0);
+
+            // Then: a real storage path still resolves to a completed item, unaffected
+            Assert.NotNull(item);
+            Assert.Equal("completed", item!.Status);
+            Assert.Equal("/downloads/complete/Book", item.ContentPath);
+        }
+
+        [Fact]
+        public void MapQueueSlotToQueueItem_DownloadingStatusWithoutStorage_StillReturnsItem()
+        {
+            // Given: a genuinely still-downloading slot, which never carries storage
+            var client = new DownloadClientConfiguration { DownloadPath = "/downloads" };
+            using var document = System.Text.Json.JsonDocument.Parse(
+                """
+                {
+                  "nzo_id": "sab-race-3",
+                  "filename": "Book",
+                  "status": "Downloading",
+                  "percentage": "50",
+                  "mb": "100",
+                  "mbleft": "50"
+                }
+                """);
+
+            // When
+            var item = SabnzbdResponseMapper.MapQueueSlotToQueueItem(
+                client,
+                document.RootElement,
+                configuredCategory: string.Empty,
+                speed: 0);
+
+            // Then: the new guard only targets "completed" - in-progress items are unaffected
+            Assert.NotNull(item);
+            Assert.Equal("downloading", item!.Status);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #839.

SABnzbd downloads occasionally get marked `Completed` with an empty `DownloadPath`, which permanently blocks import: `DownloadProcessingJobProcessor.ProcessJobAsync` throws `Inconsistency: Download {id} has no path set` and nothing ever retries with a corrected path afterward — the download just sits `ImportBlocked` forever. Hit this repeatedly (6 different releases) across a single session of grabbing several audiobooks in quick succession.

**Root cause:** SABnzbd briefly reports an item as `status: "Completed"` in the active queue (`mode=queue`) before archiving it to history (`mode=history`) with the real `storage` path. `SabnzbdResponseMapper.MapQueueSlotToQueueItem`'s own existing comment already acknowledges this ("Active SABnzbd queue slots do not reliably expose the completed storage path") but the method still mapped that slot into a `QueueItem` with `Status = "completed"` regardless. `QueueItemConverter.UpdateFromQueueItem` then sees `normalizedState == "completed"` and calls `download.Completed()` immediately, before a path was ever set (`download.DownloadPath` is only assigned `if (!string.IsNullOrEmpty(item.LocalPath))`). Once `Status == Completed`, nothing backfills the path — the download is stuck.

## Changes

### Fixed
- `SabnzbdResponseMapper.MapQueueSlotToQueueItem`: when the mapped status is `"completed"` and there's no explicit `storage` path on the slot, return `null` instead of a pathless completed `QueueItem`.

This isn't a dead end for that download — excluding it from the active-queue result set makes `SabnzbdQueueFetchWorkflow.GetMissingTrackedIds` treat it as missing from the queue, which sets `historyRequired = true` and triggers a history lookup **in the same poll cycle**. History reliably has the real `storage` path by the time an item shows up there, so the download resolves correctly via `MapHistorySlotToQueueItem` (the code path that already works), instead of completing early on unreliable telemetry.

### Added
- `SabnzbdResponseMapperTests.cs` — three focused unit tests directly against the static mapper (no DI/database/filesystem needed):
  - `MapQueueSlotToQueueItem_CompletedStatusWithoutStorage_ReturnsNull` — the regression case.
  - `MapQueueSlotToQueueItem_CompletedStatusWithStorage_ReturnsCompletedItem` — a real storage path still resolves normally, unaffected.
  - `MapQueueSlotToQueueItem_DownloadingStatusWithoutStorage_StillReturnsItem` — the guard only targets `"completed"`; genuinely in-progress items (which never carry `storage`) are unaffected.

## Testing

- `dotnet test tests/Listenarr.Tests.csproj --filter 'FullyQualifiedName~SabnzbdResponseMapperTests'` — 3/3 pass on this branch.
- Confirmed the regression test actually catches the bug: ran the identical test file against unmodified `canary` HEAD — `MapQueueSlotToQueueItem_CompletedStatusWithoutStorage_ReturnsNull` fails there (`Assert.Null() Failure: Value is not null`), the other two pass on both. So this isn't a test that would have passed regardless of the fix.
- `dotnet build listenarr.slnx` — clean, 0 warnings, 0 errors.
- `dotnet format listenarr.slnx --no-restore --verify-no-changes --include <the 2 changed files>` — clean, no formatting changes needed.

These tests are plain static-method unit tests (no `BaseTests`/DI/EF/filesystem semantics involved), so they run cleanly in a sandboxed container without hitting the `IFileSystemSemanticsResolver` environment limitation I ran into on my previous PR (#837).

## Review coverage (per `.github/AGENTS.md`)

- Composition/DI: N/A — no service registrations, constructors, or lifetimes touched.
- Persistence/migrations: N/A — no EF/schema changes.
- Concurrency/cancellation: this change *fixes* a concurrency/timing issue (a race between two SABnzbd endpoints reporting inconsistent state for the same item); no new async paths introduced.
- Filesystem/security boundaries: N/A.
- Serialization/identity: N/A — pure JSON-slot-to-QueueItem mapping, same shape as existing code.
- Recovery/restart: improves it — previously-stuck downloads following this exact pattern should now resolve on their own via the next poll cycle rather than needing manual deletion (I was manually deleting these before diagnosing the root cause).
- Frontend/backend contracts: N/A — backend-only, no API surface change.
- Platform behavior: N/A — no OS-specific code involved.
- Tests: added (see above), and verified they actually distinguish fixed vs. unfixed behavior.

## Related

I also opened #838 (missing blocklist/blocklist feature) from the same session — unrelated root cause, separate issue, not addressed by this PR.