### PR TITLE
Add a Docker-based development environment

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,22 @@
+# Development image: SDK + Node, source is bind-mounted at runtime (nothing is
+# COPYed in). Kept separate from the production Dockerfile so upstream changes
+# to that file merge cleanly.
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+
+# Node 24 to match package.json "engines" and .nvmrc.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg procps \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs ffmpeg \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Native filesystem scanning needs a real Linux mount; ffmpeg above also gives
+# us a working ffprobe, which the macOS auto-installer cannot provide.
+WORKDIR /src
+
+ENV DOTNET_USE_POLLING_FILE_WATCHER=1 \
+    DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER=1 \
+    ASPNETCORE_ENVIRONMENT=Development \
+    LISTENARR_CONTENT_ROOT=/src/.env/development
+
+EXPOSE 4545 5173

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,53 @@
+# Dev environment: source bind-mounted, both servers in one container so vite's
+# proxy to http://localhost:4545 keeps working unchanged.
+#
+#   docker compose -f docker-compose.dev.yml up --build
+#
+services:
+  listenarr-dev:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - "4545:4545"   # API
+      - "5173:5173"   # Vite
+    volumes:
+      - .:/src
+      # Point LISTENARR_DEV_LIBRARY at a folder of audiobooks to scan; defaults to ./dev-library
+      - ${LISTENARR_DEV_LIBRARY:-./dev-library}:/audiobooks
+
+      # Host build output is macOS-targeted (osx-arm64/osx-x64) and would poison
+      # the Linux build. Mask every artifact directory with container-only volumes.
+      - dev-obj-api:/src/listenarr.api/obj
+      - dev-bin-api:/src/listenarr.api/bin
+      - dev-obj-app:/src/listenarr.application/obj
+      - dev-bin-app:/src/listenarr.application/bin
+      - dev-obj-dom:/src/listenarr.domain/obj
+      - dev-bin-dom:/src/listenarr.domain/bin
+      - dev-obj-inf:/src/listenarr.infrastructure/obj
+      - dev-bin-inf:/src/listenarr.infrastructure/bin
+      - dev-obj-tst:/src/tests/obj
+      - dev-bin-tst:/src/tests/bin
+
+      # node_modules built for darwin must not leak into the container.
+      - dev-node-root:/src/node_modules
+      - dev-node-fe:/src/fe/node_modules
+
+      # Container keeps its own database/config so it never fights the host instance.
+      - dev-config:/src/.env
+    command: ["sh", "/src/docker/dev-entrypoint.sh"]
+
+volumes:
+  dev-obj-api: {}
+  dev-bin-api: {}
+  dev-obj-app: {}
+  dev-bin-app: {}
+  dev-obj-dom: {}
+  dev-bin-dom: {}
+  dev-obj-inf: {}
+  dev-bin-inf: {}
+  dev-obj-tst: {}
+  dev-bin-tst: {}
+  dev-node-root: {}
+  dev-node-fe: {}
+  dev-config: {}

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Dev entrypoint. Lives in a file rather than compose's `command:` so the nested
+# quoting concurrently needs is not mangled by YAML folding.
+set -e
+
+echo "[dev] installing root dependencies"
+npm install --no-audit --no-fund --silent
+
+echo "[dev] installing frontend dependencies"
+(cd /src/fe && npm install --no-audit --no-fund --silent)
+
+echo "[dev] ffprobe: $(command -v ffprobe || echo 'MISSING')"
+echo "[dev] starting API + web"
+
+exec npx concurrently --names API,WEB --prefix-colors blue,green \
+  "cd /src/listenarr.api && dotnet watch run --no-launch-profile --urls http://0.0.0.0:4545" \
+  "cd /src/fe && npm run dev -- --host 0.0.0.0 --port 5173"


### PR DESCRIPTION
> **Optional tooling — close this if it isn't a direction you want.** This adds a second way to run the project, which is a maintenance surface you may not want to own. Nothing existing changes, so rejecting it costs nothing.

## Summary

Adds an optional containerised dev environment:

```bash
docker compose -f docker-compose.dev.yml up -d
```

Source is bind-mounted rather than copied, with `dotnet watch` and vite running inside the container, so hot reload behaves as it does natively.

## Why this is worth having

**macOS filesystem scanning does not currently work** — and that's not hypothetical. `UnixOpenFlags.EnsureMacOSArchitectureSupported` rejects anything but x64, and on x64 the raw `fstat` P/Invoke misclassifies every regular file (see #855). Until both are resolved, a macOS contributor cannot exercise the scan path at all. Running Linux in a container sidesteps the entire class of problem, on the platform CI actually builds and tests.

It also removes the .NET SDK and Node version-matching step from onboarding, and gives the container a working `ffprobe` from apt rather than the runtime downloader (which is itself broken on macOS — see #854).

## Changes

### Added
- `Dockerfile.dev` — SDK 10 + Node 24 + ffmpeg. Nothing is `COPY`ed in.
- `docker-compose.dev.yml` — bind-mounted source, published ports 4545/5173.
- `docker/dev-entrypoint.sh` — installs deps, then runs both servers under `concurrently`.

## Design notes

**One container, not two.** Both servers share a container so vite's proxy to `http://localhost:4545` works unchanged. Splitting them would mean editing `vite.config.ts` to target a service name — a source change to support tooling, which seemed like the wrong trade.

**Masking volumes.** Named volumes cover every `obj/` and `bin/` directory and both `node_modules` trees. Host build output is targeted at the host RID (`osx-arm64`, `osx-x64`, …) and would otherwise be read by the Linux build; `node_modules` may hold platform-native binaries. A separate volume backs `.env` so the container keeps its own database and never competes with a native instance.

**Entrypoint in a file.** The `concurrently` invocation needs nested quoting that YAML folding mangles — the script avoids that.

**Polling watchers.** `DOTNET_USE_POLLING_FILE_WATCHER=1`, since FSEvents/inotify don't propagate through bind mounts on macOS.

## Testing

Verified on macOS (Apple Silicon, Docker Desktop, VirtioFS), scanning a real 11-book library:

```
status = Completed | items = 11
```

Native `arm64` Linux, so no emulation: restore 5.8s, incremental build ~16s, `ffprobe` at `/usr/bin/ffprobe`.

Storage capability check on the bind mount, since the scanner depends on it:

| | statx INO/BTIME/MNT_ID | name_to_handle_at | FS_IOC_GETVERSION |
|---|---|---|---|
| VirtioFS bind mount | ✓ (`0x1fff`) | ✗ EOPNOTSUPP | ✗ ENOTTY |
| Named volume (ext4) | ✓ | — | ✓ |

Bind mounts land in path-only mode — the existing `HasDurableGenerationProof` branch handles this and scanning works. Contributors wanting full generation proof can point the library mount at a named volume.

## Notes

Both files are new rather than edits to the production `Dockerfile`, so there's no merge risk for release builds. The library mount is parameterised via `LISTENARR_DEV_LIBRARY` (defaults to `./dev-library`).

Not wired into CI — purely local tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
