### PR TITLE
fix(images): read the metadata envelope by reflection, not dynamic

### DIFF
--- a/listenarr.api/Features/Images/ImageCandidateLookupWorkflow.cs
+++ b/listenarr.api/Features/Images/ImageCandidateLookupWorkflow.cs
@@ -8,6 +8,7 @@
  * (at your option) any later version.
  */
 
+using System.Reflection;
 
 namespace Listenarr.Api.Features.Images
 {
@@ -337,9 +338,15 @@ namespace Listenarr.Api.Features.Images
                                     }
                                     else
                                     {
-                                        // Try dynamic access
-                                        dynamic env = metadataEnvelope;
-                                        object? mdObj = env.metadata;
+                                        // Not `dynamic`: the envelope is an anonymous type, emitted
+                                        // internal to Listenarr.Application, so the binder cannot
+                                        // see `metadata` from this assembly and throws. Reflection
+                                        // is how the inner object is read below, and how
+                                        // LibraryMetadataRescanWorkflow reads this same envelope.
+                                        object? mdObj = metadataEnvelope.GetType().GetProperty(
+                                                "metadata",
+                                                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase)
+                                            ?.GetValue(metadataEnvelope);
 
                                         // If it's already the Audible type, use it
                                         if (mdObj is AudibleBookResponse mdMeta)

--- a/tests/Features/Api/Features/Images/ImagesController_MetadataDownloadFallbackTests.cs
+++ b/tests/Features/Api/Features/Images/ImagesController_MetadataDownloadFallbackTests.cs
@@ -96,5 +96,107 @@ namespace Listenarr.Tests.Features.Api.Features.Images
                 // Best-effort test cleanup; ignore cleanup failures.
             }
         }
+
+        // The test above returns the AudibleBookResponse directly, and its own comment says that is
+        // to avoid "anonymous envelope issues". But an anonymous envelope is what the production
+        // service actually returns, so dodging it leaves the fallback covered only in the one shape
+        // that never exercises the unwrap. This covers the other one.
+        //
+        // The anonymous type here is emitted internal to this test assembly, and the workflow that
+        // unwraps it lives in Listenarr.Api, so the accessibility relationship is the same one that
+        // exists in production between Listenarr.Application and Listenarr.Api.
+        [Fact]
+        public async Task GetImage_FallbackEnvelopeIsAnonymousType_StillFindsTheImageUrl()
+        {
+            var identifier = "BTESTASIN";
+            var relativePath = $"config/cache/images/temp/{identifier}.jpg";
+            var imageUrl = "https://audnexus.covers/anonymous-envelope.jpg";
+
+            var mockImageCache = new Mock<IImageCacheService>();
+            mockImageCache
+                .Setup(m => m.DownloadAndCacheImageAsync(imageUrl, identifier))
+                .ReturnsAsync(relativePath);
+            mockImageCache
+                .SetupSequence(m => m.GetCachedImagePathAsync(identifier))
+                .ReturnsAsync((string?)null)
+                .ReturnsAsync(relativePath);
+
+            using var httpClientForAudible = new System.Net.Http.HttpClient();
+            var audibleMock = new Mock<AudibleService>(
+                httpClientForAudible,
+                Mock.Of<ILogger<AudibleService>>());
+            audibleMock
+                .Setup(a => a.GetBookMetadataAsync(
+                    identifier,
+                    It.IsAny<string>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<string?>()))
+                .ReturnsAsync((AudibleBookResponse?)null);
+
+            var mockMetadata = new Mock<IAudiobookMetadataService>();
+            mockMetadata
+                .Setup(m => m.GetAudibleMetadataAsync(
+                    identifier,
+                    It.IsAny<string>(),
+                    It.IsAny<bool>()))
+                .ReturnsAsync((AudibleBookResponse?)null);
+            // The same envelope shape AudiobookMetadataService returns on its success path.
+            mockMetadata
+                .Setup(m => m.GetMetadataAsync(
+                    identifier,
+                    It.IsAny<string>(),
+                    It.IsAny<bool>()))
+                .ReturnsAsync((object)new
+                {
+                    metadata = new AudibleBookResponse { ImageUrl = imageUrl },
+                    source = "Audnexus",
+                    sourceUrl = "https://api.audnex.us"
+                });
+
+            var tempRoot = Path.Join(
+                Path.GetTempPath(),
+                "listenarr_test_contentroot_anonymous_envelope");
+            Directory.CreateDirectory(Path.Join(tempRoot, "config", "cache", "images", "temp"));
+            var fullPath = Path.Join(tempRoot, relativePath);
+            File.WriteAllText(fullPath, "fake image data");
+
+            var mockPathService = new Mock<IApplicationPathService>();
+            mockPathService.SetupGet(p => p.ContentRootPath).Returns(tempRoot);
+
+            var controller = new ImagesController(
+                mockImageCache.Object,
+                mockMetadata.Object,
+                audibleMock.Object,
+                Mock.Of<IAudnexusService>(),
+                Mock.Of<IAudiobookRepository>(),
+                Mock.Of<ILogger<ImagesController>>(),
+                mockPathService.Object,
+                new LocalFileSystem());
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext()
+            };
+
+            var result = await controller.GetImage(identifier);
+
+            // The URL has to be recovered from inside the envelope for the downloader to be called
+            // at all. Reading it with `dynamic` throws RuntimeBinderException, which is not in the
+            // recoverable list, so it escapes the filtered catch and the controller returns 500
+            // having never reached the download.
+            mockImageCache.Verify(
+                m => m.DownloadAndCacheImageAsync(imageUrl, identifier),
+                Times.Once);
+            Assert.IsNotType<StatusCodeResult>(result);
+
+            try
+            {
+                File.Delete(fullPath);
+                Directory.Delete(Path.Join(tempRoot, "config", "cache", "images", "temp"), true);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                // Best-effort test cleanup; ignore cleanup failures.
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

`GET /api/v1/images/{identifier}` returns 500 whenever the metadata fallback runs, because the envelope it gets back is read with `dynamic` across an assembly boundary. This reads it by reflection instead.

Full write-up in #859.

## Changes

### Fixed
- `ImageCandidateLookupWorkflow` reads `metadata` off the envelope with `GetType().GetProperty(...)` rather than `dynamic`.

`GetMetadataAsync` is declared `Task<object?>` and returns an anonymous type. The compiler emits anonymous types as `internal`, so the envelope is internal to `Listenarr.Application` while this call site is in `Listenarr.Api`. The runtime binder resolves members against what is visible from the call site's assembly, so it cannot see `metadata` and throws `RuntimeBinderException` reported against `object`. Reflection is not subject to that.

`RuntimeBinderException` is not in `IsRecoverableImageLookupException`, so it escapes the filtered catch that was written to make a malformed envelope degrade quietly, and reaches the controller catch-all. The throw is deterministic on that path; what makes it rare is the guard above, since most requests resolve a URL earlier and never enter the fallback.

## Why reflection rather than something nicer

Because it is what the surrounding code already does. Ten lines below the change, the same block reads `ImageUrl` and `Isbn` off the inner object with `t.GetProperty(...)`. `LibraryMetadataRescanWorkflow.TryExtractMetadataLookupResult` unwraps this exact envelope the same way and works. Of the four callers of `GetMetadataAsync`, this was the only one using `dynamic`, and the only one that throws.

The better fix is a named public record for the envelope so `GetMetadataAsync` stops returning `object?`, which would remove the reason three consumers each invented their own unwrapping. I did not do that here because it changes an interface with four call sites, and whether that signature should stay `object?` is a design decision rather than a bug fix. This does not foreclose it. The issue lays out both.

## Testing

`ImagesController_MetadataDownloadFallbackTests` gains a case using an anonymous envelope, which is the shape production actually returns. Because the anonymous type is emitted internal to the test assembly and the workflow lives in `Listenarr.Api`, it reproduces the same accessibility relationship as production.

The existing test in that file covers this fallback but mocks a bare `AudibleBookResponse`, and its own comment says that is to avoid "anonymous envelope issues". That takes the `is AudibleBookResponse` branch and never reaches the unwrap, so the one shape that fails was the one shape not covered.

Verified as a real guard: with `dynamic` restored the new test fails, and it fails by never calling the downloader at all, which is the actual production symptom rather than a proxy for it.

Full suite: 3,030 passed, 0 failed, 125 skipped, against a 3,029 baseline on `03958c15`.

## One note on the comment

`BackendArchitectureTests.ActiveProductionSourceFiles_RemainFocused` caps a production source file at 500 lines, and this file is at 487 on canary. My first version of the explanatory comment took it to 503 and failed that test. The comment is deliberately short as a result and the full reasoning lives in the issue. Flagging it because it is the kind of budget worth knowing about before writing prose into a file near the limit.
