### PR TITLE
Reduce rendered folder names in title tags to the bare title

### DIFF
--- a/listenarr.infrastructure/Library/Scanning/UnmatchedScanBackgroundService.cs
+++ b/listenarr.infrastructure/Library/Scanning/UnmatchedScanBackgroundService.cs
@@ -355,7 +355,8 @@ namespace Listenarr.Infrastructure.Library.Scanning
                         var parsed = PathMetadataParser.ParsePathOnly(
                             representative,
                             rootFolderPath,
-                            semantics);
+                            semantics,
+                            appSettings?.FolderNamingPattern);
                         if (hasDurableGenerationProof)
                         {
                             await ApplyPinnedFolderMetadataAsync(

--- a/listenarr.infrastructure/Library/Scanning/UnmatchedScanBackgroundService.cs
+++ b/listenarr.infrastructure/Library/Scanning/UnmatchedScanBackgroundService.cs
@@ -401,7 +401,7 @@ namespace Listenarr.Infrastructure.Library.Scanning
 
                         if (tags != null)
                         {
-                            ApplyEmbeddedTags(parsed, tags);
+                            ApplyEmbeddedTags(parsed, tags, appSettings?.FolderNamingPattern);
                         }
 
                         var relativeFolder = bookFolder.Length > rootFolderPath.Length

--- a/listenarr.infrastructure/Library/Scanning/UnmatchedScanProcessor.Grouping.cs
+++ b/listenarr.infrastructure/Library/Scanning/UnmatchedScanProcessor.Grouping.cs
@@ -391,9 +391,18 @@ namespace Listenarr.Infrastructure.Library.Scanning
             }
         }
 
-        private static void ApplyEmbeddedTags(PathParsedMetadata target, PathParsedMetadata tags)
+        private static void ApplyEmbeddedTags(
+            PathParsedMetadata target,
+            PathParsedMetadata tags,
+            string? folderNamingPattern = null)
         {
-            if (!string.IsNullOrEmpty(tags.Title)) target.Title = tags.Title;
+            // Album/title tags often carry the whole rendered folder name. Reduce such a value to
+            // its title so display and search see "Dilation Sleep", not
+            // "[Revelation Space 10] Dilation Sleep".
+            if (!string.IsNullOrEmpty(tags.Title))
+            {
+                target.Title = NamingPatternFolderMatcher.ExtractTitle(tags.Title, folderNamingPattern);
+            }
             if (!string.IsNullOrEmpty(tags.Author)) target.Author = tags.Author;
             if (!string.IsNullOrEmpty(tags.Narrator)) target.Narrator = tags.Narrator;
             if (!string.IsNullOrEmpty(tags.Series)) target.Series = tags.Series;

--- a/listenarr.infrastructure/Metadata/Parsing/NamingPatternFolderMatcher.cs
+++ b/listenarr.infrastructure/Metadata/Parsing/NamingPatternFolderMatcher.cs
@@ -1,0 +1,186 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Listenarr.Infrastructure.Metadata.Parsing;
+
+/// <summary>
+/// Derives a folder-name matcher from the configured folder naming pattern, so scanning reads back
+/// the layout the renamer writes instead of guessing at a fixed convention.
+///
+/// The matcher mirrors the renderer's elision rules: a bracket group containing only tokens
+/// disappears when all of them are empty, and renders partially when only some are, so every token
+/// inside such a group is independently optional here.
+/// </summary>
+internal static class NamingPatternFolderMatcher
+{
+    private static readonly ConcurrentDictionary<string, Regex?> Cache = new(StringComparer.Ordinal);
+
+    private static readonly Regex TokenPattern = new(@"\{(\w+)\}", RegexOptions.Compiled);
+
+    // Tolerates bracketed extras the pattern does not mention - a second series bracket, or a
+    // trailing tag such as "[abridged]" - so one stray annotation does not lose the whole match.
+    private const string AnyBracketGroup = @"(?:\s*\[[^\[\]]*\])";
+
+    private static readonly Dictionary<char, char> Delimiters = new()
+    {
+        ['['] = ']',
+        ['('] = ')',
+        ['{'] = '}',
+    };
+
+    /// <summary>Token names that carry enough signal to call a directory a book folder.</summary>
+    private static readonly string[] MarkerTokens =
+        ["Series", "SeriesNumber", "Year", "Narrator", "Subtitle", "Edition", "Asin"];
+
+    public static Regex? GetOrBuild(string? folderNamingPattern)
+    {
+        if (string.IsNullOrWhiteSpace(folderNamingPattern))
+        {
+            return null;
+        }
+
+        return Cache.GetOrAdd(folderNamingPattern, static pattern =>
+        {
+            try
+            {
+                var segments = pattern.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
+                if (segments.Length == 0)
+                {
+                    return null;
+                }
+
+                // Only the last segment names the book folder; earlier segments are parent levels
+                // that the caller already walks.
+                var body = Convert(segments[^1], tokensOptional: false);
+
+                // Allow unmentioned leading bracket groups immediately before the title.
+                const string titleGroup = "(?<Title>";
+                var titleIndex = body.IndexOf(titleGroup, StringComparison.Ordinal);
+                if (titleIndex >= 0)
+                {
+                    body = body[..titleIndex] + AnyBracketGroup + @"*\s*" + body[titleIndex..];
+                }
+
+                return new Regex(
+                    "^" + body + AnyBracketGroup + @"*\s*$",
+                    RegexOptions.Compiled | RegexOptions.IgnoreCase,
+                    TimeSpan.FromSeconds(1));
+            }
+            catch (ArgumentException)
+            {
+                // An unparseable pattern must not break scanning; callers fall back to the
+                // built-in convention.
+                return null;
+            }
+        });
+    }
+
+    /// <summary>
+    /// True when the match carries at least one non-title marker. Without this a bare directory
+    /// name such as "Alastair Reynolds" satisfies the all-optional pattern and an author folder
+    /// gets claimed as a book.
+    /// </summary>
+    public static bool HasBookFolderMarker(Match match)
+    {
+        foreach (var token in MarkerTokens)
+        {
+            var group = match.Groups[token];
+            if (group.Success && !string.IsNullOrWhiteSpace(group.Value))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string Convert(string segment, bool tokensOptional)
+    {
+        var builder = new StringBuilder();
+        var index = 0;
+
+        while (index < segment.Length)
+        {
+            var token = TokenPattern.Match(segment, index);
+            if (token.Success && token.Index == index)
+            {
+                builder.Append(RenderToken(token.Groups[1].Value, tokensOptional));
+                index = token.Index + token.Length;
+                continue;
+            }
+
+            var current = segment[index];
+            if (Delimiters.TryGetValue(current, out var closing))
+            {
+                var depth = 1;
+                var scan = index + 1;
+                while (scan < segment.Length && depth > 0)
+                {
+                    if (segment[scan] == current) depth++;
+                    else if (segment[scan] == closing) depth--;
+                    scan++;
+                }
+
+                var inner = segment[(index + 1)..(scan - 1)];
+                var innerTokens = TokenPattern.Matches(inner).Count;
+                var onlyTokens = TokenPattern.Replace(inner, string.Empty).Trim().Length == 0;
+
+                if (innerTokens > 0 && onlyTokens)
+                {
+                    builder.Append(@"(?:\s*")
+                        .Append(Regex.Escape(current.ToString()))
+                        .Append(Convert(inner, tokensOptional: true))
+                        .Append(Regex.Escape(closing.ToString()))
+                        .Append(")?");
+                }
+                else
+                {
+                    builder.Append(Regex.Escape(current.ToString()))
+                        .Append(Convert(inner, tokensOptional))
+                        .Append(Regex.Escape(closing.ToString()));
+                }
+
+                index = scan;
+                continue;
+            }
+
+            // Literal whitespace becomes flexible so an elided group does not strand a separator.
+            builder.Append(char.IsWhiteSpace(current) ? @"\s*" : Regex.Escape(current.ToString()));
+            index++;
+        }
+
+        return builder.ToString();
+    }
+
+    private static string RenderToken(string name, bool optional)
+    {
+        var body = name switch
+        {
+            "Year" => @"\d{4}",
+            "SeriesNumber" => @"[\d.]+",
+            "DiskNumber" or "ChapterNumber" => @"\d+",
+            _ => ".+?",
+        };
+
+        var group = $"(?<{name}>{body})";
+        return optional ? $"(?:{group})?" : group;
+    }
+}

--- a/listenarr.infrastructure/Metadata/Parsing/NamingPatternFolderMatcher.cs
+++ b/listenarr.infrastructure/Metadata/Parsing/NamingPatternFolderMatcher.cs
@@ -112,6 +112,50 @@ internal static class NamingPatternFolderMatcher
         return false;
     }
 
+    /// <summary>
+    /// Strips folder-pattern decoration from a value that is itself a rendered folder name.
+    /// Taggers frequently write the whole rendered name into the album tag, which then reaches
+    /// search as "[Revelation Space 10] Dilation Sleep" and matches nothing. When the value parses
+    /// as the configured pattern, the bare title is returned; otherwise the value is left alone.
+    /// </summary>
+    public static string? ExtractTitle(string? value, string? folderNamingPattern)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        var pattern = GetOrBuild(folderNamingPattern);
+        if (pattern == null)
+        {
+            return value;
+        }
+
+        Match match;
+        try
+        {
+            match = pattern.Match(value);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return value;
+        }
+
+        if (!match.Success || !HasBookFolderMarker(match))
+        {
+            return value;
+        }
+
+        var title = match.Groups["Title"];
+        if (!title.Success)
+        {
+            return value;
+        }
+
+        var trimmed = title.Value.Trim();
+        return trimmed.Length > 0 ? trimmed : value;
+    }
+
     private static string Convert(string segment, bool tokensOptional)
     {
         var builder = new StringBuilder();

--- a/listenarr.infrastructure/Metadata/Parsing/PathMetadataParser.cs
+++ b/listenarr.infrastructure/Metadata/Parsing/PathMetadataParser.cs
@@ -58,20 +58,23 @@ namespace Listenarr.Infrastructure.Metadata.Parsing
         public static PathParsedMetadata Parse(
             string filePath,
             string rootFolderPath,
-            FileSystemPathSemantics semantics) =>
-            ParseCore(filePath, rootFolderPath, semantics, includeFilesystemMetadata: true);
+            FileSystemPathSemantics semantics,
+            string? folderNamingPattern = null) =>
+            ParseCore(filePath, rootFolderPath, semantics, includeFilesystemMetadata: true, folderNamingPattern);
 
         internal static PathParsedMetadata ParsePathOnly(
             string filePath,
             string rootFolderPath,
-            FileSystemPathSemantics semantics) =>
-            ParseCore(filePath, rootFolderPath, semantics, includeFilesystemMetadata: false);
+            FileSystemPathSemantics semantics,
+            string? folderNamingPattern = null) =>
+            ParseCore(filePath, rootFolderPath, semantics, includeFilesystemMetadata: false, folderNamingPattern);
 
         private static PathParsedMetadata ParseCore(
             string filePath,
             string rootFolderPath,
             FileSystemPathSemantics semantics,
-            bool includeFilesystemMetadata)
+            bool includeFilesystemMetadata,
+            string? folderNamingPattern = null)
         {
             var result = new PathParsedMetadata();
 
@@ -94,25 +97,60 @@ namespace Listenarr.Infrastructure.Metadata.Parsing
             if (parts.Length < 2) return result;
             var folderParts = parts[..^1];
 
-            // Find the first folder level that matches the "Year - Title" pattern
+            // Prefer the configured folder naming pattern so scanning reads back exactly the layout
+            // the renamer writes; fall back to the built-in "{Year} - {Title}" convention.
             int bookFolderIndex = -1;
-            for (int i = 0; i < folderParts.Length; i++)
+            Match? configuredMatch = null;
+            var configuredPattern = NamingPatternFolderMatcher.GetOrBuild(folderNamingPattern);
+
+            if (configuredPattern != null)
             {
-                if (BookFolderPattern.IsMatch(folderParts[i]))
+                for (int i = 0; i < folderParts.Length; i++)
                 {
-                    bookFolderIndex = i;
-                    break;
+                    var candidate = configuredPattern.Match(folderParts[i]);
+                    if (candidate.Success && NamingPatternFolderMatcher.HasBookFolderMarker(candidate))
+                    {
+                        bookFolderIndex = i;
+                        configuredMatch = candidate;
+                        break;
+                    }
+                }
+            }
+
+            if (bookFolderIndex < 0)
+            {
+                for (int i = 0; i < folderParts.Length; i++)
+                {
+                    if (BookFolderPattern.IsMatch(folderParts[i]))
+                    {
+                        bookFolderIndex = i;
+                        break;
+                    }
                 }
             }
 
             if (bookFolderIndex < 0) return result;
 
-            // Parse year, title, series, seriesNumber from the matched folder
-            var m = BookFolderPattern.Match(folderParts[bookFolderIndex]);
-            result.Year = m.Groups[1].Value;
-            result.Title = m.Groups[2].Value.Trim();
-            if (m.Groups[3].Success) result.Series = m.Groups[3].Value.Trim();
-            if (m.Groups[4].Success) result.SeriesNumber = m.Groups[4].Value.Trim();
+            if (configuredMatch != null)
+            {
+                AssignGroup(configuredMatch, "Title", v => result.Title = v);
+                AssignGroup(configuredMatch, "Series", v => result.Series = v);
+                AssignGroup(configuredMatch, "SeriesNumber", v => result.SeriesNumber = v);
+                AssignGroup(configuredMatch, "Narrator", v => result.Narrator = v);
+                AssignGroup(configuredMatch, "Asin", v => result.Asin = v);
+                result.Year = configuredMatch.Groups["Year"].Success
+                    ? configuredMatch.Groups["Year"].Value
+                    : string.Empty;
+            }
+            else
+            {
+                // Parse year, title, series, seriesNumber from the matched folder
+                var m = BookFolderPattern.Match(folderParts[bookFolderIndex]);
+                result.Year = m.Groups[1].Value;
+                result.Title = m.Groups[2].Value.Trim();
+                if (m.Groups[3].Success) result.Series = m.Groups[3].Value.Trim();
+                if (m.Groups[4].Success) result.SeriesNumber = m.Groups[4].Value.Trim();
+            }
 
             // Assign Author and Series from path levels before the book folder
             if (bookFolderIndex == 1)
@@ -288,6 +326,14 @@ namespace Listenarr.Infrastructure.Metadata.Parsing
                 RegexOptions.IgnoreCase);
 
             return match.Success ? match.Value.ToUpperInvariant() : null;
+        }
+
+        private static void AssignGroup(Match match, string name, Action<string> assign)
+        {
+            var group = match.Groups[name];
+            if (!group.Success) return;
+            var value = group.Value.Trim();
+            if (value.Length > 0) assign(value);
         }
 
         private static void TryReadSidecar(string folder, string filename, Action<string> assign)

--- a/tests/Features/Infrastructure/Metadata/Parsing/PathMetadataParser_ConfiguredPatternTests.cs
+++ b/tests/Features/Infrastructure/Metadata/Parsing/PathMetadataParser_ConfiguredPatternTests.cs
@@ -1,0 +1,162 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace Listenarr.Tests.Features.Infrastructure.Metadata.Parsing
+{
+    /// <summary>
+    /// Scanning should read back the layout the renamer writes, so folder parsing is driven by the
+    /// configured folder naming pattern rather than a fixed convention.
+    /// </summary>
+    public class PathMetadataParser_ConfiguredPatternTests
+    {
+        private const string BracketPattern =
+            "{Author}/[{Series} {SeriesNumber}] {Title} {{Narrator}} ({Year})";
+
+        private static PathParsedMetadata Parse(string author, string bookFolder, string? pattern = BracketPattern)
+        {
+            var root = Path.Join(Path.GetTempPath(), $"MetadataRoot-{Guid.NewGuid():N}");
+            var file = Path.Join(root, author, bookFolder, "book.m4b");
+            var syntax = FileSystemPathSemantics.CurrentHostDefault.Syntax;
+            return PathMetadataParser.ParsePathOnly(
+                file,
+                root,
+                new FileSystemPathSemantics(syntax, FileSystemCaseSensitivity.Insensitive),
+                pattern);
+        }
+
+        [Theory]
+        [InlineData("[Revelation Space 10] Dilation Sleep (1990)", "Revelation Space", "10", "Dilation Sleep", "1990")]
+        [InlineData("[Chronicles of Narnia 0] Chronicles of Narnia Intro (2019)", "Chronicles of Narnia", "0", "Chronicles of Narnia Intro", "2019")]
+        [InlineData("[Known Space 00.0] Beclaimed in Hell (2017)", "Known Space", "00.0", "Beclaimed in Hell", "2017")]
+        [InlineData("[The Expanse 2.7] Drive (2012)", "The Expanse", "2.7", "Drive", "2012")]
+        [InlineData("[Rama 03] The Garden of Rama (1991)", "Rama", "03", "The Garden of Rama", "1991")]
+        public void ParsesEverySeriesNumberForm(
+            string folder, string series, string part, string title, string year)
+        {
+            var parsed = Parse("Some Author", folder);
+
+            Assert.Equal(series, parsed.Series);
+            Assert.Equal(part, parsed.SeriesNumber);
+            Assert.Equal(title, parsed.Title);
+            Assert.Equal(year, parsed.Year);
+        }
+
+        [Fact]
+        public void SeriesGroupRenderedWithoutItsNumber_StillParses()
+        {
+            // "[{Series} {SeriesNumber}]" renders as "[Radicalized]" when the number is empty,
+            // so each token inside an elidable group must be independently optional when reading.
+            var parsed = Parse("Cory Doctorow", "[Radicalized] Radicalized (2019)");
+
+            Assert.Equal("Radicalized", parsed.Series);
+            Assert.Null(parsed.SeriesNumber);
+            Assert.Equal("Radicalized", parsed.Title);
+            Assert.Equal("2019", parsed.Year);
+        }
+
+        [Fact]
+        public void UnmentionedTrailingTag_DoesNotSwallowTheYear()
+        {
+            var parsed = Parse("Arthur C. Clarke", "[Rama 03] The Garden of Rama (1991) [abridged]");
+
+            Assert.Equal("The Garden of Rama", parsed.Title);
+            Assert.Equal("1991", parsed.Year);
+        }
+
+        [Fact]
+        public void SecondSeriesBracket_IsToleratedAndFirstWins()
+        {
+            var parsed = Parse(
+                "Orson Scott Card",
+                "[Enderverse 07.5][Ender's Saga 1.1] A War Of Gifts {Scott Brick} (2007)");
+
+            Assert.Equal("Enderverse", parsed.Series);
+            Assert.Equal("07.5", parsed.SeriesNumber);
+            Assert.Equal("A War Of Gifts", parsed.Title);
+            Assert.Equal("Scott Brick", parsed.Narrator);
+            Assert.Equal("2007", parsed.Year);
+        }
+
+        [Fact]
+        public void StandaloneBook_ParsesNarratorAndYearWithoutSeries()
+        {
+            var parsed = Parse("Robert A. Heinlein", "Revolt in 2100 {Eric Michael Summerer} (2009)");
+
+            Assert.Null(parsed.Series);
+            Assert.Equal("Revolt in 2100", parsed.Title);
+            Assert.Equal("Eric Michael Summerer", parsed.Narrator);
+            Assert.Equal("2009", parsed.Year);
+        }
+
+        [Fact]
+        public void FolderWithoutYear_StillParses()
+        {
+            var parsed = Parse("Victoria Schwab", "[Villians 0] 5 Warm Up - A Prequel to Vicious");
+
+            Assert.Equal("Villians", parsed.Series);
+            Assert.Equal("0", parsed.SeriesNumber);
+            Assert.Equal("5 Warm Up - A Prequel to Vicious", parsed.Title);
+        }
+
+        [Fact]
+        public void AuthorDirectory_IsNotClaimedAsABookFolder()
+        {
+            // Every token in the pattern is optional, so a bare name satisfies it structurally.
+            // Requiring a non-title marker stops "Author/Series/book.m4b" resolving to the author.
+            var root = Path.Join(Path.GetTempPath(), $"MetadataRoot-{Guid.NewGuid():N}");
+            var file = Path.Join(root, "Alastair Reynolds", "Revelation Space", "book.m4b");
+            var syntax = FileSystemPathSemantics.CurrentHostDefault.Syntax;
+
+            var parsed = PathMetadataParser.ParsePathOnly(
+                file,
+                root,
+                new FileSystemPathSemantics(syntax, FileSystemCaseSensitivity.Insensitive),
+                BracketPattern);
+
+            Assert.Null(parsed.Title);
+            Assert.Null(parsed.Series);
+        }
+
+        [Fact]
+        public void NoConfiguredPattern_FallsBackToBuiltInConvention()
+        {
+            var parsed = Parse("Brandon Sanderson", "2010 - The Way of Kings [The Stormlight Archive 1]", pattern: null);
+
+            Assert.Equal("The Stormlight Archive", parsed.Series);
+            Assert.Equal("1", parsed.SeriesNumber);
+            Assert.Equal("The Way of Kings", parsed.Title);
+            Assert.Equal("2010", parsed.Year);
+        }
+
+        [Fact]
+        public void ConfiguredPatternThatDoesNotMatch_FallsBackToBuiltInConvention()
+        {
+            var parsed = Parse("Brandon Sanderson", "2010 - The Way of Kings [The Stormlight Archive 1]");
+
+            Assert.Equal("The Way of Kings", parsed.Title);
+            Assert.Equal("2010", parsed.Year);
+        }
+
+        [Fact]
+        public void MalformedPattern_DoesNotBreakScanning()
+        {
+            var parsed = Parse("Some Author", "2010 - A Title", pattern: "{Author}/[{Unclosed");
+
+            Assert.Equal("A Title", parsed.Title);
+        }
+    }
+}

--- a/tests/Features/Infrastructure/Metadata/Parsing/PathMetadataParser_ConfiguredPatternTests.cs
+++ b/tests/Features/Infrastructure/Metadata/Parsing/PathMetadataParser_ConfiguredPatternTests.cs
@@ -151,6 +151,36 @@ namespace Listenarr.Tests.Features.Infrastructure.Metadata.Parsing
             Assert.Equal("2010", parsed.Year);
         }
 
+        [Theory]
+        // Taggers often write the rendered folder name into the album tag; searching for that
+        // whole string matches nothing, so it is reduced to the bare title.
+        [InlineData("[Revelation Space 10] Dilation Sleep", "Dilation Sleep")]
+        [InlineData("[Known Space 00.0] Beclaimed in Hell", "Beclaimed in Hell")]
+        [InlineData("[Radicalized] Radicalized", "Radicalized")]
+        [InlineData("[Enderverse 07.5][Ender's Saga 1.1] A War Of Gifts {Scott Brick} (2007)", "A War Of Gifts")]
+        [InlineData("Revolt in 2100 {Eric Michael Summerer} (2009)", "Revolt in 2100")]
+        public void ExtractTitle_StripsRenderedFolderDecoration(string tagValue, string expected)
+        {
+            Assert.Equal(expected, NamingPatternFolderMatcher.ExtractTitle(tagValue, BracketPattern));
+        }
+
+        [Theory]
+        // A plain title carries no pattern markers and must be returned untouched.
+        [InlineData("Dilation Sleep")]
+        [InlineData("The Garden of Rama")]
+        [InlineData("Harry Potter and the Sorcerer's Stone")]
+        public void ExtractTitle_LeavesUndecoratedTitlesAlone(string tagValue)
+        {
+            Assert.Equal(tagValue, NamingPatternFolderMatcher.ExtractTitle(tagValue, BracketPattern));
+        }
+
+        [Fact]
+        public void ExtractTitle_WithoutConfiguredPattern_ReturnsInputUnchanged()
+        {
+            const string value = "[Revelation Space 10] Dilation Sleep";
+            Assert.Equal(value, NamingPatternFolderMatcher.ExtractTitle(value, null));
+        }
+
         [Fact]
         public void MalformedPattern_DoesNotBreakScanning()
         {

--- a/tests/Features/Infrastructure/Metadata/Parsing/PathMetadataParser_ConfiguredPatternTests.cs
+++ b/tests/Features/Infrastructure/Metadata/Parsing/PathMetadataParser_ConfiguredPatternTests.cs
@@ -15,13 +15,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+using Listenarr.Tests.Common;
+
 namespace Listenarr.Tests.Features.Infrastructure.Metadata.Parsing
 {
     /// <summary>
     /// Scanning should read back the layout the renamer writes, so folder parsing is driven by the
     /// configured folder naming pattern rather than a fixed convention.
     /// </summary>
-    public class PathMetadataParser_ConfiguredPatternTests
+    [Trait("Area", "Metadata")]
+    [Trait("Name", "PathMetadataParser_ConfiguredPatternTests")]
+    [Trait("Category", "PathMetadataParser")]
+    public class PathMetadataParser_ConfiguredPatternTests : BaseTests
     {
         private const string BracketPattern =
             "{Author}/[{Series} {SeriesNumber}] {Title} {{Narrator}} ({Year})";


### PR DESCRIPTION
> **Product decision — close this if you disagree.** Whether an embedded tag should ever be normalised is a judgement call that belongs to you, not to me. I think the evidence below makes it the right call, but I've kept it deliberately narrow so it's easy to reject without affecting anything else. **Stacked on #856** — please review that first; this branches from it.

## Summary

Taggers routinely write the whole rendered folder name into the album tag. A book organised as `[Revelation Space 10] Dilation Sleep (1990)` carries:

```
TAG:album=[Revelation Space 10] Dilation Sleep
TAG:title=Dilation Sleep
```

`ApplyEmbeddedTags` copies that verbatim, and library import sends it to search as the title.

The metadata lookup is a **text search against the Audible storefront**, so a decorated query matches nothing. Measured on a real instance:

| Query sent | Result | Time |
|---|---|---|
| `[Revelation Space 10] Dilation Sleep` | **0 results** | 15s |
| `Dilation Sleep` | resolves | — |

The failure is silent — search returns nothing, and the user sees matching fail on books that *are* in the catalogue. This is the single most common reason "Start Matching" appears broken on an otherwise well-tagged library.

## Why normalising is defensible

The narrow argument: **this only un-renders a value that was rendered from the user's own pattern.** It runs the tag through the *same* pattern-derived regex added in #856, and only rewrites when the value parses as that pattern *and* carries pattern markers. A tag that is already a plain title carries no markers and is returned untouched.

So the rule is not "clean up tags" — it's "if the tag is literally this library's folder name, treat it as one".

Crucially it **does not change tag-versus-path precedence**. Tags still win for every field, including title. Nothing is reordered.

## The counter-argument

Tags are user data, and silently rewriting them is a real cost. If you'd rather the app never second-guess a tag, this should be closed — I'd rather that than argue it into the codebase. Two alternatives if you like the outcome but not the mechanism:

- do it in `buildLibraryImportSearchParams` so only the *query* is cleaned and displayed metadata stays verbatim;
- put it behind a setting, defaulted off.

I'd lean against the frontend option only because the pattern lives server-side and duplicating the derivation in TypeScript invites drift.

## Changes

### Added
- `NamingPatternFolderMatcher.ExtractTitle` — returns the bare title when a value parses as the configured folder pattern, otherwise the input unchanged.
- Tests for decorated values, undecorated values, and the no-pattern-configured case.

### Changed
- `ApplyEmbeddedTags` routes the incoming title through it.

## Testing

30/30 pass.

Verified end-to-end. Titles reaching search, before → after:

| Before | After |
|---|---|
| `[Revelation Space 10] Dilation Sleep` | `Dilation Sleep` |
| `[Known Space 00.0] Beclaimed in Hell` | `Beclaimed in Hell` |
| `[Enderverse 07.5][Ender's Saga 1.1] A War Of Gifts {Scott Brick} (2007)` | `A War Of Gifts` |
| `[Radicalized] Radicalized` | `Radicalized` |

Undecorated titles (`Dilation Sleep`, `The Garden of Rama`, `Harry Potter and the Sorcerer's Stone`) are asserted to pass through unchanged, and with no configured pattern the input is always returned as-is.

Three books that previously failed to match resolved immediately afterwards, including one where the catalogue title corrected a typo in the folder name (`Beclaimed` → `Becalmed in Hell`).

## Notes

No-ops entirely when `FolderNamingPattern` is unset. Regex is cached and timeout-guarded; `RegexMatchTimeoutException` returns the input unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
