### PR TITLE
Parse book folders using the configured naming pattern

### DIFF
--- a/listenarr.infrastructure/Library/Scanning/UnmatchedScanBackgroundService.cs
+++ b/listenarr.infrastructure/Library/Scanning/UnmatchedScanBackgroundService.cs
@@ -355,7 +355,8 @@ namespace Listenarr.Infrastructure.Library.Scanning
                         var parsed = PathMetadataParser.ParsePathOnly(
                             representative,
                             rootFolderPath,
-                            semantics);
+                            semantics,
+                            appSettings?.FolderNamingPattern);
                         if (hasDurableGenerationProof)
                         {
                             await ApplyPinnedFolderMetadataAsync(

--- a/listenarr.infrastructure/Metadata/Parsing/NamingPatternFolderMatcher.cs
+++ b/listenarr.infrastructure/Metadata/Parsing/NamingPatternFolderMatcher.cs
@@ -1,0 +1,186 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Listenarr.Infrastructure.Metadata.Parsing;
+
+/// <summary>
+/// Derives a folder-name matcher from the configured folder naming pattern, so scanning reads back
+/// the layout the renamer writes instead of guessing at a fixed convention.
+///
+/// The matcher mirrors the renderer's elision rules: a bracket group containing only tokens
+/// disappears when all of them are empty, and renders partially when only some are, so every token
+/// inside such a group is independently optional here.
+/// </summary>
+internal static class NamingPatternFolderMatcher
+{
+    private static readonly ConcurrentDictionary<string, Regex?> Cache = new(StringComparer.Ordinal);
+
+    private static readonly Regex TokenPattern = new(@"\{(\w+)\}", RegexOptions.Compiled);
+
+    // Tolerates bracketed extras the pattern does not mention - a second series bracket, or a
+    // trailing tag such as "[abridged]" - so one stray annotation does not lose the whole match.
+    private const string AnyBracketGroup = @"(?:\s*\[[^\[\]]*\])";
+
+    private static readonly Dictionary<char, char> Delimiters = new()
+    {
+        ['['] = ']',
+        ['('] = ')',
+        ['{'] = '}',
+    };
+
+    /// <summary>Token names that carry enough signal to call a directory a book folder.</summary>
+    private static readonly string[] MarkerTokens =
+        ["Series", "SeriesNumber", "Year", "Narrator", "Subtitle", "Edition", "Asin"];
+
+    public static Regex? GetOrBuild(string? folderNamingPattern)
+    {
+        if (string.IsNullOrWhiteSpace(folderNamingPattern))
+        {
+            return null;
+        }
+
+        return Cache.GetOrAdd(folderNamingPattern, static pattern =>
+        {
+            try
+            {
+                var segments = pattern.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
+                if (segments.Length == 0)
+                {
+                    return null;
+                }
+
+                // Only the last segment names the book folder; earlier segments are parent levels
+                // that the caller already walks.
+                var body = Convert(segments[^1], tokensOptional: false);
+
+                // Allow unmentioned leading bracket groups immediately before the title.
+                const string titleGroup = "(?<Title>";
+                var titleIndex = body.IndexOf(titleGroup, StringComparison.Ordinal);
+                if (titleIndex >= 0)
+                {
+                    body = body[..titleIndex] + AnyBracketGroup + @"*\s*" + body[titleIndex..];
+                }
+
+                return new Regex(
+                    "^" + body + AnyBracketGroup + @"*\s*$",
+                    RegexOptions.Compiled | RegexOptions.IgnoreCase,
+                    TimeSpan.FromSeconds(1));
+            }
+            catch (ArgumentException)
+            {
+                // An unparseable pattern must not break scanning; callers fall back to the
+                // built-in convention.
+                return null;
+            }
+        });
+    }
+
+    /// <summary>
+    /// True when the match carries at least one non-title marker. Without this a bare directory
+    /// name such as "Alastair Reynolds" satisfies the all-optional pattern and an author folder
+    /// gets claimed as a book.
+    /// </summary>
+    public static bool HasBookFolderMarker(Match match)
+    {
+        foreach (var token in MarkerTokens)
+        {
+            var group = match.Groups[token];
+            if (group.Success && !string.IsNullOrWhiteSpace(group.Value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string Convert(string segment, bool tokensOptional)
+    {
+        var builder = new StringBuilder();
+        var index = 0;
+
+        while (index < segment.Length)
+        {
+            var token = TokenPattern.Match(segment, index);
+            if (token.Success && token.Index == index)
+            {
+                builder.Append(RenderToken(token.Groups[1].Value, tokensOptional));
+                index = token.Index + token.Length;
+                continue;
+            }
+
+            var current = segment[index];
+            if (Delimiters.TryGetValue(current, out var closing))
+            {
+                var depth = 1;
+                var scan = index + 1;
+                while (scan < segment.Length && depth > 0)
+                {
+                    if (segment[scan] == current) depth++;
+                    else if (segment[scan] == closing) depth--;
+                    scan++;
+                }
+
+                var inner = segment[(index + 1)..(scan - 1)];
+                var innerTokens = TokenPattern.Matches(inner).Count;
+                var onlyTokens = TokenPattern.Replace(inner, string.Empty).Trim().Length == 0;
+
+                if (innerTokens > 0 && onlyTokens)
+                {
+                    builder.Append(@"(?:\s*")
+                        .Append(Regex.Escape(current.ToString()))
+                        .Append(Convert(inner, tokensOptional: true))
+                        .Append(Regex.Escape(closing.ToString()))
+                        .Append(")?");
+                }
+                else
+                {
+                    builder.Append(Regex.Escape(current.ToString()))
+                        .Append(Convert(inner, tokensOptional))
+                        .Append(Regex.Escape(closing.ToString()));
+                }
+
+                index = scan;
+                continue;
+            }
+
+            // Literal whitespace becomes flexible so an elided group does not strand a separator.
+            builder.Append(char.IsWhiteSpace(current) ? @"\s*" : Regex.Escape(current.ToString()));
+            index++;
+        }
+
+        return builder.ToString();
+    }
+
+    private static string RenderToken(string name, bool optional)
+    {
+        var body = name switch
+        {
+            "Year" => @"\d{4}",
+            "SeriesNumber" => @"[\d.]+",
+            "DiskNumber" or "ChapterNumber" => @"\d+",
+            _ => ".+?",
+        };
+
+        var group = $"(?<{name}>{body})";
+        return optional ? $"(?:{group})?" : group;
+    }
+}

--- a/listenarr.infrastructure/Metadata/Parsing/PathMetadataParser.cs
+++ b/listenarr.infrastructure/Metadata/Parsing/PathMetadataParser.cs
@@ -58,20 +58,23 @@ namespace Listenarr.Infrastructure.Metadata.Parsing
         public static PathParsedMetadata Parse(
             string filePath,
             string rootFolderPath,
-            FileSystemPathSemantics semantics) =>
-            ParseCore(filePath, rootFolderPath, semantics, includeFilesystemMetadata: true);
+            FileSystemPathSemantics semantics,
+            string? folderNamingPattern = null) =>
+            ParseCore(filePath, rootFolderPath, semantics, includeFilesystemMetadata: true, folderNamingPattern);
 
         internal static PathParsedMetadata ParsePathOnly(
             string filePath,
             string rootFolderPath,
-            FileSystemPathSemantics semantics) =>
-            ParseCore(filePath, rootFolderPath, semantics, includeFilesystemMetadata: false);
+            FileSystemPathSemantics semantics,
+            string? folderNamingPattern = null) =>
+            ParseCore(filePath, rootFolderPath, semantics, includeFilesystemMetadata: false, folderNamingPattern);
 
         private static PathParsedMetadata ParseCore(
             string filePath,
             string rootFolderPath,
             FileSystemPathSemantics semantics,
-            bool includeFilesystemMetadata)
+            bool includeFilesystemMetadata,
+            string? folderNamingPattern = null)
         {
             var result = new PathParsedMetadata();
 
@@ -94,25 +97,60 @@ namespace Listenarr.Infrastructure.Metadata.Parsing
             if (parts.Length < 2) return result;
             var folderParts = parts[..^1];
 
-            // Find the first folder level that matches the "Year - Title" pattern
+            // Prefer the configured folder naming pattern so scanning reads back exactly the layout
+            // the renamer writes; fall back to the built-in "{Year} - {Title}" convention.
             int bookFolderIndex = -1;
-            for (int i = 0; i < folderParts.Length; i++)
+            Match? configuredMatch = null;
+            var configuredPattern = NamingPatternFolderMatcher.GetOrBuild(folderNamingPattern);
+
+            if (configuredPattern != null)
             {
-                if (BookFolderPattern.IsMatch(folderParts[i]))
+                for (int i = 0; i < folderParts.Length; i++)
                 {
-                    bookFolderIndex = i;
-                    break;
+                    var candidate = configuredPattern.Match(folderParts[i]);
+                    if (candidate.Success && NamingPatternFolderMatcher.HasBookFolderMarker(candidate))
+                    {
+                        bookFolderIndex = i;
+                        configuredMatch = candidate;
+                        break;
+                    }
+                }
+            }
+
+            if (bookFolderIndex < 0)
+            {
+                for (int i = 0; i < folderParts.Length; i++)
+                {
+                    if (BookFolderPattern.IsMatch(folderParts[i]))
+                    {
+                        bookFolderIndex = i;
+                        break;
+                    }
                 }
             }
 
             if (bookFolderIndex < 0) return result;
 
-            // Parse year, title, series, seriesNumber from the matched folder
-            var m = BookFolderPattern.Match(folderParts[bookFolderIndex]);
-            result.Year = m.Groups[1].Value;
-            result.Title = m.Groups[2].Value.Trim();
-            if (m.Groups[3].Success) result.Series = m.Groups[3].Value.Trim();
-            if (m.Groups[4].Success) result.SeriesNumber = m.Groups[4].Value.Trim();
+            if (configuredMatch != null)
+            {
+                AssignGroup(configuredMatch, "Title", v => result.Title = v);
+                AssignGroup(configuredMatch, "Series", v => result.Series = v);
+                AssignGroup(configuredMatch, "SeriesNumber", v => result.SeriesNumber = v);
+                AssignGroup(configuredMatch, "Narrator", v => result.Narrator = v);
+                AssignGroup(configuredMatch, "Asin", v => result.Asin = v);
+                result.Year = configuredMatch.Groups["Year"].Success
+                    ? configuredMatch.Groups["Year"].Value
+                    : string.Empty;
+            }
+            else
+            {
+                // Parse year, title, series, seriesNumber from the matched folder
+                var m = BookFolderPattern.Match(folderParts[bookFolderIndex]);
+                result.Year = m.Groups[1].Value;
+                result.Title = m.Groups[2].Value.Trim();
+                if (m.Groups[3].Success) result.Series = m.Groups[3].Value.Trim();
+                if (m.Groups[4].Success) result.SeriesNumber = m.Groups[4].Value.Trim();
+            }
 
             // Assign Author and Series from path levels before the book folder
             if (bookFolderIndex == 1)
@@ -288,6 +326,14 @@ namespace Listenarr.Infrastructure.Metadata.Parsing
                 RegexOptions.IgnoreCase);
 
             return match.Success ? match.Value.ToUpperInvariant() : null;
+        }
+
+        private static void AssignGroup(Match match, string name, Action<string> assign)
+        {
+            var group = match.Groups[name];
+            if (!group.Success) return;
+            var value = group.Value.Trim();
+            if (value.Length > 0) assign(value);
         }
 
         private static void TryReadSidecar(string folder, string filename, Action<string> assign)

--- a/tests/Features/Infrastructure/Metadata/Parsing/PathMetadataParser_ConfiguredPatternTests.cs
+++ b/tests/Features/Infrastructure/Metadata/Parsing/PathMetadataParser_ConfiguredPatternTests.cs
@@ -1,0 +1,162 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace Listenarr.Tests.Features.Infrastructure.Metadata.Parsing
+{
+    /// <summary>
+    /// Scanning should read back the layout the renamer writes, so folder parsing is driven by the
+    /// configured folder naming pattern rather than a fixed convention.
+    /// </summary>
+    public class PathMetadataParser_ConfiguredPatternTests
+    {
+        private const string BracketPattern =
+            "{Author}/[{Series} {SeriesNumber}] {Title} {{Narrator}} ({Year})";
+
+        private static PathParsedMetadata Parse(string author, string bookFolder, string? pattern = BracketPattern)
+        {
+            var root = Path.Join(Path.GetTempPath(), $"MetadataRoot-{Guid.NewGuid():N}");
+            var file = Path.Join(root, author, bookFolder, "book.m4b");
+            var syntax = FileSystemPathSemantics.CurrentHostDefault.Syntax;
+            return PathMetadataParser.ParsePathOnly(
+                file,
+                root,
+                new FileSystemPathSemantics(syntax, FileSystemCaseSensitivity.Insensitive),
+                pattern);
+        }
+
+        [Theory]
+        [InlineData("[Revelation Space 10] Dilation Sleep (1990)", "Revelation Space", "10", "Dilation Sleep", "1990")]
+        [InlineData("[Chronicles of Narnia 0] Chronicles of Narnia Intro (2019)", "Chronicles of Narnia", "0", "Chronicles of Narnia Intro", "2019")]
+        [InlineData("[Known Space 00.0] Beclaimed in Hell (2017)", "Known Space", "00.0", "Beclaimed in Hell", "2017")]
+        [InlineData("[The Expanse 2.7] Drive (2012)", "The Expanse", "2.7", "Drive", "2012")]
+        [InlineData("[Rama 03] The Garden of Rama (1991)", "Rama", "03", "The Garden of Rama", "1991")]
+        public void ParsesEverySeriesNumberForm(
+            string folder, string series, string part, string title, string year)
+        {
+            var parsed = Parse("Some Author", folder);
+
+            Assert.Equal(series, parsed.Series);
+            Assert.Equal(part, parsed.SeriesNumber);
+            Assert.Equal(title, parsed.Title);
+            Assert.Equal(year, parsed.Year);
+        }
+
+        [Fact]
+        public void SeriesGroupRenderedWithoutItsNumber_StillParses()
+        {
+            // "[{Series} {SeriesNumber}]" renders as "[Radicalized]" when the number is empty,
+            // so each token inside an elidable group must be independently optional when reading.
+            var parsed = Parse("Cory Doctorow", "[Radicalized] Radicalized (2019)");
+
+            Assert.Equal("Radicalized", parsed.Series);
+            Assert.Null(parsed.SeriesNumber);
+            Assert.Equal("Radicalized", parsed.Title);
+            Assert.Equal("2019", parsed.Year);
+        }
+
+        [Fact]
+        public void UnmentionedTrailingTag_DoesNotSwallowTheYear()
+        {
+            var parsed = Parse("Arthur C. Clarke", "[Rama 03] The Garden of Rama (1991) [abridged]");
+
+            Assert.Equal("The Garden of Rama", parsed.Title);
+            Assert.Equal("1991", parsed.Year);
+        }
+
+        [Fact]
+        public void SecondSeriesBracket_IsToleratedAndFirstWins()
+        {
+            var parsed = Parse(
+                "Orson Scott Card",
+                "[Enderverse 07.5][Ender's Saga 1.1] A War Of Gifts {Scott Brick} (2007)");
+
+            Assert.Equal("Enderverse", parsed.Series);
+            Assert.Equal("07.5", parsed.SeriesNumber);
+            Assert.Equal("A War Of Gifts", parsed.Title);
+            Assert.Equal("Scott Brick", parsed.Narrator);
+            Assert.Equal("2007", parsed.Year);
+        }
+
+        [Fact]
+        public void StandaloneBook_ParsesNarratorAndYearWithoutSeries()
+        {
+            var parsed = Parse("Robert A. Heinlein", "Revolt in 2100 {Eric Michael Summerer} (2009)");
+
+            Assert.Null(parsed.Series);
+            Assert.Equal("Revolt in 2100", parsed.Title);
+            Assert.Equal("Eric Michael Summerer", parsed.Narrator);
+            Assert.Equal("2009", parsed.Year);
+        }
+
+        [Fact]
+        public void FolderWithoutYear_StillParses()
+        {
+            var parsed = Parse("Victoria Schwab", "[Villians 0] 5 Warm Up - A Prequel to Vicious");
+
+            Assert.Equal("Villians", parsed.Series);
+            Assert.Equal("0", parsed.SeriesNumber);
+            Assert.Equal("5 Warm Up - A Prequel to Vicious", parsed.Title);
+        }
+
+        [Fact]
+        public void AuthorDirectory_IsNotClaimedAsABookFolder()
+        {
+            // Every token in the pattern is optional, so a bare name satisfies it structurally.
+            // Requiring a non-title marker stops "Author/Series/book.m4b" resolving to the author.
+            var root = Path.Join(Path.GetTempPath(), $"MetadataRoot-{Guid.NewGuid():N}");
+            var file = Path.Join(root, "Alastair Reynolds", "Revelation Space", "book.m4b");
+            var syntax = FileSystemPathSemantics.CurrentHostDefault.Syntax;
+
+            var parsed = PathMetadataParser.ParsePathOnly(
+                file,
+                root,
+                new FileSystemPathSemantics(syntax, FileSystemCaseSensitivity.Insensitive),
+                BracketPattern);
+
+            Assert.Null(parsed.Title);
+            Assert.Null(parsed.Series);
+        }
+
+        [Fact]
+        public void NoConfiguredPattern_FallsBackToBuiltInConvention()
+        {
+            var parsed = Parse("Brandon Sanderson", "2010 - The Way of Kings [The Stormlight Archive 1]", pattern: null);
+
+            Assert.Equal("The Stormlight Archive", parsed.Series);
+            Assert.Equal("1", parsed.SeriesNumber);
+            Assert.Equal("The Way of Kings", parsed.Title);
+            Assert.Equal("2010", parsed.Year);
+        }
+
+        [Fact]
+        public void ConfiguredPatternThatDoesNotMatch_FallsBackToBuiltInConvention()
+        {
+            var parsed = Parse("Brandon Sanderson", "2010 - The Way of Kings [The Stormlight Archive 1]");
+
+            Assert.Equal("The Way of Kings", parsed.Title);
+            Assert.Equal("2010", parsed.Year);
+        }
+
+        [Fact]
+        public void MalformedPattern_DoesNotBreakScanning()
+        {
+            var parsed = Parse("Some Author", "2010 - A Title", pattern: "{Author}/[{Unclosed");
+
+            Assert.Equal("A Title", parsed.Title);
+        }
+    }
+}

--- a/tests/Features/Infrastructure/Metadata/Parsing/PathMetadataParser_ConfiguredPatternTests.cs
+++ b/tests/Features/Infrastructure/Metadata/Parsing/PathMetadataParser_ConfiguredPatternTests.cs
@@ -15,13 +15,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+using Listenarr.Tests.Common;
+
 namespace Listenarr.Tests.Features.Infrastructure.Metadata.Parsing
 {
     /// <summary>
     /// Scanning should read back the layout the renamer writes, so folder parsing is driven by the
     /// configured folder naming pattern rather than a fixed convention.
     /// </summary>
-    public class PathMetadataParser_ConfiguredPatternTests
+    [Trait("Area", "Metadata")]
+    [Trait("Name", "PathMetadataParser_ConfiguredPatternTests")]
+    [Trait("Category", "PathMetadataParser")]
+    public class PathMetadataParser_ConfiguredPatternTests : BaseTests
     {
         private const string BracketPattern =
             "{Author}/[{Series} {SeriesNumber}] {Title} {{Narrator}} ({Year})";


### PR DESCRIPTION
## Summary

Folder **rendering** is configurable via `FolderNamingPattern`, but folder **parsing** is hardcoded:

```csharp
// "2010 - The Way of Kings [The Stormlight Archive 1]"
private static readonly Regex BookFolderPattern = new(
    @"^(\d{4})\s+-\s+(.+?)(?:\s+\[(.+?)\s+([\d.]+)\])?$", …);
```

**These disagree out of the box.** The default pattern is `{Author}/{Series}/{Title}`, which renders `Brandon Sanderson/Stormlight Archive/The Way of Kings` — and the parser requires a leading four-digit year, so none of it matches:

```
'The Way of Kings'      -> NO MATCH
'Stormlight Archive'    -> NO MATCH
'Some Title'            -> NO MATCH
```

A library organised by Listenarr's own default settings cannot be read back. Any user whose pattern isn't `{Year} - {Title} [{Series} {Part}]` gets no path-derived series, title or year — scanning silently falls back to embedded tags alone, and books with no series tags simply have no series.

## Approach

Derive the matcher from the configured pattern, so **parsing is the inverse of rendering**.

The derivation mirrors the renderer's elision rules: a bracket group containing only tokens disappears when every token is empty, and renders *partially* when only some are. So `[{Series} {SeriesNumber}]` renders `[Radicalized]` for an unnumbered series — meaning each token inside an elidable group must be independently optional when reading.

Two safeguards:

- **Marker requirement.** With every token optional, a bare name satisfies the pattern structurally and an author directory would be claimed as a book. A match is only accepted when it carries a non-title marker (series/year/narrator/…). `Author/Series/book.m4b` correctly parses to nothing.
- **Fallback.** An unparseable pattern yields no matcher rather than throwing; that case and any non-matching folder fall through to the existing convention. Current layouts are unaffected.

## Changes

### Added
- `NamingPatternFolderMatcher` — builds and caches a regex from `FolderNamingPattern`.
- `PathMetadataParser_ConfiguredPatternTests`.

### Changed
- `PathMetadataParser` accepts an optional pattern and prefers it, falling back to the built-in convention.
- The unmatched scan passes `appSettings.FolderNamingPattern` (already loaded ~125 lines above the call site).

## Testing

21/21 pass, including the pre-existing `PathMetadataParser` tests.

Verified end-to-end against a real library with `{Author}/[{Series} {SeriesNumber}] {Title} {{Narrator}} ({Year})`. Before, series came only from embedded tags — every book without them had none. After:

| Folder | Before | After |
|---|---|---|
| `[Chronicles of Narnia 0] …` | — | Chronicles of Narnia / **0** |
| `[Known Space 00.0] …` | — | Known Space / **00.0** |
| `[Enderverse 07.5][Ender's Saga 1.1] …` | — | Enderverse / **07.5** |
| `[Radicalized] Radicalized (2019)` | — | Radicalized / *(no number)* |
| `Alastair Reynolds` *(author dir)* | — | correctly rejected |

Covers zero-padding, decimals, plain `0`, unnumbered series, standalone books, and folders with no year.

## Notes

Two tolerances go slightly beyond a literal inversion, both for real-world folder noise:

1. **Extra leading bracket groups** — `[Enderverse 07.5][Ender's Saga 1.1] Title` (a book in two series). First bracket wins.
2. **Trailing tags** — `… (1991) [abridged]`, which otherwise swallows the year into the title.

I've kept them because both occur in practice and neither can be expressed in a pattern, but they *are* judgement calls — happy to drop either and let those folders fall back if you'd prefer a strict inversion.

The regex is cached per pattern string and compiled with a 1s timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
