### PR TITLE
Make the OpenLibrary fallback reachable

### DIFF
--- a/listenarr.application/Search/Audible/AsinCandidateCollector.cs
+++ b/listenarr.application/Search/Audible/AsinCandidateCollector.cs
@@ -106,7 +106,10 @@ public class AsinCandidateCollector
             foreach (var book in books.Docs.Take(3))
             {
                 ct.ThrowIfCancellationRequested();
-                if (!string.IsNullOrEmpty(book.Title) && !string.Equals(book.Title, query, StringComparison.OrdinalIgnoreCase))
+                // An exact title match is the strongest candidate, not one to discard: skipping
+                // titles equal to the query silently threw away the best result for every book
+                // whose catalogue title matches what was searched for.
+                if (!string.IsNullOrEmpty(book.Title))
                 {
                     _logger.LogInformation("OpenLibrary suggested title: {Title}", book.Title);
                     await _searchProgressReporter.BroadcastAsync($"OpenLibrary found: {book.Title}", null);

--- a/listenarr.application/Search/Audible/AsinCandidateCollector.cs
+++ b/listenarr.application/Search/Audible/AsinCandidateCollector.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 /*
  * Listenarr - Audiobook Management System
  * Copyright (C) 2024-2026 Listenarr Contributors
@@ -47,29 +48,60 @@ public class AsinCandidateCollector
     public async Task<AsinCandidateCollection> CollectCandidatesAsync(
         string query,
         bool skipOpenLibrary = false,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        string? title = null,
+        string? author = null)
     {
         var collection = new AsinCandidateCollection();
 
-        _logger.LogInformation("Collecting candidates from OpenLibrary (query='{Query}')", query);
+        // The composed query still carries its "AUTHOR:"/"TITLE:" prefixes. OpenLibrary's
+        // normalizer drops the colons, which turns the prefixes into literal search tokens and
+        // matches nothing, so prefer the fields the caller already parsed.
+        var searchTitle = !string.IsNullOrWhiteSpace(title) ? title : StripSearchPrefixes(query);
+        var searchAuthor = !string.IsNullOrWhiteSpace(author) ? author : null;
+
+        _logger.LogInformation(
+            "Collecting candidates from OpenLibrary (title='{Title}', author='{Author}')",
+            searchTitle,
+            searchAuthor);
 
         // Augment ASIN candidates with OpenLibrary suggestions
-        if (!skipOpenLibrary && !string.IsNullOrEmpty(query))
+        if (!skipOpenLibrary && !string.IsNullOrWhiteSpace(searchTitle))
         {
             ct.ThrowIfCancellationRequested();
-            await CollectOpenLibraryCandidatesAsync(query, collection, ct);
+            await CollectOpenLibraryCandidatesAsync(searchTitle, searchAuthor, collection, ct);
         }
 
         return collection;
     }
 
-    private async Task CollectOpenLibraryCandidatesAsync(string query, AsinCandidateCollection collection, CancellationToken ct = default)
+    /// <summary>
+    /// Removes "FIELD:" prefixes from a composed query so it can be used as a plain search term.
+    /// Only used when the caller did not supply already-parsed fields.
+    /// </summary>
+    private static string StripSearchPrefixes(string? query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            return string.Empty;
+        }
+
+        var stripped = Regex.Replace(
+            query,
+            @"\b(?:ASIN|ISBN|AUTHOR|TITLE|SERIES|NARRATOR)\s*:\s*",
+            " ",
+            RegexOptions.IgnoreCase);
+
+        return Regex.Replace(stripped, @"\s{2,}", " ").Trim();
+    }
+
+    private async Task CollectOpenLibraryCandidatesAsync(string query, string? author, AsinCandidateCollection collection, CancellationToken ct = default)
     {
         try
         {
             ct.ThrowIfCancellationRequested();
             await _searchProgressReporter.BroadcastAsync($"Searching OpenLibrary for additional titles", null);
-            var books = await _openLibraryService.SearchBooksAsync(query, null, 5);
+            var books = await _openLibraryService.SearchBooksAsync(query, author, 5);
 
             foreach (var book in books.Docs.Take(3))
             {

--- a/listenarr.application/Search/Core/SearchService.Intelligent.cs
+++ b/listenarr.application/Search/Core/SearchService.Intelligent.cs
@@ -109,7 +109,7 @@ namespace Listenarr.Application.Search.Core
 
                 // Step 2: Collect candidates from OpenLibrary (and other non-scraping sources)
                 var candidateCollection = await _asinCandidateCollector.CollectCandidatesAsync(
-                    query, skipOpenLibrary, ct);
+                    query, skipOpenLibrary, ct, titleVal, authorVal);
 
                 var asinCandidates = candidateCollection.AsinCandidates;
                 var asinToRawResult = candidateCollection.AsinToRawResult;

--- a/listenarr.infrastructure/Metadata/Providers/OpenLibrary/OpenLibraryService.cs
+++ b/listenarr.infrastructure/Metadata/Providers/OpenLibrary/OpenLibraryService.cs
@@ -76,7 +76,14 @@ namespace Listenarr.Infrastructure.Metadata.Providers.OpenLibrary
                 }
 
                 var searchParams = new List<string>();
-                var q = qParts.Any() ? string.Join("+", qParts) : string.Empty;
+                // Join with a space, not "+". Uri.EscapeDataString encodes "+" as %2B, so a
+                // plus-joined query reaches OpenLibrary as literal plus characters and matches
+                // nothing ("radicalized%2Bcory%2Bdoctorow" -> 0 results, "radicalized cory
+                // doctorow" -> 6). NormalizeForOpenLibrary also joins its tokens with "+", so
+                // undo that here as well.
+                var q = qParts.Any()
+                    ? string.Join(" ", qParts).Replace("+", " ")
+                    : string.Empty;
                 if (!string.IsNullOrEmpty(q))
                 {
                     searchParams.Add($"q={Uri.EscapeDataString(q)}");

--- a/tests/Features/Application/Search/Audible/AsinCandidateCollector_OpenLibraryQueryTests.cs
+++ b/tests/Features/Application/Search/Audible/AsinCandidateCollector_OpenLibraryQueryTests.cs
@@ -1,0 +1,111 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Listenarr.Tests.Features.Application.Search.Audible
+{
+    /// <summary>
+    /// The composed search query carries "AUTHOR:"/"TITLE:" prefixes. OpenLibrary's normalizer
+    /// strips punctuation, so those prefixes become literal search tokens and match nothing -
+    /// which silently disables the OpenLibrary fallback for books with no Audible edition.
+    /// </summary>
+    public class AsinCandidateCollector_OpenLibraryQueryTests
+    {
+        private static (AsinCandidateCollector Collector, Mock<IOpenLibraryService> Service) Create()
+        {
+            var openLibrary = new Mock<IOpenLibraryService>();
+            openLibrary
+                .Setup(s => s.SearchBooksAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<int>()))
+                .ReturnsAsync(new OpenLibrarySearchResponse());
+
+            var collector = new AsinCandidateCollector(
+                NullLogger<AsinCandidateCollector>.Instance,
+                openLibrary.Object,
+                new MetadataConverters(
+                    Mock.Of<IImageCacheService>(),
+                    NullLogger<MetadataConverters>.Instance),
+                new SearchProgressReporter(null, NullLogger<SearchProgressReporter>.Instance));
+
+            return (collector, openLibrary);
+        }
+
+        [Fact]
+        public async Task ParsedFieldsArePreferredOverTheComposedQuery()
+        {
+            var (collector, service) = Create();
+
+            await collector.CollectCandidatesAsync(
+                "AUTHOR:Abelson TITLE:Structure and Interpretation of Computer Programs",
+                skipOpenLibrary: false,
+                ct: default,
+                title: "Structure and Interpretation of Computer Programs",
+                author: "Abelson");
+
+            service.Verify(
+                s => s.SearchBooksAsync(
+                    "Structure and Interpretation of Computer Programs",
+                    "Abelson",
+                    It.IsAny<int>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task WithoutParsedFields_PrefixesAreStrippedFromTheQuery()
+        {
+            var (collector, service) = Create();
+
+            await collector.CollectCandidatesAsync(
+                "AUTHOR:Abelson TITLE:Structure and Interpretation of Computer Programs",
+                skipOpenLibrary: false);
+
+            service.Verify(
+                s => s.SearchBooksAsync(
+                    It.Is<string>(q =>
+                        !q.Contains("AUTHOR:", StringComparison.OrdinalIgnoreCase)
+                        && !q.Contains("TITLE:", StringComparison.OrdinalIgnoreCase)
+                        && q.Contains("Structure and Interpretation of Computer Programs")),
+                    It.IsAny<string?>(),
+                    It.IsAny<int>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task PlainQueryIsPassedThroughUnchanged()
+        {
+            var (collector, service) = Create();
+
+            await collector.CollectCandidatesAsync("Dilation Sleep", skipOpenLibrary: false);
+
+            service.Verify(
+                s => s.SearchBooksAsync("Dilation Sleep", It.IsAny<string?>(), It.IsAny<int>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task OpenLibraryIsNotQueriedWhenDisabled()
+        {
+            var (collector, service) = Create();
+
+            await collector.CollectCandidatesAsync("Dilation Sleep", skipOpenLibrary: true);
+
+            service.Verify(
+                s => s.SearchBooksAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<int>()),
+                Times.Never);
+        }
+    }
+}

--- a/tests/Features/Application/Search/Audible/AsinCandidateCollector_OpenLibraryQueryTests.cs
+++ b/tests/Features/Application/Search/Audible/AsinCandidateCollector_OpenLibraryQueryTests.cs
@@ -17,6 +17,8 @@
  */
 using Microsoft.Extensions.Logging.Abstractions;
 
+using Listenarr.Tests.Common;
+
 namespace Listenarr.Tests.Features.Application.Search.Audible
 {
     /// <summary>
@@ -24,7 +26,10 @@ namespace Listenarr.Tests.Features.Application.Search.Audible
     /// strips punctuation, so those prefixes become literal search tokens and match nothing -
     /// which silently disables the OpenLibrary fallback for books with no Audible edition.
     /// </summary>
-    public class AsinCandidateCollector_OpenLibraryQueryTests
+    [Trait("Area", "Search")]
+    [Trait("Name", "AsinCandidateCollector_OpenLibraryQueryTests")]
+    [Trait("Category", "AsinCandidateCollector")]
+    public class AsinCandidateCollector_OpenLibraryQueryTests : BaseTests
     {
         private static (AsinCandidateCollector Collector, Mock<IOpenLibraryService> Service) Create()
         {


### PR DESCRIPTION
## Summary

`SearchService` merges OpenLibrary-derived candidates when no enriched metadata was found, so books with no Audible edition still produce results:

```csharp
// Merge OpenLibrary-derived results … so OpenLibrary-only augmentation produces
// visible, scoreable items without calling Amazon.
if ((openLibraryDerivedResults != null && openLibraryDerivedResults.Any()) && !enrichedList.Any())
```

**That branch can never be taken.** Three independent defects upstream of it leave `OpenLibraryDerivedResults` empty, so the fallback silently does nothing and such books return zero results.

## The three defects

**1. The composed query is used as the OpenLibrary title.**

```csharp
var books = await _openLibraryService.SearchBooksAsync(query, null, 5);
//                                    ↑ "AUTHOR:Abelson TITLE:Structure and Interpretation…"
```

`NormalizeForOpenLibrary` tokenises on `[a-z0-9\-]+`, dropping the colons and leaving `AUTHOR`/`TITLE` as literal search terms. The author is also discarded as `null`, despite the caller having parsed it.

**2. Exact title matches are discarded.**

```csharp
if (!string.IsNullOrEmpty(book.Title) && !string.Equals(book.Title, query, StringComparison.OrdinalIgnoreCase))
```

An exact title match is the strongest candidate available. Searching `Radicalized` by Cory Doctorow returns six documents, the first two titled exactly `Radicalized` — all dropped. `The Garden of Rama` kept only a four-book omnibus, precisely *because* the omnibus title differs from the query while the actual book's does not.

**3. Query terms are joined with `+`, then URL-escaped.**

```csharp
var q = string.Join("+", qParts);
searchParams.Add($"q={Uri.EscapeDataString(q)}");   // "+" → %2B
```

OpenLibrary receives literal plus characters between words. Measured against the live API:

| Query | numFound |
|---|---|
| `radicalized%2Bcory%2Bdoctorow` | **0** |
| `radicalized cory doctorow` | **6** |
| `the%2Bgarden%2Bof%2Brama%2Barthur%2Bc%2Bclarke` | **1** (omnibus only) |
| `the garden of rama arthur c clarke` | **5** |

This is the dominant one — it corrupts every OpenLibrary query the app makes.

## Changes

### Fixed
- Pass the caller's already-parsed title and author into `SearchBooksAsync` (`SearchService` logs both one line before the call); strip `FIELD:` prefixes for callers that only have a composed string.
- Keep documents whose title equals the query and let existing scoring/dedupe rank them.
- Join query terms with spaces so escaping produces separators rather than literal `+`.

### Added
- `AsinCandidateCollector_OpenLibraryQueryTests` — parsed fields preferred, prefixes stripped when absent, plain queries untouched, and no call when OpenLibrary is disabled.

## Testing

34/34 pass, including the existing parser suite.

Verified end-to-end against a running instance. Log lines that never appeared before now do:

```
Collecting candidates from OpenLibrary (title='Radicalized', author='Cory Doctorow')
OpenLibrary suggested title: Radicalized
Merging 1 OpenLibrary-derived candidate(s) into enriched results
```

Real searches, before → after:

| Query | Before | After |
|---|---|---|
| `Radicalized` / Cory Doctorow | 0 results | **2** — `'Radicalized'` first |
| `The Garden of Rama` / Arthur C. Clarke | 1 — `'Rama Series, Collection Set of 4 Books…'` | **1 — `'The Garden of Rama'`** |
| `Structure and Interpretation…` / Abelson | 0 results | **1** |

A control case still correctly returns nothing: `Chronicles of Narnia Intro` is an intro track rather than a book, and OpenLibrary has no such title (`numFound=0`); dropping "Intro" returns 234.

## Notes

Each defect masked the next, so fixing any one alone leaves the symptom unchanged — I confirmed each independently against the live OpenLibrary API before and after.

Behaviour is unchanged when `EnableOpenLibrarySearch` is off, and no Audible/Audnexus path is touched; this only affects queries that would otherwise have returned nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
