### PR TITLE
fix(import): actually embed the ASIN after an import

### DIFF
--- a/listenarr.infrastructure/FileSystem/PinnedAudiobookFileRegistrationLease.cs
+++ b/listenarr.infrastructure/FileSystem/PinnedAudiobookFileRegistrationLease.cs
@@ -65,7 +65,9 @@ internal sealed class PinnedAudiobookFileRegistrationLease :
                 "Pinned path-only registration leases do not authorize metadata writes.");
         }
 
-        return _file.OpenIndependentWriteStream(
+        // Read+write, because the only consumer is a tag library that parses the container it
+        // is about to rewrite through this same stream.
+        return _file.OpenIndependentReadWriteStream(
             bufferSize: 128 * 1024,
             asynchronous: false);
     }

--- a/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.FileMove.Native.cs
+++ b/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.FileMove.Native.cs
@@ -101,12 +101,15 @@ internal sealed partial class PinnedDirectoryCreation
     private static SafeFileHandle OpenRelativeFileForWriteUnix(
         SafeFileHandle parentHandle,
         string fileName,
-        string fullPath)
+        string fullPath,
+        bool readable = false)
     {
         var fd = OpenAt(
             parentHandle.DangerousGetHandle().ToInt32(),
             fileName,
-            UnixOpenFlags.OpenWriteNoFollow(),
+            readable
+                ? UnixOpenFlags.OpenReadWriteNoFollow()
+                : UnixOpenFlags.OpenWriteNoFollow(),
             mode: 0);
         if (fd >= 0)
         {

--- a/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.FileOpenWindows.cs
+++ b/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.FileOpenWindows.cs
@@ -259,7 +259,8 @@ internal sealed partial class PinnedDirectoryCreation
     private static SafeFileHandle OpenRelativeFileForWriteWindows(
         SafeFileHandle parentHandle,
         string fileName,
-        string fullPath)
+        string fullPath,
+        bool readable = false)
     {
         var nameBuffer = Marshal.StringToHGlobalUni(fileName);
         var unicodeStringPointer = IntPtr.Zero;
@@ -281,7 +282,8 @@ internal sealed partial class PinnedDirectoryCreation
             };
             var status = NtCreateFile(
                 out var rawHandle,
-                GenericWrite | FileReadAttributes | Synchronize,
+                (readable ? GenericRead : 0u)
+                    | GenericWrite | FileReadAttributes | Synchronize,
                 ref attributes,
                 out _,
                 IntPtr.Zero,

--- a/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.FileStreams.cs
+++ b/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.FileStreams.cs
@@ -23,21 +23,28 @@ internal sealed partial class PinnedDirectoryCreation
                 asynchronous);
         }
 
-        internal FileStream OpenIndependentWriteStream(int bufferSize, bool asynchronous)
+        // Tag libraries rewrite a container in place: they parse the existing box or frame
+        // structure through the same stream they then write back to, so a write-only handle
+        // fails while still reading. The pinning is unaffected by the wider access mode — the
+        // handle is still opened relative to the pinned parent, still refuses to follow a
+        // link, and is still checked against the validated file object below.
+        internal FileStream OpenIndependentReadWriteStream(int bufferSize, bool asynchronous)
         {
             ThrowIfDisposed();
             var handle = OperatingSystem.IsWindows()
                 ? OpenRelativeFileForWriteWindows(
                     _parentHandle,
                     _fileName,
-                    FullPath)
+                    FullPath,
+                    readable: true)
                 : OpenRelativeFileForWriteUnix(
                     _parentHandle,
                     _fileName,
-                    FullPath);
+                    FullPath,
+                    readable: true);
             return OpenVerifiedIndependentStream(
                 handle,
-                FileAccess.Write,
+                FileAccess.ReadWrite,
                 bufferSize,
                 asynchronous);
         }

--- a/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.FileStreams.cs
+++ b/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.FileStreams.cs
@@ -25,7 +25,7 @@ internal sealed partial class PinnedDirectoryCreation
 
         // Tag libraries rewrite a container in place: they parse the existing box or frame
         // structure through the same stream they then write back to, so a write-only handle
-        // fails while still reading. The pinning is unaffected by the wider access mode — the
+        // fails while still reading. The pinning is unaffected by the wider access mode. The
         // handle is still opened relative to the pinned parent, still refuses to follow a
         // link, and is still checked against the validated file object below.
         internal FileStream OpenIndependentReadWriteStream(int bufferSize, bool asynchronous)

--- a/listenarr.infrastructure/FileSystem/UnixOpenFlags.cs
+++ b/listenarr.infrastructure/FileSystem/UnixOpenFlags.cs
@@ -76,6 +76,20 @@ internal static class UnixOpenFlags
         return LinuxWriteOnly | noFollow | LinuxCloseOnExec;
     }
 
+    // For a caller that has to read the file back through the same descriptor it writes to.
+    // Tag libraries do this: they parse the existing container through the stream they are
+    // about to rewrite, so a write-only descriptor fails partway through the parse.
+    internal static int OpenReadWriteNoFollow()
+    {
+        if (IsMacOSHost())
+        {
+            return MacReadWrite | MacNoFollow | MacCloseOnExec;
+        }
+
+        var (_, noFollow) = GetCurrentLinuxDirectorySafetyFlags();
+        return LinuxReadWrite | noFollow | LinuxCloseOnExec;
+    }
+
     internal static int CreateWriteExclusiveNoFollow()
     {
         if (IsMacOSHost())

--- a/listenarr.infrastructure/Library/Files/TagLibAudioTagWriter.cs
+++ b/listenarr.infrastructure/Library/Files/TagLibAudioTagWriter.cs
@@ -90,7 +90,11 @@ namespace Listenarr.Infrastructure.Library.Files
 
         private static void ApplyAsinTag(TagLib.File file, string asin)
         {
-            if (file.Tag is TagLib.Mpeg4.AppleTag appleTag)
+            // An MPEG-4 file's Tag is a CombinedTag wrapping the Apple tag, never the AppleTag
+            // itself, so a type test on file.Tag matches nothing here and the save that follows
+            // writes an unchanged file while still reporting success. The tag has to be asked
+            // for by type. Only MPEG-4 answers to Apple, so mp3 and flac fall through as before.
+            if (file.GetTag(TagLib.TagTypes.Apple, create: true) is TagLib.Mpeg4.AppleTag appleTag)
                 appleTag.SetDashBox("com.apple.iTunes", "ASIN", asin);
             else if (file.GetTag(TagLib.TagTypes.Id3v2) is TagLib.Id3v2.Tag id3Tag)
             {

--- a/tests/Features/Infrastructure/FileSystem/PinnedAudiobookFileRegistrationLeaseTests.cs
+++ b/tests/Features/Infrastructure/FileSystem/PinnedAudiobookFileRegistrationLeaseTests.cs
@@ -93,6 +93,32 @@ public sealed class PinnedAudiobookFileRegistrationLeaseTests : BaseTests
             await File.ReadAllTextAsync(displacedPath));
     }
 
+    [Fact]
+    public async Task OpenMetadataWriteStream_IsReadableSoATagLibraryCanParseWhatItRewrites()
+    {
+        var parent = FileService.GetTempDirectory(
+            "registration-lease-metadata-write-access");
+        var publicPath = await FileService.GetFileAsync(
+            parent,
+            "book.m4b",
+            "original generation");
+        using var lease = PinnedAudiobookFileRegistrationLease.Open(publicPath);
+
+        using var stream = lease.OpenMetadataWriteStream();
+
+        // TagLib reads the existing box structure back through the write stream before it
+        // saves, so a write-only handle throws NotSupportedException mid-parse and the tag is
+        // never written. The import still reports success, which is why this needs asserting
+        // rather than observing.
+        Assert.True(stream.CanWrite);
+        Assert.True(stream.CanRead);
+        Assert.True(stream.CanSeek);
+
+        var buffer = new byte[stream.Length];
+        Assert.Equal(buffer.Length, stream.Read(buffer, 0, buffer.Length));
+        Assert.Equal("original generation", System.Text.Encoding.UTF8.GetString(buffer));
+    }
+
     [WindowsFact]
     public async Task StableRegistrationLease_BlocksPublicPathReplacementUntilDisposed()
     {

--- a/tests/Features/Infrastructure/FileSystem/UnixOpenFlagsTests.cs
+++ b/tests/Features/Infrastructure/FileSystem/UnixOpenFlagsTests.cs
@@ -49,6 +49,21 @@ public sealed class UnixOpenFlagsTests : BaseTests
     }
 
     [Fact]
+    public void OpenReadWriteNoFollow_AsksForReadAccessWhereOpenWriteDoesNot()
+    {
+        // Given / When
+        var writeOnly = UnixOpenFlags.OpenWriteNoFollow();
+        var readWrite = UnixOpenFlags.OpenReadWriteNoFollow();
+
+        // Then: the access mode is the low two bits, and only that differs. Asserting the
+        // difference rather than a literal keeps this honest on both released architectures,
+        // since the noFollow bit is not the same value on arm64 and x64.
+        Assert.Equal(1, writeOnly & 0x3);
+        Assert.Equal(2, readWrite & 0x3);
+        Assert.Equal(writeOnly & ~0x3, readWrite & ~0x3);
+    }
+
+    [Fact]
     public void EnsureMacOSArchitectureSupported_AcceptsReleasedX64Target()
     {
         // Given / When / Then


### PR DESCRIPTION
## Summary

After a successful manual import, the step that writes the book's ASIN into the imported file's own tags never gets there. Two independent faults, and the import reports success through both of them, because the enrichment step is deliberately non-fatal.

Full write-up, measurements and the one decision I did not want to make myself are in #842.

## Changes

### Fixed
- `UnixOpenFlags` gains `OpenReadWriteNoFollow()` beside the existing `OpenWriteNoFollow()`. `PinnedFileEntry.OpenIndependentWriteStream` becomes `OpenIndependentReadWriteStream` and uses it, so the stream handed to TagLib can be read as well as written. `Mpeg4.File.Save()` parses the existing box structure through that same stream before writing, so a write-only handle throws `NotSupportedException` mid-parse.
- `ApplyAsinTag` asks for the tag by type, `file.GetTag(TagTypes.Apple, create: true)`, rather than testing `file.Tag is AppleTag`. An MPEG-4 file's `Tag` is a `CombinedTag` wrapping the Apple tag, so the type test never matched and `Save()` rewrote an unchanged file. Only MPEG-4 answers to Apple, so mp3 and flac fall through as before.

The second fault is why the first one alone is not enough. On a build carrying only the stream change, the writer stops throwing and logs `Wrote ASIN tag` at Debug for a file whose bytes did not change. That was observed on the way through rather than predicted.

Pinning is unchanged. The handle is still opened relative to the pinned parent, still refuses to follow a link, and is still checked against the validated file object. Widening the access mode does not widen what the lease will open.

## Testing

`PinnedAudiobookFileRegistrationLeaseTests` gains a case asserting the metadata write stream is readable, seekable and returns the file's existing bytes. Verified as a real guard in both directions: with `FileAccess.Write` restored it fails on `CanRead`, and with the change it passes.

`UnixOpenFlagsTests` gains a case for the new method, asserting that only the access-mode bits differ from `OpenWriteNoFollow` and that everything else is identical. It is written as a difference rather than as a literal on purpose, since #828 established that `noFollow` is not the same value on arm64 and x64.

Full suite on this branch: 3,031 passed, 0 failed, 125 skipped, against a 3,029 baseline on `03958c15`.

Reproduced end to end before and after against `ghcr.io/listenarrs/listenarr:canary`. On canary the imported file reads untagged with one `Failed to write ASIN tag` in the log; on a build of this branch it reads tagged and ffprobe reports the ASIN on the destination. The check is public, in the test-data repo linked from the issue, and it refuses a verdict unless a hand-stamped control reads tagged and the input file reads untagged in the same run.

## Notes

This is rebuilt on top of #828. The earlier version of the change added a `bool readable` parameter to `GetUnixWriteExistingFlags`, which that commit deleted. Adding a sibling method to the new helper is both smaller and better, since it picks up the per-architecture `noFollow` detection rather than carrying a literal of its own.

One thing I would rather you decided than me, and it is the reason this is worth a look beyond the diff. The lease exists to fence a specific generation of a specific file, and I do not know whether write-only was a deliberate part of that. Nothing reads back through the handle today and the pinning is enforced separately, which is why I think widening it is safe. If it was deliberate, the fix belongs elsewhere: open a separate read+write handle for tagging and verify identity against the lease, rather than widening the lease's own. Say so and I will redo it that way.
