### PR TITLE
Download the ffprobe archive on macOS

### DIFF
--- a/listenarr.infrastructure/Ffmpeg/Installation/FfprobePlatformDefaults.cs
+++ b/listenarr.infrastructure/Ffmpeg/Installation/FfprobePlatformDefaults.cs
@@ -35,7 +35,11 @@ namespace Listenarr.Infrastructure.Ffmpeg.Installation
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return "https://evermeet.cx/ffmpeg/ffmpeg-6.0.zip";
+                // Must be the ffprobe archive: every caller looks for an "ffprobe" binary in the
+                // extracted files, so the ffmpeg archive installs nothing and the scan then runs
+                // without embedded-tag metadata. "getrelease" tracks the current build rather than
+                // pinning a version that ages out.
+                return "https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip";
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
## Summary

`FfprobePlatformDefaults.GetDownloadUrl()` returns the **ffmpeg** archive for macOS, but every consumer looks for a binary named `ffprobe` in the extracted files. The download succeeds and the install then fails:

```
[INF] Downloaded ffprobe archive SHA256=9a810d222862a7230fd7035c91e32beb605af7501c3517580f2bc1eb8faddacc
[INF] No ffprobe binary found in extracted files under .../.env/development/config/ffmpeg
[WRN] ffprobe install did not produce the expected binary at .../config/ffmpeg/ffprobe
[WRN] ffprobe was not installed or auto-install disabled
```

The residue in the config directory confirms the wrong asset is fetched — a 78 MB file named `ffmpeg`, and no `ffprobe`:

```
-rw-r--r--  78829164  ffmpeg      <- extracted from the downloaded archive
                                  <- no ffprobe
```

Consequence: on macOS the unmatched scan runs with `ffprobePath == null`, so embedded-tag extraction is skipped entirely and books import with only path-derived metadata.

**macOS is the only affected platform.** Linux downloads a static tarball containing both binaries, and the Windows "essentials" archive ships `ffprobe.exe` — so both happen to satisfy the `ffprobe` search by accident.

## Changes

### Fixed
- Point the macOS download at the ffprobe release (`https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip`) rather than the ffmpeg archive.

The `getrelease` endpoint tracks the current build instead of pinning `ffmpeg-6.0.zip`, which is several years old.

## Testing

Downloaded the corrected URL and confirmed the archive contains a working `ffprobe` that depends only on system frameworks:

```
$ curl -sSL -o ffprobe.zip "https://evermeet.cx/ffmpeg/getrelease/ffprobe/zip"   # 26 MB
$ unzip -q ffprobe.zip && ./ffprobe -version
ffprobe version 9.0.1-tessus  https://evermeet.cx/ffmpeg/
```

Placed at the expected path, the running instance picks it up with no restart, and tag extraction works against a real library:

```
GET /api/v1/ffmpeg/info
{"ffprobePath":".../.env/development/config/ffmpeg/ffprobe"}

[INF] Found bundled ffprobe at .../config/ffmpeg/ffprobe
```

```
TAG:title=The Ickabog
TAG:comment=The Ickabog is coming… A mythical monster, a kingdom in peril…
TAG:description=The Ickabog is coming… A mythical monster, a kingdom in peril…
```

## Notes

Only the URL changes; the download, checksum, extraction and install paths are untouched. Users who already have a working `ffprobe` in their config directory are unaffected, since installation short-circuits when the binary is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
