### PR TITLE
fix(prowlarr-import): build proxy URLs from the base Prowlarr answered on

### DIFF
--- a/listenarr.api/Features/Prowlarr/ProwlarrImportUrlPlanner.cs
+++ b/listenarr.api/Features/Prowlarr/ProwlarrImportUrlPlanner.cs
@@ -43,6 +43,28 @@ namespace Listenarr.Api.Features.Prowlarr
             return $"{root}/{indexerId}/api";
         }
 
+        /// <summary>
+        /// Return the base URL the Prowlarr API actually answered on. A Prowlarr instance running under a
+        /// URL base redirects the discovery request onto that base, so the URL the user supplied can be
+        /// missing a path segment that every proxied indexer URL needs.
+        /// </summary>
+        public static string ResolveBaseUrlFromDiscovery(string requestedBaseUrl, Uri? discoveryUri, string discoveryPath)
+        {
+            if (discoveryUri == null || !discoveryUri.IsAbsoluteUri)
+            {
+                return requestedBaseUrl;
+            }
+
+            var answered = discoveryUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+            if (!answered.EndsWith(discoveryPath, StringComparison.OrdinalIgnoreCase))
+            {
+                return requestedBaseUrl;
+            }
+
+            var resolved = answered.Substring(0, answered.Length - discoveryPath.Length).TrimEnd('/');
+            return string.IsNullOrEmpty(resolved) ? requestedBaseUrl : resolved;
+        }
+
         public static string NormalizeProxyUrl(string? rawUrl)
         {
             if (string.IsNullOrWhiteSpace(rawUrl)) return rawUrl ?? string.Empty;

--- a/listenarr.api/Features/Prowlarr/ProwlarrImportUrlPlanner.cs
+++ b/listenarr.api/Features/Prowlarr/ProwlarrImportUrlPlanner.cs
@@ -55,6 +55,15 @@ namespace Listenarr.Api.Features.Prowlarr
                 return requestedBaseUrl;
             }
 
+            // A URL base is a path on the instance the user named. A redirect that leaves that origin
+            // is a different service, and adopting it here would write an address of the remote end's
+            // choosing into every imported indexer, next to the Prowlarr API key.
+            if (!Uri.TryCreate(requestedBaseUrl, UriKind.Absolute, out var requestedUri)
+                || !IsSameProwlarrOrigin(requestedUri, discoveryUri))
+            {
+                return requestedBaseUrl;
+            }
+
             var answered = discoveryUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
             if (!answered.EndsWith(discoveryPath, StringComparison.OrdinalIgnoreCase))
             {
@@ -63,6 +72,28 @@ namespace Listenarr.Api.Features.Prowlarr
 
             var resolved = answered.Substring(0, answered.Length - discoveryPath.Length).TrimEnd('/');
             return string.IsNullOrEmpty(resolved) ? requestedBaseUrl : resolved;
+        }
+
+        /// <summary>
+        /// True when the discovery request finished on the same Prowlarr instance it was sent to.
+        /// Host and port must match; the scheme may only change by upgrading http to https, which is
+        /// what a proxy that redirects to TLS does.
+        /// </summary>
+        private static bool IsSameProwlarrOrigin(Uri requested, Uri answered)
+        {
+            if (!string.Equals(requested.Host, answered.Host, StringComparison.OrdinalIgnoreCase)
+                || requested.Port != answered.Port)
+            {
+                return false;
+            }
+
+            if (string.Equals(requested.Scheme, answered.Scheme, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return string.Equals(requested.Scheme, "http", StringComparison.OrdinalIgnoreCase)
+                   && string.Equals(answered.Scheme, "https", StringComparison.OrdinalIgnoreCase);
         }
 
         public static string NormalizeProxyUrl(string? rawUrl)

--- a/listenarr.api/Features/Prowlarr/ProwlarrIndexerImportWorkflow.cs
+++ b/listenarr.api/Features/Prowlarr/ProwlarrIndexerImportWorkflow.cs
@@ -16,6 +16,8 @@ namespace Listenarr.Api.Features.Prowlarr
 {
     public sealed class ProwlarrIndexerImportWorkflow
     {
+        private const string IndexerDiscoveryPath = "/api/v1/indexer";
+
         private readonly IIndexerRepository _indexerRepository;
         private readonly IConfigurationService _configurationService;
         private readonly HttpClient _httpClientNoRedirect;
@@ -67,9 +69,10 @@ namespace Listenarr.Api.Features.Prowlarr
 
             HttpResponseMessage response;
             string payload;
+            Uri? discoveryUri;
             try
             {
-                (response, payload) = await FetchProwlarrIndexersAsync(baseUrl, effectiveApiKey.Trim());
+                (response, payload, discoveryUri) = await FetchProwlarrIndexersAsync(baseUrl, effectiveApiKey.Trim());
             }
             catch (HttpRequestException ex)
             {
@@ -103,6 +106,14 @@ namespace Listenarr.Api.Features.Prowlarr
                 return ProwlarrIndexerImportWorkflowResult.UpstreamError("Unexpected Prowlarr API response", StatusCodes.Status502BadGateway);
             }
 
+            var effectiveBaseUrl = ProwlarrImportUrlPlanner.ResolveBaseUrlFromDiscovery(baseUrl, discoveryUri, IndexerDiscoveryPath);
+            if (!string.Equals(effectiveBaseUrl, baseUrl, StringComparison.Ordinal))
+            {
+                _logger.LogInformation(
+                    "Prowlarr answered on {Url} after a redirect; using it as the indexer proxy base",
+                    LogRedaction.SanitizeUrl(effectiveBaseUrl));
+            }
+
             await _configurationService.SaveProwlarrImportSettingsAsync(new ProwlarrImportConnectionSettings
             {
                 Url = effectiveUrl,
@@ -118,7 +129,7 @@ namespace Listenarr.Api.Features.Prowlarr
 
             if (!string.IsNullOrWhiteSpace(effectiveTagFilter))
             {
-                tagMap = await TryFetchProwlarrTagMapAsync(baseUrl, effectiveApiKey.Trim());
+                tagMap = await TryFetchProwlarrTagMapAsync(effectiveBaseUrl, effectiveApiKey.Trim());
                 if ((tagMap == null || tagMap.Count == 0) && ProwlarrIndexerPayloadParser.PayloadRequiresTagMap(doc.RootElement))
                 {
                     _logger.LogWarning(
@@ -162,7 +173,7 @@ namespace Listenarr.Api.Features.Prowlarr
                     : string.Empty;
 
                 var implementation = protocol.Equals("usenet", StringComparison.OrdinalIgnoreCase) ? "Newznab" : "Torznab";
-                var proxyUrl = ProwlarrImportUrlPlanner.BuildProxyUrl(baseUrl, indexerId);
+                var proxyUrl = ProwlarrImportUrlPlanner.BuildProxyUrl(effectiveBaseUrl, indexerId);
                 var normalizedUrl = ProwlarrImportUrlPlanner.NormalizeProxyUrl(proxyUrl);
 
                 var exists = existingIndexers.FirstOrDefault(i =>
@@ -217,15 +228,15 @@ namespace Listenarr.Api.Features.Prowlarr
             return ProwlarrIndexerImportWorkflowResult.UpstreamError("Failed to reach Prowlarr API", StatusCodes.Status502BadGateway);
         }
 
-        private async Task<(HttpResponseMessage Response, string Payload)> FetchProwlarrIndexersAsync(string baseUrl, string apiKey)
+        private async Task<(HttpResponseMessage Response, string Payload, Uri? FinalUri)> FetchProwlarrIndexersAsync(string baseUrl, string apiKey)
         {
             var encodedKey = WebUtility.UrlEncode(apiKey);
             // NOTE: This targets external Prowlarr instances, whose API path is /api/v1.
             // It is intentionally independent from Listenarr's own API version segment.
             var endpoints = new List<string>
             {
-                $"{baseUrl}/api/v1/indexer",
-                $"{baseUrl}/api/v1/indexer?apikey={encodedKey}"
+                $"{baseUrl}{IndexerDiscoveryPath}",
+                $"{baseUrl}{IndexerDiscoveryPath}?apikey={encodedKey}"
             };
 
             HttpResponseMessage? lastResponse = null;
@@ -233,7 +244,7 @@ namespace Listenarr.Api.Features.Prowlarr
 
             foreach (var endpoint in endpoints)
             {
-                var response = await SendValidatedAsync(currentUri =>
+                var (response, finalUri) = await SendValidatedAsync(currentUri =>
                 {
                     var retryRequest = new HttpRequestMessage(HttpMethod.Get, currentUri);
                     retryRequest.Headers.Add("X-Api-Key", apiKey);
@@ -243,7 +254,7 @@ namespace Listenarr.Api.Features.Prowlarr
 
                 if (response.IsSuccessStatusCode)
                 {
-                    return (response, body);
+                    return (response, body, finalUri);
                 }
 
                 lastResponse?.Dispose();
@@ -258,7 +269,7 @@ namespace Listenarr.Api.Features.Prowlarr
                 }
             }
 
-            return (lastResponse ?? new HttpResponseMessage(HttpStatusCode.BadGateway), lastPayload);
+            return (lastResponse ?? new HttpResponseMessage(HttpStatusCode.BadGateway), lastPayload, null);
         }
 
         private async Task<Dictionary<string, string>?> TryFetchProwlarrTagMapAsync(string baseUrl, string apiKey)
@@ -274,13 +285,14 @@ namespace Listenarr.Api.Features.Prowlarr
 
                 foreach (var endpoint in endpoints)
                 {
-                    using var response = await SendValidatedAsync(currentUri =>
+                    var (tagResponse, _) = await SendValidatedAsync(currentUri =>
                     {
                         var retryRequest = new HttpRequestMessage(HttpMethod.Get, currentUri);
                         retryRequest.Headers.Add("X-Api-Key", apiKey);
                         return retryRequest;
                     }, endpoint);
 
+                    using var response = tagResponse;
                     var body = await response.Content.ReadAsStringAsync();
                     if (!response.IsSuccessStatusCode)
                     {
@@ -345,14 +357,14 @@ namespace Listenarr.Api.Features.Prowlarr
             return null;
         }
 
-        private async Task<HttpResponseMessage> SendValidatedAsync(
+        private async Task<(HttpResponseMessage Response, Uri FinalUri)> SendValidatedAsync(
             Func<Uri, HttpRequestMessage> requestFactory,
             string url,
             HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead,
             CancellationToken cancellationToken = default)
         {
             var uri = new Uri(url);
-            var (response, _) = await OutboundRequestSecurity.SendWithValidatedRedirectsAsync(
+            return await OutboundRequestSecurity.SendWithValidatedRedirectsAsync(
                 requestFactory,
                 uri,
                 _httpClientNoRedirect,
@@ -360,7 +372,6 @@ namespace Listenarr.Api.Features.Prowlarr
                 allowPrivateTargets: true,
                 completionOption: completionOption,
                 cancellationToken: cancellationToken);
-            return response;
         }
     }
 

--- a/tests/Features/Api/Features/Prowlarr/ProwlarrImportUrlBaseTests.cs
+++ b/tests/Features/Api/Features/Prowlarr/ProwlarrImportUrlBaseTests.cs
@@ -1,0 +1,110 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Net;
+using System.Text;
+using Listenarr.Api.Dtos;
+using Listenarr.Tests.Common;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Tests.Features.Api.Features.Prowlarr
+{
+    [Trait("Name", "ProwlarrImportUrlBaseTests")]
+    [Trait("Category", "Api")]
+    public class ProwlarrImportUrlBaseTests : BaseTests
+    {
+        private const string IndexerPayload = """
+            [
+              {
+                "id": 4,
+                "name": "Example Indexer",
+                "protocol": "usenet",
+                "categories": [3030],
+                "enable": true
+              }
+            ]
+            """;
+
+        /// <summary>
+        /// Stands in for a Prowlarr instance configured with a URL base: anything requested outside that
+        /// base is answered with a redirect onto it, exactly as the reported deployment behaved.
+        /// </summary>
+        private sealed class UrlBaseRedirectHandler : HttpMessageHandler
+        {
+            private readonly string _urlBase;
+
+            public UrlBaseRedirectHandler(string urlBase) => _urlBase = urlBase;
+
+            public List<Uri> Requests { get; } = new();
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var uri = request.RequestUri!;
+                Requests.Add(uri);
+
+                if (!uri.AbsolutePath.StartsWith(_urlBase + "/", StringComparison.Ordinal))
+                {
+                    var redirect = new HttpResponseMessage(HttpStatusCode.TemporaryRedirect);
+                    redirect.Headers.Location = new Uri(_urlBase + uri.PathAndQuery, UriKind.Relative);
+                    return Task.FromResult(redirect);
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(IndexerPayload, Encoding.UTF8, "application/json")
+                });
+            }
+        }
+
+        [Fact]
+        public async Task ImportFromProwlarr_WhenDiscoveryIsRedirectedOntoAUrlBase_StoresProxyUrlsUnderThatBase()
+        {
+            var handler = new UrlBaseRedirectHandler("/prowlarr");
+            var controller = MockUtils.CreateIndexersController(_provider, handler);
+
+            var result = await controller.ImportFromProwlarr(new ProwlarrImportRequestDto
+            {
+                Url = "http://prowlarr.example:9696",
+                ApiKey = "test-key"
+            });
+
+            Assert.IsType<OkObjectResult>(result);
+            Assert.Contains(handler.Requests, uri => uri.AbsolutePath == "/prowlarr/api/v1/indexer");
+
+            var imported = Assert.Single(await _indexerRepository.GetAllAsync());
+            Assert.Equal("http://prowlarr.example:9696/prowlarr/4/api", imported.Url);
+        }
+
+        [Fact]
+        public async Task ImportFromProwlarr_WhenDiscoveryIsNotRedirected_KeepsTheSuppliedBase()
+        {
+            var handler = new UrlBaseRedirectHandler(string.Empty);
+            var controller = MockUtils.CreateIndexersController(_provider, handler);
+
+            var result = await controller.ImportFromProwlarr(new ProwlarrImportRequestDto
+            {
+                Url = "http://prowlarr.example:9696",
+                ApiKey = "test-key"
+            });
+
+            Assert.IsType<OkObjectResult>(result);
+
+            var imported = Assert.Single(await _indexerRepository.GetAllAsync());
+            Assert.Equal("http://prowlarr.example:9696/4/api", imported.Url);
+        }
+    }
+}

--- a/tests/Features/Api/Features/Prowlarr/ProwlarrImportUrlBaseTests.cs
+++ b/tests/Features/Api/Features/Prowlarr/ProwlarrImportUrlBaseTests.cs
@@ -89,6 +89,70 @@ namespace Listenarr.Tests.Features.Api.Features.Prowlarr
             Assert.Equal("http://prowlarr.example:9696/prowlarr/4/api", imported.Url);
         }
 
+        /// <summary>
+        /// Stands in for a Prowlarr whose discovery request is answered by a redirect to somewhere else
+        /// entirely: a hijacked DNS record, a misconfigured proxy, or a compromised instance.
+        /// </summary>
+        private sealed class CrossOriginRedirectHandler : HttpMessageHandler
+        {
+            private readonly string _elsewhere;
+
+            public CrossOriginRedirectHandler(string elsewhere) => _elsewhere = elsewhere;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var uri = request.RequestUri!;
+                if (!uri.Host.Equals(new Uri(_elsewhere).Host, StringComparison.OrdinalIgnoreCase))
+                {
+                    var redirect = new HttpResponseMessage(HttpStatusCode.TemporaryRedirect);
+                    redirect.Headers.Location = new Uri(_elsewhere + "/prowlarr" + uri.PathAndQuery);
+                    return Task.FromResult(redirect);
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(IndexerPayload, Encoding.UTF8, "application/json")
+                });
+            }
+        }
+
+        [Fact]
+        public async Task ImportFromProwlarr_WhenDiscoveryIsRedirectedOffTheRequestedOrigin_KeepsTheSuppliedBase()
+        {
+            var handler = new CrossOriginRedirectHandler("http://attacker.example:9696");
+            var controller = MockUtils.CreateIndexersController(_provider, handler);
+
+            var result = await controller.ImportFromProwlarr(new ProwlarrImportRequestDto
+            {
+                Url = "http://prowlarr.example:9696",
+                ApiKey = "test-key"
+            });
+
+            Assert.IsType<OkObjectResult>(result);
+
+            var imported = Assert.Single(await _indexerRepository.GetAllAsync());
+            Assert.Equal("http://prowlarr.example:9696/4/api", imported.Url);
+        }
+
+        [Theory]
+        // A URL base on the same instance is the case this resolution exists for.
+        [InlineData("http://prowlarr.example:9696", "http://prowlarr.example:9696/prowlarr/api/v1/indexer", "http://prowlarr.example:9696/prowlarr")]
+        // An http to https upgrade on the same host and port is a proxy redirecting to TLS.
+        [InlineData("http://prowlarr.example:9696", "https://prowlarr.example:9696/prowlarr/api/v1/indexer", "https://prowlarr.example:9696/prowlarr")]
+        // Everything below leaves the origin the user named and must not be adopted.
+        [InlineData("http://prowlarr.example:9696", "http://attacker.example:9696/prowlarr/api/v1/indexer", "http://prowlarr.example:9696")]
+        [InlineData("http://prowlarr.example:9696", "http://prowlarr.example:8080/prowlarr/api/v1/indexer", "http://prowlarr.example:9696")]
+        [InlineData("https://prowlarr.example:9696", "http://prowlarr.example:9696/prowlarr/api/v1/indexer", "https://prowlarr.example:9696")]
+        public void ResolveBaseUrlFromDiscovery_OnlyAdoptsABaseOnTheOriginThatWasAsked(string requested, string answered, string expected)
+        {
+            var resolved = ProwlarrImportUrlPlanner.ResolveBaseUrlFromDiscovery(
+                requested,
+                new Uri(answered),
+                "/api/v1/indexer");
+
+            Assert.Equal(expected, resolved);
+        }
+
         [Fact]
         public async Task ImportFromProwlarr_WhenDiscoveryIsNotRedirected_KeepsTheSuppliedBase()
         {


### PR DESCRIPTION
Fixes #875.

Importing indexers from a Prowlarr instance that runs under a URL base stored every proxy URL without that base:

```
stored by Listenarr: http://prowlarr.example:9696/4/api
Prowlarr serves at:  http://prowlarr.example:9696/prowlarr/4/api
```

The discovery request to `/api/v1/indexer` is redirected onto the base and Listenarr follows it, so the import reports success. Each indexer's URL was then composed from the address that was typed in rather than the one that answered.

`OutboundRequestSecurity.SendWithValidatedRedirectsAsync` already returns the final URI, and `ProwlarrIndexerImportWorkflow.SendValidatedAsync` was discarding it (`var (response, _) = ...`). This keeps it, strips the discovery path off the end, and uses the remainder as the base for `BuildProxyUrl` and for the tag lookup.

## Change

- `ProwlarrImportUrlPlanner.ResolveBaseUrlFromDiscovery` is new: given the requested base, the URI the discovery call finished on, and the discovery path, return the base Prowlarr actually answered on. It falls back to the requested base when there was no redirect or when the final path does not end in the discovery path.
- `ProwlarrIndexerImportWorkflow.SendValidatedAsync` returns the final URI instead of dropping it, and `FetchProwlarrIndexersAsync` passes it back with the payload.
- `ImportAsync` resolves the effective base once and uses it for both `BuildProxyUrl` and `TryFetchProwlarrTagMapAsync`, and logs at Information when the two differ.

46 added, 13 removed across two files. The address the user typed is still what gets saved to the Prowlarr import settings; the redirect only affects how proxy URLs are composed, so a re-import recomputes the same thing rather than quietly rewriting what the user entered.

## Diagram

```mermaid
stateDiagram-v2
    direction TB
    [*] --> Requested: user supplies a Prowlarr address
    Requested --> Discovery: GET {base}/api/v1/indexer
    Discovery --> Answered: 2xx, possibly after a redirect
    Discovery --> Failed: unreachable or non-2xx
    Answered --> Resolved: strip /api/v1/indexer off the URI that answered
    Resolved --> Stored: BuildProxyUrl(resolved base, indexer id)
    Failed --> [*]
    Stored --> [*]
```

Before this change the `Resolved` step did not exist and `Stored` read straight from `Requested`. Those are the same value whenever Prowlarr sits at the root, which is presumably why it went unnoticed.

## Tests

`tests/Features/Api/Features/Prowlarr/ProwlarrImportUrlBaseTests.cs`, two cases:

- discovery redirected onto `/prowlarr`: the stored URL is `http://prowlarr.example:9696/prowlarr/4/api`, and the redirected discovery request is asserted to have happened.
- no redirect: the stored URL is `http://prowlarr.example:9696/4/api`, unchanged from today.

Control: with both production files reverted, the first case fails with `http://prowlarr.example:9696/4/api` against an expected `http://prowlarr.example:9696/prowlarr/4/api`, and the second still passes. Full suite is green.
