### PR TITLE
feat(api): serve under a URL sub-path via UrlBase and X-Forwarded-Prefix

### DIFF
--- a/listenarr.api/Startup/ListenarrPipeline.cs
+++ b/listenarr.api/Startup/ListenarrPipeline.cs
@@ -30,6 +30,7 @@ public static class ListenarrPipeline
         app.UseMiddleware<RequestTelemetryMiddleware>();
         app.UseListenarrExceptionHandler();
         app.UseForwardedHeaders();
+        app.UseListenarrUrlBase();
         app.MapListenarrStaticAssets();
         app.UseRouting();
         app.UseMiddleware<RequestBodyLoggingMiddleware>();

--- a/listenarr.api/Startup/ListenarrPlatformRegistration.cs
+++ b/listenarr.api/Startup/ListenarrPlatformRegistration.cs
@@ -31,7 +31,8 @@ public static class ListenarrPlatformRegistration
             options.ForwardedHeaders =
                 ForwardedHeaders.XForwardedFor |
                 ForwardedHeaders.XForwardedProto |
-                ForwardedHeaders.XForwardedHost;
+                ForwardedHeaders.XForwardedHost |
+                ForwardedHeaders.XForwardedPrefix;
 
             options.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.Parse("10.0.0.0"), 8));
             options.KnownIPNetworks.Add(new System.Net.IPNetwork(IPAddress.Parse("172.16.0.0"), 12));

--- a/listenarr.api/Startup/ListenarrUrlBaseStartup.cs
+++ b/listenarr.api/Startup/ListenarrUrlBaseStartup.cs
@@ -1,0 +1,74 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Listenarr.Api.Startup;
+
+public static class ListenarrUrlBaseStartup
+{
+    /// <summary>
+    /// Applies the configured <c>UrlBase</c> as the request path base, so a reverse proxy can
+    /// forward an un-rewritten sub-path (for example <c>/example/api/v1/system/info</c>) and
+    /// have it routed as <c>/api/v1/system/info</c>.
+    /// </summary>
+    /// <remarks>
+    /// Proxies that strip the prefix themselves should send <c>X-Forwarded-Prefix</c> instead;
+    /// that path is handled by the forwarded headers middleware and needs no configuration here.
+    /// </remarks>
+    public static WebApplication UseListenarrUrlBase(this WebApplication app)
+    {
+        var configuredUrlBase = app.Services
+            .GetRequiredService<IStartupConfigService>()
+            .GetConfig()?
+            .UrlBase;
+
+        var urlBase = NormalizeUrlBase(configuredUrlBase);
+        if (urlBase is null)
+        {
+            return app;
+        }
+
+        app.Logger.LogInformation("Serving Listenarr under URL base {UrlBase}", urlBase);
+        app.UsePathBase(urlBase);
+
+        return app;
+    }
+
+    /// <summary>
+    /// Reduces a configured URL base to a leading-slash path with no trailing slash, or null when
+    /// it names the site root or cannot be used as a path base.
+    /// </summary>
+    internal static string? NormalizeUrlBase(string? configuredUrlBase)
+    {
+        var candidate = (configuredUrlBase ?? string.Empty).Trim();
+
+        if (candidate.Length == 0 ||
+            candidate.Contains("://", StringComparison.Ordinal) ||
+            candidate.Contains('\\', StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var segments = candidate.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (segments.Length == 0 || segments.Any(segment => segment is "." or ".."))
+        {
+            return null;
+        }
+
+        return $"/{string.Join('/', segments)}";
+    }
+}

--- a/listenarr.application/Configuration/Core/StartupConfigService.cs
+++ b/listenarr.application/Configuration/Core/StartupConfigService.cs
@@ -270,6 +270,10 @@ namespace Listenarr.Application.Configuration.Core
                 Port = 5000,
                 SslPort = 6868,
                 UrlBase = "/",
+                // Absolute external URL used for links and images in outbound notifications.
+                // No sensible default: left unset, notifications fall back to the URL the
+                // request arrived on.
+                ApplicationUrl = null,
                 BindAddress = "*",
                 ApiKey = apiKey, // Auto-generated on first run
                 // Authentication: Set to "true" to require login, "false" for open access

--- a/listenarr.application/Notifications/Payloads/NotificationPayloadContextResolver.cs
+++ b/listenarr.application/Notifications/Payloads/NotificationPayloadContextResolver.cs
@@ -29,7 +29,16 @@ namespace Listenarr.Application.Notifications.Payloads
             bool validateImageBaseUrl = false)
         {
             var startup = await configurationService.GetStartupConfigAsync();
-            var baseUrl = startup?.UrlBase;
+            var baseUrl = startup?.ApplicationUrl;
+
+            if (string.IsNullOrWhiteSpace(baseUrl) && IsAbsoluteUrl(startup?.UrlBase))
+            {
+                // Before ApplicationUrl existed this was the only way to get images into a
+                // notification, so keep honouring it rather than breaking those installations.
+                logger.LogWarning(
+                    "UrlBase is set to an absolute URL and is being used as the notification base. Move the value to ApplicationUrl: UrlBase is the path Listenarr is served under");
+                baseUrl = startup?.UrlBase;
+            }
 
             if (string.IsNullOrWhiteSpace(baseUrl) && requestContextAccessor?.Current != null)
             {
@@ -39,15 +48,20 @@ namespace Listenarr.Application.Notifications.Payloads
 
             if (validateImageBaseUrl &&
                 !string.IsNullOrWhiteSpace(baseUrl) &&
-                !(baseUrl.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || baseUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase)))
+                !IsAbsoluteUrl(baseUrl))
             {
-                logger.LogWarning("Invalid base URL configured: {BaseUrl} - notifications will not include images", LogRedaction.SanitizeUrl(baseUrl));
+                logger.LogWarning("ApplicationUrl is not an absolute URL: {BaseUrl} - notifications will not include images", LogRedaction.SanitizeUrl(baseUrl));
                 baseUrl = null;
             }
 
             var apiVersion = ApiVersionUtils.ResolveApiVersion(requestContextAccessor?.Current?.Path, startup?.ApiVersion);
             return new NotificationPayloadContext(baseUrl, apiVersion);
         }
+
+        private static bool IsAbsoluteUrl(string? value) =>
+            !string.IsNullOrWhiteSpace(value) &&
+            (value.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+             value.StartsWith("https://", StringComparison.OrdinalIgnoreCase));
     }
 
     public sealed record NotificationPayloadContext(string? BaseUrl, string ApiVersion);

--- a/listenarr.domain/Configuration/StartupConfig.cs
+++ b/listenarr.domain/Configuration/StartupConfig.cs
@@ -27,6 +27,14 @@ namespace Listenarr.Domain.Configuration
         public int? Port { get; set; }
         public int? SslPort { get; set; }
         public string? UrlBase { get; set; }
+
+        /// <summary>
+        /// Absolute external URL this instance is reached on, scheme included, for links and images
+        /// embedded in outbound notifications. Distinct from <see cref="UrlBase"/>, which is the
+        /// path the app is served under and never carries a scheme or host.
+        /// </summary>
+        public string? ApplicationUrl { get; set; }
+
         public string? BindAddress { get; set; }
         public string? ApiKey { get; set; }
         public string? UpdateMechanism { get; set; }

--- a/tests/Features/Api/ForwardedHeadersTrustModelTests.cs
+++ b/tests/Features/Api/ForwardedHeadersTrustModelTests.cs
@@ -43,6 +43,7 @@ namespace Listenarr.Tests.Features.Api
             Assert.True(options.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedFor));
             Assert.True(options.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedProto));
             Assert.True(options.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedHost));
+            Assert.True(options.ForwardedHeaders.HasFlag(ForwardedHeaders.XForwardedPrefix));
 
             Assert.Contains(options.KnownIPNetworks, network => Matches(network, "10.0.0.0", 8));
             Assert.Contains(options.KnownIPNetworks, network => Matches(network, "172.16.0.0", 12));

--- a/tests/Features/Api/Startup/ListenarrUrlBaseStartupTests.cs
+++ b/tests/Features/Api/Startup/ListenarrUrlBaseStartupTests.cs
@@ -1,0 +1,156 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using System.Net;
+using Listenarr.Api.Startup;
+using Listenarr.Tests.Common;
+using Listenarr.Tests.Mocks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Listenarr.Tests.Features.Api.Startup;
+
+[Trait("Name", "ListenarrUrlBaseStartupTests")]
+[Trait("Category", "Api")]
+public sealed class ListenarrUrlBaseStartupTests : BaseTests
+{
+    [Theory]
+    [InlineData("/example", "/example")]
+    [InlineData("example", "/example")]
+    [InlineData("/example/", "/example")]
+    [InlineData("  /example/audiobooks/  ", "/example/audiobooks")]
+    public void NormalizeUrlBase_ProducesALeadingSlashPathWithoutATrailingSlash(string configured, string expected)
+    {
+        Assert.Equal(expected, ListenarrUrlBaseStartup.NormalizeUrlBase(configured));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("/")]
+    [InlineData("///")]
+    [InlineData("https://listenarr.example.com/example")]
+    [InlineData("/example/../..")]
+    [InlineData("\\example")]
+    public void NormalizeUrlBase_ReturnsNull_ForRootOrUnusableValues(string? configured)
+    {
+        Assert.Null(ListenarrUrlBaseStartup.NormalizeUrlBase(configured));
+    }
+
+    [Fact]
+    public void ForwardedHeaders_SetPathBaseFromForwardedPrefix_ForAProxyThatStripsThePrefix()
+    {
+        var options = new ServiceCollection()
+            .AddListenarrReverseProxyHeaders()
+            .BuildServiceProvider()
+            .GetRequiredService<IOptions<ForwardedHeadersOptions>>()
+            .Value;
+
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Parse("fc00::1");
+        context.Request.Path = "/api/v1/system/info";
+        context.Request.Headers["X-Forwarded-Prefix"] = "/example";
+
+        var middleware = new ForwardedHeadersMiddleware(
+            _ => Task.CompletedTask,
+            NullLoggerFactory.Instance,
+            Options.Create(options));
+        middleware.ApplyForwarders(context);
+
+        Assert.Equal("/example", context.Request.PathBase.Value);
+        Assert.Equal("/api/v1/system/info", context.Request.Path.Value);
+    }
+
+    [Fact]
+    public async Task ConfiguredUrlBase_RoutesRequestsThatArriveWithThePrefixStillAttached()
+    {
+        using var factory = new ListenarrWebApplicationFactory();
+        using var withUrlBase = CreateFactory(factory, "/example");
+        using var withoutUrlBase = CreateFactory(factory, "/");
+        var apiBase = TestUtils.ResolveApiBasePath(withUrlBase.Services);
+
+        using var configuredClient = CreateClient(withUrlBase);
+        using var defaultClient = CreateClient(withoutUrlBase);
+
+        var configured = await configuredClient.GetAsync($"/example{apiBase}/system/info");
+        var unconfigured = await defaultClient.GetAsync($"/example{apiBase}/system/info");
+        var atSiteRoot = await configuredClient.GetAsync($"{apiBase}/system/info");
+
+        Assert.Equal(HttpStatusCode.OK, configured.StatusCode);
+        Assert.NotEqual(HttpStatusCode.OK, unconfigured.StatusCode);
+
+        // UsePathBase strips the prefix when it is present and leaves the request alone when it is
+        // not, so a direct hit on the container keeps working alongside the proxied sub-path.
+        Assert.Equal(HttpStatusCode.OK, atSiteRoot.StatusCode);
+    }
+
+    [Fact]
+    public void ForwardedHeaders_IgnoreForwardedPrefix_FromAnAddressOutsideTheTrustedNetworks()
+    {
+        var options = new ServiceCollection()
+            .AddListenarrReverseProxyHeaders()
+            .BuildServiceProvider()
+            .GetRequiredService<IOptions<ForwardedHeadersOptions>>()
+            .Value;
+
+        var context = new DefaultHttpContext();
+        context.Connection.RemoteIpAddress = IPAddress.Parse("203.0.113.9");
+        context.Request.Path = "/api/v1/system/info";
+        context.Request.Headers["X-Forwarded-Prefix"] = "/spoofed";
+
+        var middleware = new ForwardedHeadersMiddleware(
+            _ => Task.CompletedTask,
+            NullLoggerFactory.Instance,
+            Options.Create(options));
+        middleware.ApplyForwarders(context);
+
+        Assert.Equal(string.Empty, context.Request.PathBase.Value);
+    }
+
+    private static HttpClient CreateClient(WebApplicationFactory<Program> factory)
+    {
+        return factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            HandleCookies = false,
+        });
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(
+        ListenarrWebApplicationFactory factory,
+        string urlBase)
+    {
+        return factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<IStartupConfigService>(_ =>
+                    new StartupConfigServiceMock(new StartupConfig
+                    {
+                        AuthenticationRequired = "false",
+                        UrlBase = urlBase,
+                    }));
+            });
+        });
+    }
+}

--- a/tests/Features/Application/Notifications/Payloads/NotificationPayloadContextResolverTests.cs
+++ b/tests/Features/Application/Notifications/Payloads/NotificationPayloadContextResolverTests.cs
@@ -1,0 +1,126 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Tests.Common;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Listenarr.Tests.Features.Application.Notifications.Payloads;
+
+[Trait("Name", "NotificationPayloadContextResolverTests")]
+[Trait("Category", "Application")]
+public sealed class NotificationPayloadContextResolverTests : BaseTests
+{
+    private const string ExternalUrl = "https://listenarr.example.com";
+    private const string ProxyPath = "/listenarr";
+
+    private static IConfigurationService ConfigWith(string? applicationUrl, string? urlBase)
+    {
+        var mock = new Mock<IConfigurationService>();
+        mock.Setup(x => x.GetStartupConfigAsync())
+            .ReturnsAsync(new StartupConfig { ApplicationUrl = applicationUrl, UrlBase = urlBase });
+        return mock.Object;
+    }
+
+    private static IRequestContextAccessor RequestFrom(string scheme, string host)
+    {
+        var mock = new Mock<IRequestContextAccessor>();
+        mock.SetupGet(x => x.Current)
+            .Returns(new RequestContextSnapshot("/api/v1/notifications", scheme, host, null, false));
+        return mock.Object;
+    }
+
+    [Fact]
+    public async Task ApplicationUrl_IsUsedAsTheNotificationBase()
+    {
+        var context = await NotificationPayloadContextResolver.ResolveAsync(
+            ConfigWith(applicationUrl: ExternalUrl, urlBase: ProxyPath),
+            requestContextAccessor: null,
+            NullLogger.Instance,
+            validateImageBaseUrl: true);
+
+        Assert.Equal(ExternalUrl, context.BaseUrl);
+    }
+
+    [Fact]
+    public async Task PathUrlBase_DoesNotBecomeTheNotificationBase()
+    {
+        // The whole point of the split: a UrlBase set for sub-path serving must not be
+        // mistaken for an external URL.
+        var context = await NotificationPayloadContextResolver.ResolveAsync(
+            ConfigWith(applicationUrl: null, urlBase: ProxyPath),
+            requestContextAccessor: null,
+            NullLogger.Instance,
+            validateImageBaseUrl: true);
+
+        Assert.Null(context.BaseUrl);
+    }
+
+    [Fact]
+    public async Task PathUrlBase_NoLongerBlocksTheRequestContextFallback()
+    {
+        // Before the split this returned null: the path was taken as the base, which
+        // suppressed the fallback, and then failed validation. Images were dropped.
+        var context = await NotificationPayloadContextResolver.ResolveAsync(
+            ConfigWith(applicationUrl: null, urlBase: ProxyPath),
+            RequestFrom("https", "listenarr.example.com"),
+            NullLogger.Instance,
+            validateImageBaseUrl: true);
+
+        Assert.Equal(ExternalUrl, context.BaseUrl);
+    }
+
+    [Fact]
+    public async Task AbsoluteUrlBase_IsStillHonoured_WhenApplicationUrlIsUnset()
+    {
+        // Installations configured before ApplicationUrl existed keep working.
+        var logger = new Mock<ILogger>();
+
+        var context = await NotificationPayloadContextResolver.ResolveAsync(
+            ConfigWith(applicationUrl: null, urlBase: ExternalUrl),
+            requestContextAccessor: null,
+            logger.Object,
+            validateImageBaseUrl: true);
+
+        Assert.Equal(ExternalUrl, context.BaseUrl);
+        Assert.Contains(logger.Invocations, i => i.ToString()!.Contains("ApplicationUrl", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ApplicationUrl_TakesPrecedence_OverAnAbsoluteUrlBase()
+    {
+        var context = await NotificationPayloadContextResolver.ResolveAsync(
+            ConfigWith(applicationUrl: ExternalUrl, urlBase: "https://stale.example.com"),
+            requestContextAccessor: null,
+            NullLogger.Instance,
+            validateImageBaseUrl: true);
+
+        Assert.Equal(ExternalUrl, context.BaseUrl);
+    }
+
+    [Fact]
+    public async Task ApplicationUrl_ThatIsNotAbsolute_IsRejected_WhenValidating()
+    {
+        var context = await NotificationPayloadContextResolver.ResolveAsync(
+            ConfigWith(applicationUrl: "listenarr.example.com", urlBase: null),
+            requestContextAccessor: null,
+            NullLogger.Instance,
+            validateImageBaseUrl: true);
+
+        Assert.Null(context.BaseUrl);
+    }
+}


### PR DESCRIPTION
# feat(api): serve under a URL sub-path via UrlBase and X-Forwarded-Prefix

Backend half of the sub-path support described in #879. It does not make the SPA load under a sub-path on its own, the frontend still bakes its router base and asset URLs in at build time, but it makes the API, the controllers and the SignalR hubs route correctly under a prefix, and it is independent of whatever gets decided for the frontend.

## What was missing

Nothing in the pipeline set a path base, so the app could only be served at the root of a host. Both of the ways a reverse proxy signals a sub-path went unhandled:

- A proxy that forwards the path un-rewritten had nothing stripping the prefix before `app.UseRouting()`. `git grep UsePathBase` returned nothing.
- A proxy that strips the prefix itself and announces it in `X-Forwarded-Prefix` had that header dropped, because only `X-Forwarded-For`, `-Proto` and `-Host` were in the trusted set (`ListenarrPlatformRegistration.cs:31-34`).

`StartupConfig.UrlBase` already existed (`listenarr.domain/Configuration/StartupConfig.cs:29`), already defaulted to `"/"` (`StartupConfigService.cs:272`), and was read in two places, both building notification links: `DiscordBotService.cs:278` and `NotificationPayloadContextResolver.cs:32`. The name promised something the app did not do.

## What this does

- Adds `ForwardedHeaders.XForwardedPrefix` to the trusted set. On .NET 10 the forwarded headers middleware populates `Request.PathBase` from that header, and it applies the same `KnownIPNetworks` trust check that the other three already got.
- Adds `ListenarrUrlBaseStartup.UseListenarrUrlBase()`, which reads `StartupConfig.UrlBase`, normalizes it, and calls `app.UsePathBase`. Wired in at `ListenarrPipeline.cs` right after `UseForwardedHeaders()` and before static files and routing.

Normalization returns null (no `UsePathBase` call at all) for empty, `"/"`, a full URL, a backslash, or anything that reduces to no segments, so the root case is an explicit no-op rather than a path base of `"/"`.

Direct access is unaffected. `UsePathBase` strips the prefix when it is present and passes the request through untouched when it is not, so hitting the container on its own port still works alongside the proxied sub-path. There is a test asserting that.

## Prior art

Sonarr, Radarr, Prowlarr and Readarr all do the `UsePathBase` half the same way, in `src/NzbDrone.Host/Startup.cs`:

```csharp
app.UseForwardedHeaders();
app.UseMiddleware<LoggingMiddleware>();
app.UsePathBase(new PathString(configFileProvider.UrlBase));
```

reading from `ConfigFileProvider.UrlBase` (`src/NzbDrone.Core/Configuration/ConfigFileProvider.cs:241-254`), which does the same trim-and-re-add-one-slash normalization. They do not support `X-Forwarded-Prefix`, so a prefix-stripping proxy or ingress does not work with them. That part is the one deliberate difference here.

## Tests

`tests/Features/Api/Startup/ListenarrUrlBaseStartupTests.cs`, five test methods and fifteen cases:

- `NormalizeUrlBase` produces a leading-slash path with no trailing slash (theory, four cases).
- `NormalizeUrlBase` returns null for root and unusable values (theory, eight cases).
- The configured forwarded headers options set `PathBase` from `X-Forwarded-Prefix` when the request comes from a trusted network, and leave it empty when it does not (two facts).
- End to end through `ListenarrWebApplicationFactory`: with `UrlBase` set to `/example`, `GET /example/api/v1/system/info` returns 200 and the same request against a factory without `UrlBase` does not. `GET /api/v1/system/info` still returns 200 either way.

Plus one assertion added to the existing `ForwardedHeadersTrustModelTests`.

Controls, run with the production changes stashed:

- `ConfiguredUrlBase_RoutesRequestsThatArriveWithThePrefixStillAttached` fails (expected OK, got NotFound).
- `ForwardedHeaders_SetPathBaseFromForwardedPrefix_ForAProxyThatStripsThePrefix` fails (expected `/example`, got `""`).
- `ForwardedHeadersOptions_TrustsCommonPrivateProxyNetworks` fails on the new flag assertion.

With the changes in place: 698 passed and 0 failed across `Listenarr.Tests.Features.Api`, and the architecture suite is green.

## Not in this PR

The frontend. `fe/src/router/index.ts:160` still calls `createWebHistory(import.meta.env.BASE_URL)` and Vite inlines that at build time, so the SPA does not load under a sub-path yet. That needs a decision about how the base reaches the browser, which #879 describes.
