### PR TITLE
Fix optional token elision in naming patterns

### DIFF
--- a/listenarr.application/Common/FileNamingService.cs
+++ b/listenarr.application/Common/FileNamingService.cs
@@ -207,7 +207,7 @@ namespace Listenarr.Application.Common
 
             // Replace variables. If a variable is empty, emit a sentinel so we can clean up surrounding
             // punctuation and separators (for example: remove "{Series}/" when Series is empty).
-            const string EmptySentinel = "__EMPTY_VAR__";
+            const string EmptySentinel = "\uE000";
             result = variableRegex.Replace(result, match =>
             {
                 var variableName = match.Groups[1].Value;
@@ -253,10 +253,18 @@ namespace Listenarr.Application.Common
                 return EmptySentinel;
             });
 
-            // Cleanup: remove empty sentinel inside any brackets (e.g. "(__EMPTY_VAR__)" -> "")
-            result = Regex.Replace(result, @"[\(\[\{]\s*" + EmptySentinel + @"\s*[\)\]\}]", string.Empty);
+            // Cleanup order matters. Bracket groups are resolved first so a sentinel can never leak a
+            // stray separator or slash into the rendered name.
 
-            // Remove common separators adjacent to the sentinel (e.g. " - __EMPTY_VAR__" or "__EMPTY_VAR__ - ")
+            // Bracket groups: a group whose contents are entirely empty tokens disappears, however many
+            // tokens it held; a group that still holds real content keeps the group and drops only the
+            // empty tokens. This is what lets "[{Series} {SeriesNumber}]" vanish for a standalone book
+            // and render as "[Radicalized]" for a series with no number.
+            result = CollapseBracketGroup(result, '(', ')', EmptySentinel);
+            result = CollapseBracketGroup(result, '[', ']', EmptySentinel);
+            result = CollapseBracketGroup(result, '{', '}', EmptySentinel);
+
+            // Remove common separators adjacent to any surviving sentinel (e.g. " - {sentinel}")
             result = Regex.Replace(result, @"\s*[-–—:_]\s*" + EmptySentinel, string.Empty);
             result = Regex.Replace(result, EmptySentinel + @"\s*[-–—:_]\s*", string.Empty);
 
@@ -305,6 +313,45 @@ namespace Listenarr.Application.Common
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Resolves a single kind of bracket group against empty-token sentinels.
+        /// Groups holding nothing but sentinels are removed entirely; groups that retain real content
+        /// keep their brackets with the sentinels stripped out.
+        /// </summary>
+        private static string CollapseBracketGroup(string input, char open, char close, string sentinel)
+        {
+            // Escape explicitly rather than via Regex.Escape: Regex.Escape leaves ']' and '}' alone,
+            // and a bare ']' would close the negated character class below early.
+            var openEscaped = "\\" + open;
+            var closeEscaped = "\\" + close;
+
+            // Non-nested groups only - a group may not contain its own delimiters.
+            var groupPattern = openEscaped + "[^" + openEscaped + closeEscaped + "]*" + closeEscaped;
+
+            return Regex.Replace(input, groupPattern, match =>
+            {
+                var group = match.Value;
+                if (!group.Contains(sentinel, StringComparison.Ordinal))
+                {
+                    return group;
+                }
+
+                var inner = group
+                    .Substring(1, group.Length - 2)
+                    .Replace(sentinel, string.Empty, StringComparison.Ordinal);
+
+                inner = Regex.Replace(inner, @"\s{2,}", " ").Trim();
+
+                // Nothing meaningful survived - drop the whole group.
+                if (!inner.Any(char.IsLetterOrDigit))
+                {
+                    return string.Empty;
+                }
+
+                return open + inner + close;
+            });
         }
 
         public string ApplyNamingPattern(string pattern, AudioMetadata metadata, bool treatAsFilename = false)

--- a/tests/Features/Api/Services/FileNamingService_OptionalTokenElisionTests.cs
+++ b/tests/Features/Api/Services/FileNamingService_OptionalTokenElisionTests.cs
@@ -1,0 +1,137 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace Listenarr.Tests.Features.Api.Services
+{
+    /// <summary>
+    /// A bracket group may hold more than one optional token (for example "[{Series} {SeriesNumber}]").
+    /// These cover the group disappearing when every token inside it is empty, and surviving with the
+    /// empty tokens stripped when some content remains.
+    /// </summary>
+    public class FileNamingService_OptionalTokenElisionTests
+    {
+        private const string FolderPattern =
+            "{Author}/[{Series} {SeriesNumber}] {Title} {{Narrator}} ({Year})";
+
+        private const string FilePattern =
+            "{Author} - [{Series} {SeriesNumber}] {Title} {{Narrator}} ({Year})";
+
+        private static FileNamingService CreateService()
+        {
+            var loggerMock = new Mock<ILogger<FileNamingService>>();
+            var configMock = new Mock<IConfigurationService>();
+            return new FileNamingService(configMock.Object, loggerMock.Object);
+        }
+
+        private static Dictionary<string, object> Variables(
+            string author, string series, string seriesNumber, string title, string narrator, string year)
+        {
+            return new Dictionary<string, object>
+            {
+                { "Author", author },
+                { "Series", series },
+                { "SeriesNumber", seriesNumber },
+                { "Title", title },
+                { "Narrator", narrator },
+                { "Year", year }
+            };
+        }
+
+        [Fact]
+        public void AllTokensPresent_RendersEveryGroup()
+        {
+            var result = CreateService().ApplyNamingPattern(
+                FolderPattern,
+                Variables("J.K. Rowling", "Harry Potter", "1", "Harry Potter and the Sorcerer's Stone", "Jim Dale", "1997"));
+
+            Assert.Equal(
+                Path.Join("J.K. Rowling", "[Harry Potter 1] Harry Potter and the Sorcerer's Stone {Jim Dale} (1997)"),
+                result);
+        }
+
+        [Fact]
+        public void EmptySeriesTokens_DropTheWholeBracketGroup()
+        {
+            var result = CreateService().ApplyNamingPattern(
+                FolderPattern,
+                Variables("J.K. Rowling", null, null, "The Ickabog", "Stephen Fry", "2020"));
+
+            Assert.Equal(
+                Path.Join("J.K. Rowling", "The Ickabog {Stephen Fry} (2020)"),
+                result);
+        }
+
+        [Fact]
+        public void EmptySeriesAndNarrator_LeaveOnlyTitleAndYear()
+        {
+            var result = CreateService().ApplyNamingPattern(
+                FolderPattern,
+                Variables("Adrian Tchaikovsky", null, null, "Cage of Souls", null, "2019"));
+
+            Assert.Equal(
+                Path.Join("Adrian Tchaikovsky", "Cage of Souls (2019)"),
+                result);
+        }
+
+        [Fact]
+        public void SeriesWithoutNumber_KeepsBracketGroupWithoutStrayCharacters()
+        {
+            var result = CreateService().ApplyNamingPattern(
+                FolderPattern,
+                Variables("Cory Doctorow", "Radicalized", null, "Radicalized", null, "2019"));
+
+            Assert.Equal(
+                Path.Join("Cory Doctorow", "[Radicalized] Radicalized (2019)"),
+                result);
+        }
+
+        [Fact]
+        public void TrailingOptionalTokens_LeaveNoTrailingSeparators()
+        {
+            var result = CreateService().ApplyNamingPattern(
+                FolderPattern,
+                Variables("Alastair Reynolds", "Revelation Space", "11", "Chasm City", null, null));
+
+            Assert.Equal(
+                Path.Join("Alastair Reynolds", "[Revelation Space 11] Chasm City"),
+                result);
+        }
+
+        [Fact]
+        public void FilenamePattern_ElidesEmptyGroupsToo()
+        {
+            var result = CreateService().ApplyNamingPattern(
+                FilePattern,
+                Variables("J.K. Rowling", null, null, "The Ickabog", "Stephen Fry", "2020"),
+                treatAsFilename: true);
+
+            Assert.Equal("J.K. Rowling - The Ickabog {Stephen Fry} (2020)", result);
+        }
+
+        [Fact]
+        public void SentinelNeverLeaksIntoOutput()
+        {
+            var result = CreateService().ApplyNamingPattern(
+                FolderPattern,
+                Variables("Some Author", null, null, "Some Title", null, null));
+
+            Assert.DoesNotContain("EMPTY", result, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain('\uE000', result);
+            Assert.Equal(Path.Join("Some Author", "Some Title"), result);
+        }
+    }
+}

--- a/tests/Features/Api/Services/FileNamingService_OptionalTokenElisionTests.cs
+++ b/tests/Features/Api/Services/FileNamingService_OptionalTokenElisionTests.cs
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+using Listenarr.Tests.Common;
+
 namespace Listenarr.Tests.Features.Api.Services
 {
     /// <summary>
@@ -22,7 +24,10 @@ namespace Listenarr.Tests.Features.Api.Services
     /// These cover the group disappearing when every token inside it is empty, and surviving with the
     /// empty tokens stripped when some content remains.
     /// </summary>
-    public class FileNamingService_OptionalTokenElisionTests
+    [Trait("Area", "Api")]
+    [Trait("Name", "FileNamingService_OptionalTokenElisionTests")]
+    [Trait("Category", "FileNamingService")]
+    public class FileNamingService_OptionalTokenElisionTests : BaseTests
     {
         private const string FolderPattern =
             "{Author}/[{Series} {SeriesNumber}] {Title} {{Narrator}} ({Year})";


### PR DESCRIPTION
## Summary

Naming patterns support optional tokens by emitting a sentinel for empty values and stripping the surrounding punctuation afterwards. That works for a bracket group holding a single token, but not for one holding several — so a pattern like `[{Series} {SeriesNumber}]` leaks a literal sentinel into folder and file names for every book without a series.

With `{Author}/[{Series} {SeriesNumber}] {Title} {{Narrator}} ({Year})`:

| Case | Before | After |
|---|---|---|
| Standalone book | `J.K. Rowling/[__EMPTY_VAR_] The Ickabog {Stephen Fry} (2020)` | `J.K. Rowling/The Ickabog {Stephen Fry} (2020)` |
| Series without a number | `Cory Doctorow/[Radicalized /] Radicalized (2019)` | `Cory Doctorow/[Radicalized] Radicalized (2019)` |
| Series with everything | unchanged | unchanged |

Two root causes:

1. The sentinel was `__EMPTY_VAR__`, and `_` is part of the separator character class used by the cleanup regexes — so cleanup partially consumed the sentinel itself, leaving `__EMPTY_VAR_` behind.
2. The bracket rule only matched a group containing exactly one sentinel. With two, the group survived long enough for the slash rule to rewrite the sentinel as `/` *inside* the brackets.

## Changes

### Fixed
- Replace the `__EMPTY_VAR__` sentinel with `U+E000`, which shares no characters with the separator class.
- Resolve bracket groups before separator and slash handling, so a surviving sentinel can no longer inject a stray `/` into a name.
- Collapse bracket groups containing any number of empty tokens: drop the group when nothing meaningful survives, otherwise keep it with the empty tokens removed.

### Added
- `FileNamingService_OptionalTokenElisionTests` covering all-tokens-present, empty series, empty series + narrator, series without a number, trailing optional tokens, the filename variant, and a guard that the sentinel never reaches output.

## Testing

`dotnet test` filtered to the naming suites: **28 passed, 1 failed**.

The single failure is `DownloadNaming_AudiobookMetadataTests.ProcessCompletedDownload_UsesAudiobookMetadata_ForNaming`, which **fails identically on unmodified `canary`** — verified by stashing this change and re-running that test alone. It is pre-existing and unrelated.

Existing `DownloadNaming_PatternCollapseTests` and `FileNamingService_PatternSelectionTests` still pass, so single-token groups and duplicate-component collapsing are unaffected.

## Notes

Delimiters are escaped explicitly rather than through `Regex.Escape`, which does not escape `]` — building the negated class with it produces `[^\[]]`, closing the class early. That bug was caught by the new tests.

Behaviour only changes where the old output was already broken; patterns whose groups hold a single token render exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
