### PR TITLE
fix(scan): group chapter files indexed as "N of M" into one unmatched-scan item

### DIFF
--- a/listenarr.infrastructure/Library/Scanning/UnmatchedScanProcessor.Grouping.cs
+++ b/listenarr.infrastructure/Library/Scanning/UnmatchedScanProcessor.Grouping.cs
@@ -405,15 +405,27 @@ namespace Listenarr.Infrastructure.Library.Scanning
 
         /// <summary>
         /// Extracts a normalized title stem from a filename for grouping purposes.
-        /// Strips leading track numbers, trailing Part/CD/Disc numbers, year and
-        /// series decorations in brackets. Files that resolve to the same stem are
-        /// treated as parts of the same audiobook. Returns the folder name as fallback
-        /// when the stem would otherwise be empty (for example purely numeric filenames).
+        /// Strips a trailing "N of M" index, leading track numbers, trailing
+        /// Part/CD/Disc numbers, year and series decorations in brackets. Files that
+        /// resolve to the same stem are treated as parts of the same audiobook. Returns
+        /// the folder name as fallback when the stem would otherwise be empty (for
+        /// example purely numeric filenames).
         /// </summary>
         private static string ExtractTitleStem(string filePath, string folderPath)
         {
             var name = Path.GetFileNameWithoutExtension(filePath);
 
+            // Strip a trailing "N of M" index: "Title 001 of 498", "Title - 3 of 12".
+            //
+            // This runs BEFORE the leading-track strip on purpose. A file named "001 of 498"
+            // with no title in it would otherwise lose its leading "001 " first, leaving
+            // "of 498" — a different stem in every file, and no longer numeric, so the
+            // folder-name fallback at the end never gets the chance to group them.
+            //
+            // Unlike a bare "(N)", this form is not ambiguous with a series marker: it
+            // carries its own total, so it says the file is one part of a set rather than
+            // one entry among separate works. Nothing is titled "Book 1 of 12".
+            name = Regex.Replace(name, @"[\s\-_]*\d+\s*of\s*\d+$", "", RegexOptions.IgnoreCase);
             // Strip leading track/disc number prefix: "01 - ", "Track 01 - ", "1. "
             name = Regex.Replace(name, @"^(track\s*)?\d+[\s\-_\.]+", "", RegexOptions.IgnoreCase);
             // Strip trailing Part/CD/Disc/Chapter number: "- Part 1", "CD2", "Disc 2", "pt00"

--- a/tests/Features/Api/Services/UnmatchedScanBackgroundServiceTests.cs
+++ b/tests/Features/Api/Services/UnmatchedScanBackgroundServiceTests.cs
@@ -119,5 +119,63 @@ namespace Listenarr.Tests.Features.Api.Services
             Assert.Contains(groups, group => group.Single() == fileA);
             Assert.Contains(groups, group => group.Single() == fileB);
         }
+
+        [Fact]
+        public void BuildGroupedFilesForFolder_GroupsChapterFilesIndexedAsNumberOfTotal()
+        {
+            // A chapter-per-file rip that numbers its parts "N of M". The index carries its
+            // own total, so it describes a set rather than distinct works, and every file
+            // belongs to the one book the folder names.
+            var folder = @"D:\test\Jack of Shadows";
+            var files = Enumerable.Range(1, 4)
+                .Select(n => Path.Join(folder, $"Jack of Shadows {n:000} of 004.mp3"))
+                .ToArray();
+
+            var groups = UnmatchedScanBackgroundService.BuildGroupedFilesForFolder(
+                files,
+                folder,
+                FileSystemPathSemantics.CurrentHostDefault);
+
+            var group = Assert.Single(groups);
+            Assert.Equal(4, group.Count);
+        }
+
+        [Fact]
+        public void BuildGroupedFilesForFolder_GroupsBareNumberOfTotalFilenames()
+        {
+            // The same convention with no title in the filename at all. Stripping the index
+            // empties the stem, which is what lets the folder-name fallback gather them.
+            var folder = @"D:\test\Jack of Shadows";
+            var files = Enumerable.Range(1, 3)
+                .Select(n => Path.Join(folder, $"{n:000} of 003.mp3"))
+                .ToArray();
+
+            var groups = UnmatchedScanBackgroundService.BuildGroupedFilesForFolder(
+                files,
+                folder,
+                FileSystemPathSemantics.CurrentHostDefault);
+
+            var group = Assert.Single(groups);
+            Assert.Equal(3, group.Count);
+        }
+
+        [Fact]
+        public void BuildGroupedFilesForFolder_KeepsTitlesWhoseOwnWordsReadLikeAnIndex()
+        {
+            // "of" between two words is not an index, and a trailing number is not a total.
+            // Two separate works in one author folder must stay separate.
+            var folder = @"D:\test\Roger Zelazny";
+            var jack = Path.Join(folder, "Jack of Shadows.mp3");
+            var nine = Path.Join(folder, "Nine Princes in Amber 2.mp3");
+
+            var groups = UnmatchedScanBackgroundService.BuildGroupedFilesForFolder(
+                new[] { jack, nine },
+                folder,
+                FileSystemPathSemantics.CurrentHostDefault);
+
+            Assert.Equal(2, groups.Count);
+            Assert.Contains(groups, group => group.Single() == jack);
+            Assert.Contains(groups, group => group.Single() == nine);
+        }
     }
 }


### PR DESCRIPTION
## Summary

A chapter-per-file book numbered `Title 001 of 006`, with no album tag to fall back on, comes back from Library Import as one scan item per file. This strips a trailing `N of M` index in `ExtractTitleStem` so those files share a stem and group into one item.

Full write-up, the measurements and the case I deliberately did not touch are in #844.

## Changes

### Fixed
- `ExtractTitleStem` strips a trailing `[\s\-_]*\d+\s*of\s*\d+$` before the existing leading-track strip.

The ordering is the part worth reviewing. A file named `001 of 498`, with no title in it at all, loses its leading `001 ` first if these run the other way round. That leaves `of 498`, which is a different stem in every file and is no longer numeric, so the folder-name fallback at the end never gets the chance to gather them. The comment says so at the call site.

`(N)` is deliberately untouched. The existing comment explains that plain numeric parens are kept because they distinguish separate books in a series, which is a real tradeoff rather than an oversight, so changing it is a product decision rather than a bug fix. The issue lays out the case for revisiting it, including that the frontend already disagrees with the backend about what `(N)` means.

## Testing

Three tests in `UnmatchedScanBackgroundServiceTests`:

- the ordinary case, `Jack of Shadows 001 of 004.mp3` and siblings, grouping into one
- the bare case, `001 of 003.mp3` with no title in the filename, which is the one that fails if the two strips run in the wrong order
- a negative case holding `Jack of Shadows.mp3` and `Nine Princes in Amber 2.mp3` apart in one author folder, since "of" between two words is not an index and a trailing number is not a total

Full suite on this branch: 3,032 passed, 0 failed, 125 skipped, against a 3,029 baseline on `03958c15`.

Reproduced end to end before and after against `ghcr.io/listenarrs/listenarr:canary`, using a generated library of nine folders that vary only in filename convention and title tags. On canary two of the nine explode; on a build of this branch `notags-n-of-m` groups into one item, `notags-paren-index` is unchanged and still explodes by design, and the other seven stay grouped. So it moves exactly the case it targets and nothing else. The check is public, in the test-data repo linked from the issue.

## Notes

The album-tag detail is worth knowing when judging the blast radius. Filenames are grouped first and embedded tags are only consulted when that produced more than one group, and the value compared is `album` rather than `title`. Any folder whose files share an album tag was already being rescued by the metadata pass, so this only changes what happens to files carrying no album tag at all.
