### PR TITLE
fix(manual-import): match the rename naming table on casing and missing tokens

### DIFF
--- a/listenarr.api/Features/Downloads/ManualImportPathPlanner.cs
+++ b/listenarr.api/Features/Downloads/ManualImportPathPlanner.cs
@@ -258,7 +258,10 @@ public sealed class ManualImportPathPlanner
         bool isMultiFile,
         out int? stableSuffixNumber)
     {
-        var variables = new Dictionary<string, object>();
+        // Ordinal-ignore-case to match RenameService.BuildNamingVariables. The token regex in
+        // FileNamingService is already case-insensitive, so a case-sensitive dictionary here means
+        // a pattern written {series} resolves under rename and misses under manual import.
+        var variables = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
         var author = audiobook.Authors?.FirstOrDefault();
         if (!string.IsNullOrWhiteSpace(author)) variables["Author"] = author;
@@ -286,6 +289,12 @@ public sealed class ManualImportPathPlanner
         variables["Title"] = !string.IsNullOrWhiteSpace(titleFull) ? titleFull : "Unknown Title";
 
         if (!string.IsNullOrWhiteSpace(audiobook.Series)) variables["Series"] = audiobook.Series;
+        // SeriesNumber and Quality were absent from this table entirely while both are present
+        // in the rename and library-add tables, so a pattern using either rendered under those
+        // and silently lost the segment here. Inserted on the same terms as their neighbours:
+        // present when known, absent when not, so the missing-variable cleanup still applies.
+        if (!string.IsNullOrWhiteSpace(audiobook.SeriesNumber)) variables["SeriesNumber"] = audiobook.SeriesNumber;
+        if (!string.IsNullOrWhiteSpace(audiobook.Quality)) variables["Quality"] = audiobook.Quality;
         if (!string.IsNullOrWhiteSpace(audiobook.PublishYear)) variables["Year"] = audiobook.PublishYear;
 
         var effectiveDiskNumber = item.DiskNumberHint

--- a/listenarr.api/Features/Downloads/ManualImportPathPlanner.cs
+++ b/listenarr.api/Features/Downloads/ManualImportPathPlanner.cs
@@ -289,10 +289,12 @@ public sealed class ManualImportPathPlanner
         variables["Title"] = !string.IsNullOrWhiteSpace(titleFull) ? titleFull : "Unknown Title";
 
         if (!string.IsNullOrWhiteSpace(audiobook.Series)) variables["Series"] = audiobook.Series;
-        // SeriesNumber and Quality were absent from this table entirely while both are present
-        // in the rename and library-add tables, so a pattern using either rendered under those
-        // and silently lost the segment here. Inserted on the same terms as their neighbours:
-        // present when known, absent when not, so the missing-variable cleanup still applies.
+        // SeriesNumber and Quality were absent from this table entirely. Rename has both with
+        // real values; library-add has SeriesNumber and carries Quality as a hard-wired empty
+        // string, so it is present in name only there. Either way a pattern using them rendered
+        // under rename and silently lost the segment here. Inserted on the same terms as their
+        // neighbours: present when known, absent when not, so the missing-variable cleanup
+        // still applies.
         if (!string.IsNullOrWhiteSpace(audiobook.SeriesNumber)) variables["SeriesNumber"] = audiobook.SeriesNumber;
         if (!string.IsNullOrWhiteSpace(audiobook.Quality)) variables["Quality"] = audiobook.Quality;
         if (!string.IsNullOrWhiteSpace(audiobook.PublishYear)) variables["Year"] = audiobook.PublishYear;

--- a/tests/Features/Api/Features/Downloads/ManualImportNamingVariableParityTests.cs
+++ b/tests/Features/Api/Features/Downloads/ManualImportNamingVariableParityTests.cs
@@ -1,0 +1,112 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Api.Dtos.ManualImport;
+using Listenarr.Tests.Builders;
+using Listenarr.Tests.Common;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Listenarr.Tests.Features.Api.Features.Downloads;
+
+[Trait("Name", "ManualImportNamingVariableParityTests")]
+[Trait("Category", "Unit")]
+public sealed class ManualImportNamingVariableParityTests : BaseTests
+{
+    private static ManualImportPathPlanner CreatePlanner() =>
+        new(new FileNamingService(
+            Mock.Of<IConfigurationService>(),
+            NullLogger<FileNamingService>.Instance));
+
+    private static Audiobook CreateSeriesBook() => new()
+    {
+        Title = "The Wonderful Wizard of Oz",
+        Authors = ["L. Frank Baum"],
+        Series = "Oz",
+        SeriesNumber = "1",
+        Asin = "B007BR5KZA"
+    };
+
+    private static async Task<string> PlanAsync(
+        Audiobook audiobook,
+        string folderPattern,
+        string filePattern)
+    {
+        var settings = new ApplicationSettingsBuilder()
+            .WithOutputPath("/library")
+            .Build();
+        settings.FolderNamingPattern = folderPattern;
+        settings.FileNamingPattern = filePattern;
+
+        var item = new ManualImportItemDto
+        {
+            FullPath = "/incoming/book.m4b",
+            MatchedAudiobookId = 1
+        };
+
+        var plan = await CreatePlanner().GeneratePathAsync(
+            audiobook,
+            audiobook.CreateBasicAudioMetadata(),
+            item,
+            "/library",
+            [new RootFolder { Id = 1, Name = "Library", Path = "/library" }],
+            settings,
+            new FileSystemPathSemantics(
+                FileSystemPathSyntax.Unix,
+                FileSystemCaseSensitivity.Sensitive));
+        return plan.DestinationPath;
+    }
+
+    // RenameService.BuildNamingVariables keys its dictionary with StringComparer.OrdinalIgnoreCase
+    // and the token regex in FileNamingService is case-insensitive, so a pattern written in any
+    // case resolves under rename. A case-sensitive dictionary here made manual import the one path
+    // where {series} and {ASIN} silently produced nothing.
+    [Theory]
+    [InlineData("{Author}/{Series}", "{Title}")]
+    [InlineData("{author}/{series}", "{title}")]
+    [InlineData("{AUTHOR}/{SERIES}", "{TITLE}")]
+    public async Task GeneratePathAsync_TokenCasing_DoesNotChangeTheResult(
+        string folderPattern,
+        string filePattern)
+    {
+        var destination = await PlanAsync(CreateSeriesBook(), folderPattern, filePattern);
+
+        Assert.Contains("L. Frank Baum", destination, StringComparison.Ordinal);
+        Assert.Contains("Oz", destination, StringComparison.Ordinal);
+    }
+
+    // SeriesNumber and Quality were absent from this table entirely while being present in the
+    // rename and library-add tables, so a pattern using either rendered one way through rename and
+    // lost the segment through manual import.
+    [Fact]
+    public async Task GeneratePathAsync_SeriesNumberToken_IsRendered()
+    {
+        var destination = await PlanAsync(
+            CreateSeriesBook(),
+            "{Author}/{Series}/{SeriesNumber}",
+            "{Title}");
+
+        Assert.Contains("1", destination, StringComparison.Ordinal);
+        Assert.DoesNotContain("SeriesNumber", destination, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // Deliberately not asserted here: whether an absent key should instead be inserted empty.
+    // A missing variable yields a sentinel that FileNamingService then cleans up, stripping
+    // brackets and adjacent separators, which an empty string does not get. So inserting empties
+    // would turn "{Series} - {Title}" into " - Title" where today it renders "Title". That
+    // divergence from RenameService is real but the behaviour here looks like the better one, so
+    // it is described in the issue rather than changed.
+}

--- a/tests/Features/Api/Features/Downloads/ManualImportNamingVariableParityTests.cs
+++ b/tests/Features/Api/Features/Downloads/ManualImportNamingVariableParityTests.cs
@@ -35,10 +35,41 @@ public sealed class ManualImportNamingVariableParityTests : BaseTests
     {
         Title = "The Wonderful Wizard of Oz",
         Authors = ["L. Frank Baum"],
-        Series = "Oz",
+        // The series name must not be a substring of the title. It was "Oz", and an assertion
+        // that the destination contains "Oz" then passed whenever the title rendered, whatever
+        // the series token did. SeriesFixture_CannotPassOnTheTitleAlone guards the property.
+        Series = "Land of Oz",
         SeriesNumber = "1",
+        Quality = "M4B 128kbps",
         Asin = "B007BR5KZA"
     };
+
+    // Split the destination into path components so an assertion names a whole segment. Asserting
+    // a substring of the whole path passes for the wrong reason as soon as some other segment
+    // happens to contain the text: a bare "1" matches a root folder id, a disk number or a
+    // sequence suffix.
+    private static string[] Segments(string destination) =>
+        destination.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, '/', '\\'],
+            StringSplitOptions.RemoveEmptyEntries);
+
+    [Fact]
+    public void SeriesFixture_CannotPassOnTheTitleAlone()
+    {
+        var book = CreateSeriesBook();
+
+        Assert.NotNull(book.Series);
+        Assert.NotNull(book.Title);
+        Assert.NotNull(book.SeriesNumber);
+        Assert.NotNull(book.Quality);
+
+        // Every token asserted below has to be absent from the other fields, or its assertion
+        // proves nothing about the token it names.
+        Assert.DoesNotContain(book.Series, book.Title, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(book.SeriesNumber, book.Title, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(book.Quality, book.Title, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(book.Series, book.Authors[0], StringComparison.OrdinalIgnoreCase);
+    }
 
     private static async Task<string> PlanAsync(
         Audiobook audiobook,
@@ -83,9 +114,12 @@ public sealed class ManualImportNamingVariableParityTests : BaseTests
         string filePattern)
     {
         var destination = await PlanAsync(CreateSeriesBook(), folderPattern, filePattern);
+        var segments = Segments(destination);
 
-        Assert.Contains("L. Frank Baum", destination, StringComparison.Ordinal);
-        Assert.Contains("Oz", destination, StringComparison.Ordinal);
+        // Whole path components, not substrings: with a case-sensitive dictionary the lookup
+        // misses, the sentinel cleanup strips the segment, and the segment is simply gone.
+        Assert.Contains("L. Frank Baum", segments);
+        Assert.Contains("Land of Oz", segments);
     }
 
     // SeriesNumber and Quality were absent from this table entirely while being present in the
@@ -99,8 +133,46 @@ public sealed class ManualImportNamingVariableParityTests : BaseTests
             "{Author}/{Series}/{SeriesNumber}",
             "{Title}");
 
-        Assert.Contains("1", destination, StringComparison.Ordinal);
+        var segments = Segments(destination);
+
+        // Its own path component. "1" as a substring of the whole path would also match a root
+        // folder id or a disk number, so the assertion would survive the key being dropped.
+        Assert.Contains("1", segments);
         Assert.DoesNotContain("SeriesNumber", destination, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // Quality is the other key this PR adds, and it was asserted nowhere: the summary claimed two
+    // tokens and the tests covered one.
+    [Fact]
+    public async Task GeneratePathAsync_QualityToken_IsRendered()
+    {
+        var destination = await PlanAsync(
+            CreateSeriesBook(),
+            "{Author}/{Series}/{Quality}",
+            "{Title}");
+
+        var segments = Segments(destination);
+
+        Assert.Contains("M4B 128kbps", segments);
+        Assert.DoesNotContain("Quality", destination, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // Both added keys resolve through a lowercase pattern too, which is the intersection of the
+    // two defects this PR fixes: a key that is present but unreachable is no better than an
+    // absent one.
+    [Fact]
+    public async Task GeneratePathAsync_AddedTokens_ResolveInAnyCase()
+    {
+        var destination = await PlanAsync(
+            CreateSeriesBook(),
+            "{author}/{seriesnumber}/{quality}",
+            "{title}");
+
+        var segments = Segments(destination);
+
+        Assert.Contains("L. Frank Baum", segments);
+        Assert.Contains("1", segments);
+        Assert.Contains("M4B 128kbps", segments);
     }
 
     // Deliberately not asserted here: whether an absent key should instead be inserted empty.


### PR DESCRIPTION
## Summary

`ManualImportPathPlanner.BuildNamingVariables` is a third hand-rolled copy of the naming-variable table that `RenameService` and `FileNamingService` also implement, and it sets twelve keys where rename sets fourteen. Two tokens are missing and the dictionary is case-sensitive, so patterns that resolve under rename silently lose a segment under manual import.

Fixes #816, which reported the `{SeriesNumber}` half.

## Changes

### Fixed
- `SeriesNumber` and `Quality` are added to the table. Both are present in `RenameService.Helpers.cs` and `FileNamingService.Helpers.cs` and were absent here.
- The dictionary is keyed with `StringComparer.OrdinalIgnoreCase`, matching `RenameService.Helpers.cs:193`. The token regex at `FileNamingService.cs:206` already carries `RegexOptions.IgnoreCase`, so a pattern written `{series}` matched the regex, missed the lookup, and took the missing-variable path. That made the divergence general rather than limited to two tokens: any token in any casing other than this table's exact spelling was dropped on import and kept on rename.

Both new keys are inserted on the same terms as their neighbours, present when known and absent when not, so the existing missing-variable cleanup still applies to them.

## What this does not change, having tried it

The third divergence is that this table inserts keys only when non-empty while `RenameService` always inserts them. I changed that too, wrote a test for it, and the test passed with the change reverted, which is why it is not in this PR.

Inserting empties is worse. An absent key yields the empty sentinel and `FileNamingService.cs:257-267` strips brackets around it and separators beside it, so `{Series} - {Title}` renders `Title` for a book with no series. An empty string gets none of that and renders ` - Title`. #816 already describes that cleanup as the right behaviour, so manual import has the better of the two and rename is arguably the one out of step.

What it does cost is a warning per affected file: `FileNamingService.cs:252` logs at warning level for the ordinary case of a book with no series. That is noise rather than a wrong path, so it is described in the issue rather than changed here.

## Testing

`ManualImportNamingVariableParityTests` asserts that three casings of the same pattern produce the same destination, and that a `{SeriesNumber}` folder pattern renders the number rather than dropping the segment.

Verified as real guards: restoring the bare dictionary fails two of the three casing cases, and removing the two keys fails the `{SeriesNumber}` case.

Full suite: 3,033 passed, 0 failed, 125 skipped, against a 3,029 baseline on `03958c15`.

## Note

The wider change is to stop having three copies of this table. That crosses an assembly boundary, since `ManualImportPathPlanner` is in `listenarr.api` and `RenameService` in `listenarr.application`, and it is a bigger decision than this. This makes the outlier agree with its neighbours on the two points where the disagreement loses data.
