### PR TITLE
fix(filemover): log a blocked or failed mutation above Information

### DIFF
--- a/listenarr.infrastructure/FileSystem/FileMover.Actions.cs
+++ b/listenarr.infrastructure/FileSystem/FileMover.Actions.cs
@@ -408,7 +408,15 @@ public partial class FileMover
     private void LogMutation(FileMutationOutcome outcome, FileAction action, string source, string? destination, string? reason = null)
     {
         var result = new FileMutationResult(outcome, action, source, destination, reason);
-        _logger.LogInformation(
+        // Blocked and Failed mean the requested action did not happen, and the caller only gets
+        // back a bool, so this line is the sole record that anything went wrong. Logging it at
+        // Information put it at the same level as a successful move, which is how a refused
+        // cross-volume move reads as silence to anyone watching at the default level.
+        var level = outcome is FileMutationOutcome.Blocked or FileMutationOutcome.Failed
+            ? LogLevel.Warning
+            : LogLevel.Information;
+        _logger.Log(
+            level,
             "File mutation {Outcome}: {Action} {Source} -> {Destination}. Reason: {Reason}",
             result.Outcome,
             result.Action,

--- a/tests/Features/Infrastructure/FileSystem/FileMoverMarkerlessMoveTests.cs
+++ b/tests/Features/Infrastructure/FileSystem/FileMoverMarkerlessMoveTests.cs
@@ -104,6 +104,50 @@ public sealed class FileMoverMarkerlessMoveTests : BaseTests
     }
 
     [LinuxFact]
+    public async Task MoveFileAsync_ForcedCrossVolumeRefusalIsLoggedAboveInformation()
+    {
+        var scenario = await CreateScenarioAsync();
+        var logger = new LevelCapturingLogger();
+
+        Assert.False(await CreateMover(forceCrossVolume: true, logger: logger).MoveFileAsync(
+            scenario.Source,
+            scenario.Destination,
+            scenario.OperationId));
+
+        // The caller gets back a bare false, and nothing consumes FileMutationResult, so this
+        // log line is the only record that the requested move did not happen. At Information it
+        // sits at the same level as a successful move, which is how an operator ends up watching
+        // a file that never arrives with nothing in the log that looks like a problem.
+        var refusal = Assert.Single(
+            logger.Entries,
+            entry => entry.Message.Contains("Blocked", StringComparison.Ordinal));
+        Assert.Equal(LogLevel.Warning, refusal.Level);
+        Assert.Contains("cross-volume", refusal.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed record CapturedMutationLog(LogLevel Level, string Message);
+
+    private sealed class LevelCapturingLogger : ILogger<FileMover>
+    {
+        public List<CapturedMutationLog> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new CapturedMutationLog(logLevel, formatter(state, exception)));
+        }
+    }
+
+    [LinuxFact]
     public async Task MoveFileAsync_CaseDistinctRetryDoesNotAdoptJournal()
     {
         var scenario = await CreateScenarioAsync();
@@ -869,6 +913,7 @@ public sealed class FileMoverMarkerlessMoveTests : BaseTests
     private FileMover CreateMover(
         bool disableNativeRename = false,
         bool forceCrossVolume = false,
+        ILogger<FileMover>? logger = null,
         Func<Task>? afterJournalPlanned = null,
         Func<Task>? afterPublishedBeforeTargetState = null,
         Func<Task>? afterTargetCreatedBeforeState = null,
@@ -881,7 +926,7 @@ public sealed class FileMoverMarkerlessMoveTests : BaseTests
         var factory = _provider.GetRequiredService<
             IDbContextFactory<ListenArrDbContext>>();
         return new FileMover(
-            new NullLogger<FileMover>(),
+            logger ?? new NullLogger<FileMover>(),
             dbContextFactory: factory,
             timeProvider: TimeProvider.System)
         {


### PR DESCRIPTION
## Summary

`LogMutation` logs every outcome at `Information`, so a refusal to perform a file mutation sits at the same level as a successful one. `Blocked` and `Failed` both mean the action did not happen.

This changes the level for those two and nothing else. Full write-up in #852.

## Changes

### Fixed
- `FileMover.LogMutation` selects `Warning` for `Blocked` and `Failed`, `Information` otherwise.

## Why this and not more

The case that surfaced it is the Unix cross-volume `Move` refusal, which is deliberate and states its reason: the source retirement cannot be generation-fenced without a library-side namespace claim. **That refusal is not touched here and I am not proposing it should be.** What this changes is that an operator watching at the default level can now tell the difference between a move that was refused and a move that succeeded.

It applies to all outcomes rather than special-casing the cross-volume one because none of the seven `Blocked` sites in this class is routine: a non-publishable action, an empty operation ID, unavailable durable markerless state, linked aliases of the same file. Every one is a refusal to do what was asked.

Worth stating plainly: **this does not make cross-volume moves work.** It makes their refusal audible. Whether to implement the namespace claim described in that reason is a separate and much larger question.

## Testing

`FileMoverMarkerlessMoveTests` gains a case that drives the real refusal through the existing `ForceCrossVolumeForTest` hook and asserts the level rather than the message text. `CreateMover` gains an optional `ILogger<FileMover>`; it previously passed `NullLogger` unconditionally, which is why no existing test in that file could observe a level. There is already a test asserting this move is rejected, so the gap was never whether it refuses, only how loudly.

Verified as a real guard: with the level flattened back to `Information` the new test fails with `Expected: Warning, Actual: Information`, and passes with the change.

Full suite: 3,030 passed, 0 failed, 125 skipped, against a 3,029 baseline on `03958c15`.

Reproduced end to end against `ghcr.io/listenarrs/listenarr:canary` with a public check that runs the same import twice, once with the source and root folder on one mount and once across two. The same-mount case is the control and completes; the cross-mount case produces no destination and leaves the source untouched. The check is in the test-data repo linked from the issue, and it reports "nothing happened at all" as its own verdict rather than as an ordinary failure, since a stall and a failure are different things to operate.
