### PR TITLE
fix(recovery): name every legacy journal blocking startup, not just the first

### DIFF
--- a/listenarr.infrastructure/Persistence/FileRegistrationRecoveryService.Protocol.cs
+++ b/listenarr.infrastructure/Persistence/FileRegistrationRecoveryService.Protocol.cs
@@ -65,7 +65,24 @@ public sealed partial class FileRegistrationRecoveryService
                     cancellationToken);
         }
 
+        // Name every journal, not just the first. This disables filesystem mutations for the whole
+        // application until an operator resolves them, and there is no in-app route to do that, so
+        // this message is the entire brief they get. Reporting one at a time turns a single repair
+        // into one restart per affected journal, with no way to know how many are left.
+        const int listed = 10;
+        var identifiers = string.Join(
+            ", ",
+            unsupported
+                .Take(listed)
+                .Select(journal => $"{journal.OperationId} ({journal.State})"));
+        var remainder = unsupported.Count > listed
+            ? $", and {unsupported.Count - listed} more"
+            : string.Empty;
+
         throw new InvalidOperationException(
-            $"File-mutation journal {unsupported[0].OperationId} uses legacy recovery protocol state {unsupported[0].State} and requires operator repair before filesystem mutations can resume.");
+            $"{unsupported.Count} file-mutation journal(s) use a legacy recovery protocol and require "
+            + $"operator repair before filesystem mutations can resume: {identifiers}{remainder}. "
+            + "Each was interrupted before this build's durable parent-directory generation fencing "
+            + "existed and cannot be resumed automatically.");
     }
 }

--- a/tests/Features/Infrastructure/Persistence/FileRegistrationRecoveryProtocolTests.cs
+++ b/tests/Features/Infrastructure/Persistence/FileRegistrationRecoveryProtocolTests.cs
@@ -1,0 +1,76 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Tests.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Listenarr.Tests.Features.Infrastructure.Persistence;
+
+[Trait("Name", "FileRegistrationRecoveryProtocolTests")]
+[Trait("Category", "Infrastructure")]
+public sealed class FileRegistrationRecoveryProtocolTests : BaseTests
+{
+    // A journal left on an older protocol version disables filesystem mutations for the whole
+    // application, and there is no in-app route to clear it, so this exception message is the
+    // entire brief an operator gets. Naming only the first of several turns one repair into one
+    // restart per journal, with no way to know how many remain.
+    [Fact]
+    public async Task ReconcileAsync_LegacyJournals_NamesEveryOneAndHowMany()
+    {
+        Init();
+        var factory = _provider.GetRequiredService<
+            IDbContextFactory<ListenArrDbContext>>();
+
+        var operationIds = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
+        await using (var seed = await factory.CreateDbContextAsync())
+        {
+            var created = DateTime.UtcNow.AddMinutes(-30);
+            foreach (var (operationId, index) in operationIds.Select((id, i) => (id, i)))
+            {
+                seed.FileMutationJournals.Add(new FileMutationJournal
+                {
+                    OperationId = operationId,
+                    Action = FileAction.HardlinkCopy,
+                    State = FileMutationJournalState.Planned,
+                    ProtocolVersion = FileMutationProtocol.Current - 1,
+                    SourcePath = $"/incoming/book-{index}.m4b",
+                    DestinationPath = $"/library/book-{index}.m4b",
+                    CreatedAt = created.AddSeconds(index),
+                    UpdatedAt = created.AddSeconds(index)
+                });
+            }
+            await seed.SaveChangesAsync();
+        }
+
+        var service = new FileRegistrationRecoveryService(
+            factory,
+            Mock.Of<IFileMover>(),
+            TimeProvider.System,
+            NullLogger<FileRegistrationRecoveryService>.Instance);
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ReconcileAsync());
+
+        // The count first, so an operator knows the size of the job before reading identifiers.
+        Assert.Contains("3 file-mutation journal(s)", thrown.Message, StringComparison.Ordinal);
+        foreach (var operationId in operationIds)
+        {
+            Assert.Contains(operationId.ToString(), thrown.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/tests/Features/Infrastructure/Persistence/FileRegistrationRecoveryProtocolTests.cs
+++ b/tests/Features/Infrastructure/Persistence/FileRegistrationRecoveryProtocolTests.cs
@@ -73,4 +73,64 @@ public sealed class FileRegistrationRecoveryProtocolTests : BaseTests
             Assert.Contains(operationId.ToString(), thrown.Message, StringComparison.OrdinalIgnoreCase);
         }
     }
+
+    // The listing is capped so the message stays readable, which puts the count an operator
+    // acts on into a branch of its own. An off-by-one there either hides a journal from the
+    // listing without admitting it, or claims a remainder that does not exist.
+    [Fact]
+    public async Task ReconcileAsync_MoreLegacyJournalsThanTheCap_ListsTenAndCountsTheRest()
+    {
+        Init();
+        var factory = _provider.GetRequiredService<
+            IDbContextFactory<ListenArrDbContext>>();
+
+        var operationIds = await SeedLegacyJournalsAsync(factory, count: 13);
+
+        var service = new FileRegistrationRecoveryService(
+            factory,
+            Mock.Of<IFileMover>(),
+            TimeProvider.System,
+            NullLogger<FileRegistrationRecoveryService>.Instance);
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.ReconcileAsync());
+
+        Assert.Contains("13 file-mutation journal(s)", thrown.Message, StringComparison.Ordinal);
+        Assert.Contains("and 3 more", thrown.Message, StringComparison.Ordinal);
+
+        // Ordered by CreatedAt, so the ten named are the ten oldest and the naming is stable
+        // across restarts. An operator who repairs those ten meets the next three, rather than
+        // a fresh arbitrary ten.
+        var listed = operationIds
+            .Select(operationId => thrown.Message.Contains(
+                operationId.ToString(),
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        Assert.Equal(Enumerable.Repeat(true, 10).Concat(Enumerable.Repeat(false, 3)), listed);
+    }
+
+    private static async Task<IReadOnlyList<Guid>> SeedLegacyJournalsAsync(
+        IDbContextFactory<ListenArrDbContext> factory,
+        int count)
+    {
+        var operationIds = Enumerable.Range(0, count).Select(_ => Guid.NewGuid()).ToList();
+        await using var seed = await factory.CreateDbContextAsync();
+        var created = DateTime.UtcNow.AddMinutes(-30);
+        foreach (var (operationId, index) in operationIds.Select((id, i) => (id, i)))
+        {
+            seed.FileMutationJournals.Add(new FileMutationJournal
+            {
+                OperationId = operationId,
+                Action = FileAction.HardlinkCopy,
+                State = FileMutationJournalState.Planned,
+                ProtocolVersion = FileMutationProtocol.Current - 1,
+                SourcePath = $"/incoming/book-{index}.m4b",
+                DestinationPath = $"/library/book-{index}.m4b",
+                CreatedAt = created.AddSeconds(index),
+                UpdatedAt = created.AddSeconds(index)
+            });
+        }
+        await seed.SaveChangesAsync();
+        return operationIds;
+    }
 }


### PR DESCRIPTION
## Summary

When a legacy file-mutation journal blocks startup reconciliation, the exception names only the first of them. The query that produced it collects every affected journal and the update marks every one, so an operator learns about one, resolves it, restarts, and meets the next.

This reports the count and the identifiers instead. Full write-up in #865.

## Changes

### Fixed
- `EnsureCurrentRecoveryProtocolAsync` names how many journals are affected and lists their operation ids and states, capped at ten with a remainder count, and folds the stored `Error` reason into the message.

## What this deliberately does not do

It does not add a repair mechanism and it does not change the refusal.

Declining to resume a mutation that cannot be safely resumed is correct and is clearly deliberate. What is missing is a route out of that state, and what "resolved" should mean for an interrupted mutation is a design decision rather than something to infer from the outside. The issue lays out both that and the separate question of whether a handful of rows should disable filesystem operations application-wide.

This is worth having on its own because the exception message is the entire brief an operator gets. `git grep FileMutationJournal` across `listenarr.api` returns nothing, so there is no endpoint, no controller and no DTO for these rows. Nothing else tells anyone what is wrong or how much of it there is.

## Testing

`FileRegistrationRecoveryProtocolTests` seeds three journals on the previous protocol version, runs `ReconcileAsync`, and asserts the thrown message carries the count and every operation id.

Verified as a real guard: with the original single-journal message restored the test fails on the missing substring, and passes with the change.

Full suite: 3,030 passed, 0 failed, 125 skipped, against a 3,029 baseline on `03958c15`.

## Note

I have not reproduced the originating condition end to end. Creating it needs a mutation genuinely in flight across a version boundary. What is verified from source is the query, the mark, the throw, and that nothing ever clears `NeedsAttention` for these rows. The runtime evidence in the issue is a reporter's rather than mine, and the issue says so.
