### PR TITLE
fix(download-clients): one circuit breaker per client, not one for all of them

### DIFF
--- a/listenarr.infrastructure/DependencyInjection/DownloadClients/DownloadClientRegistrationExtensions.cs
+++ b/listenarr.infrastructure/DependencyInjection/DownloadClients/DownloadClientRegistrationExtensions.cs
@@ -24,21 +24,24 @@ internal static class DownloadClientRegistrationExtensions
 {
     public static IServiceCollection AddDownloadClientHttpClients(this IServiceCollection services)
     {
+        // The retry policy is stateless, so one instance shared by every client is correct and is
+        // how Polly is meant to be used. A circuit breaker is not: its open/closed state and its
+        // failure count live inside the policy instance. Sharing one gives all these clients a
+        // single global breaker rather than one each, so a run of failures against any one of them
+        // stops polling for all of them. Each client gets its own.
         var retryPolicy = HttpPolicyExtensions.HandleTransientHttpError()
             .WaitAndRetryAsync(3, attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)));
-        var circuitBreakerPolicy = HttpPolicyExtensions.HandleTransientHttpError()
-            .CircuitBreakerAsync(3, TimeSpan.FromSeconds(30));
 
         services.AddHttpClient("DownloadClient")
             .ConfigureHttpClient(client => client.Timeout = TimeSpan.FromSeconds(30))
             .ConfigurePrimaryHttpMessageHandler(CreateHandler)
             .AddPolicyHandler(retryPolicy)
-            .AddPolicyHandler(circuitBreakerPolicy);
+            .AddPolicyHandler(CreateCircuitBreakerPolicy());
 
-        AddAdapterClient(services, DownloadClientTypes.Qbittorrent, useCookies: true, retryPolicy, circuitBreakerPolicy);
-        AddAdapterClient(services, DownloadClientTypes.Transmission, useCookies: false, retryPolicy, circuitBreakerPolicy);
-        AddAdapterClient(services, DownloadClientTypes.Sabnzbd, useCookies: false, retryPolicy, circuitBreakerPolicy);
-        AddAdapterClient(services, DownloadClientTypes.Nzbget, useCookies: false, retryPolicy, circuitBreakerPolicy);
+        AddAdapterClient(services, DownloadClientTypes.Qbittorrent, useCookies: true, retryPolicy);
+        AddAdapterClient(services, DownloadClientTypes.Transmission, useCookies: false, retryPolicy);
+        AddAdapterClient(services, DownloadClientTypes.Sabnzbd, useCookies: false, retryPolicy);
+        AddAdapterClient(services, DownloadClientTypes.Nzbget, useCookies: false, retryPolicy);
         return services;
     }
 
@@ -264,18 +267,23 @@ internal static class DownloadClientRegistrationExtensions
         return services;
     }
 
+    // A new breaker per call. Returning a fresh instance is the whole point: one shared instance
+    // would put every download client behind a single circuit.
+    internal static IAsyncPolicy<HttpResponseMessage> CreateCircuitBreakerPolicy() =>
+        HttpPolicyExtensions.HandleTransientHttpError()
+            .CircuitBreakerAsync(3, TimeSpan.FromSeconds(30));
+
     private static void AddAdapterClient(
         IServiceCollection services,
         string name,
         bool useCookies,
-        IAsyncPolicy<HttpResponseMessage> retryPolicy,
-        IAsyncPolicy<HttpResponseMessage> circuitBreakerPolicy)
+        IAsyncPolicy<HttpResponseMessage> retryPolicy)
     {
         services.AddHttpClient(name)
             .ConfigureHttpClient(client => client.Timeout = TimeSpan.FromSeconds(30))
             .ConfigurePrimaryHttpMessageHandler(() => CreateHandler(useCookies))
             .SetHandlerLifetime(TimeSpan.FromMinutes(5))
-            .AddPolicyHandler(circuitBreakerPolicy)
+            .AddPolicyHandler(CreateCircuitBreakerPolicy())
             .AddPolicyHandler(retryPolicy);
     }
 

--- a/tests/Features/Infrastructure/DownloadClients/Common/DownloadClientCircuitBreakerIsolationTests.cs
+++ b/tests/Features/Infrastructure/DownloadClients/Common/DownloadClientCircuitBreakerIsolationTests.cs
@@ -1,0 +1,61 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Net;
+using Listenarr.Infrastructure.DependencyInjection.DownloadClients;
+using Listenarr.Tests.Common;
+using Polly.CircuitBreaker;
+
+namespace Listenarr.Tests.Features.Infrastructure.DownloadClients.Common;
+
+[Trait("Name", "DownloadClientCircuitBreakerIsolationTests")]
+[Trait("Category", "Infrastructure")]
+public sealed class DownloadClientCircuitBreakerIsolationTests : BaseTests
+{
+    // A Polly circuit breaker is stateful: its open/closed state and failure count live in the
+    // policy instance. One instance shared across the download clients is one global breaker, so a
+    // run of failures against qBittorrent stops Transmission, SABnzbd and NZBGet too.
+    //
+    // This drives the policies directly rather than through HttpClient. Going through the named
+    // clients would also pass through the retry policy, whose backoff is 2, 4 and 8 seconds, so
+    // opening a breaker that way costs about 45 seconds. The property that matters is whether two
+    // clients share breaker state, and that is observable here in milliseconds.
+    [Fact]
+    public async Task CircuitBreakerPolicies_DoNotShareStateBetweenClients()
+    {
+        var first = DownloadClientRegistrationExtensions.CreateCircuitBreakerPolicy();
+        var second = DownloadClientRegistrationExtensions.CreateCircuitBreakerPolicy();
+
+        Assert.NotSame(first, second);
+
+        // Three consecutive transient failures is the configured threshold.
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            await first.ExecuteAsync(() =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)));
+        }
+
+        await Assert.ThrowsAnyAsync<BrokenCircuitException>(() =>
+            first.ExecuteAsync(() =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK))));
+
+        // The second client is untouched by the first client's failures.
+        var stillWorking = await second.ExecuteAsync(() =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+        Assert.Equal(HttpStatusCode.OK, stillWorking.StatusCode);
+    }
+}

--- a/tests/Features/Infrastructure/DownloadClients/Common/DownloadClientCircuitBreakerIsolationTests.cs
+++ b/tests/Features/Infrastructure/DownloadClients/Common/DownloadClientCircuitBreakerIsolationTests.cs
@@ -34,6 +34,13 @@ public sealed class DownloadClientCircuitBreakerIsolationTests : BaseTests
     // clients would also pass through the retry policy, whose backoff is 2, 4 and 8 seconds, so
     // opening a breaker that way costs about 45 seconds. The property that matters is whether two
     // clients share breaker state, and that is observable here in milliseconds.
+    //
+    // What this covers is the factory contract, that each call yields an independent breaker. It
+    // does not cover the registration wiring, that AddDownloadClientHttpClients calls the factory
+    // once per named client rather than hoisting one instance into a local and reusing it. Reading
+    // that back would mean reflecting into the private policy field of Polly's
+    // PolicyHttpMessageHandler, a Microsoft package detail that would break the suite on a package
+    // bump for a reason unrelated to Listenarr, so the wiring is covered by review instead.
     [Fact]
     public async Task CircuitBreakerPolicies_DoNotShareStateBetweenClients()
     {


### PR DESCRIPTION
## Summary

`AddDownloadClientHttpClients` built one circuit breaker and passed the same instance to five `HttpClient` registrations. Polly's circuit breaker is stateful, so that is one global breaker rather than one per client, and three transient failures against any single download client open the circuit for all of them.

Full write-up in #867.

## Changes

### Fixed
- Each download-client `HttpClient` builds its own circuit breaker through a `CreateCircuitBreakerPolicy()` factory, rather than sharing one instance.

### Deliberately unchanged
- The retry policy is still a single shared instance. `WaitAndRetryAsync` is stateless, so sharing it is correct and is how Polly is intended to be used. Splitting it too would suggest the sharing itself was the mistake rather than the sharing of state. There is a comment at the registration saying which of the two is stateful, so the difference does not read as an oversight later.
- The thresholds are untouched. Three failures and a thirty second break may or may not be right, but that is tuning and it is separable from whether the clients share a breaker.

## Why it outlasts its trigger

Polly's simple breaker returns straight to Open when one half-open trial fails, rather than requiring another run of three. With the breaker shared, that trial can be consumed by whichever client polls next, so a client that is still intermittently failing keeps re-tripping it and the others never get a successful trial through. A brief blip on one client becomes an open-ended outage for all of them.

## Testing

`DownloadClientCircuitBreakerIsolationTests` asserts the factory returns distinct instances, opens the first with three transient failures, confirms it then refuses calls, and confirms the second still executes.

It drives the policies directly rather than through `HttpClient` on purpose. Going through the named clients also passes through the retry policy, whose backoff is 2, 4 and 8 seconds, so opening a breaker that way costs about 45 seconds to observe a property that is visible in milliseconds otherwise.

Verified as a real guard: with the factory changed to return one cached instance, which is the original defect, the test fails on `Assert.NotSame`.

Full suite: 3,030 passed, 0 failed, 125 skipped, against a 3,029 baseline on `03958c15`.

## Note

Not a regression from recent work. `git diff` on this file between `f27c7989` and current canary shows no changes.

I have not reproduced the outage. What I verified is the registration, that one object reference reaches all five `AddPolicyHandler` calls, and Polly's documented behaviour for a stateful policy. The runtime evidence in the issue is a reporter's rather than mine, and the issue says so.
