### PR TITLE
Record a failed grab in history when the download client rejects it

### DIFF
--- a/listenarr.application/Downloads/Submission/DownloadService.cs
+++ b/listenarr.application/Downloads/Submission/DownloadService.cs
@@ -342,12 +342,14 @@ namespace Listenarr.Application.Downloads.Submission
             }
             catch (OperationCanceledException)
             {
-                await RemoveProvisionalDownloadAsync(downloadId);
+                await DownloadSubmissionFailureHandler.RemoveProvisionalDownloadAsync(downloadId, downloadRepository, logger);
                 throw;
             }
             catch (Exception exception) when (exception is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
             {
-                await RemoveProvisionalDownloadAsync(downloadId);
+                await DownloadSubmissionFailureHandler.RecordRejectedSubmissionAsync(
+                    downloadId, downloadClientIdForModel, candidate.Title, exception, downloadHistoryService, logger);
+                await DownloadSubmissionFailureHandler.RemoveProvisionalDownloadAsync(downloadId, downloadRepository, logger);
 
                 if (exception is DownloadClientSubmissionException)
                 {
@@ -412,19 +414,6 @@ namespace Listenarr.Application.Downloads.Submission
             }
 
             return downloadId;
-        }
-
-        private async Task RemoveProvisionalDownloadAsync(string downloadId)
-        {
-            try
-            {
-                await downloadRepository.RemoveAsync(downloadId);
-                logger.LogInformation("Removed provisional download {DownloadId} after client submission failed", downloadId);
-            }
-            catch (Exception cleanupException) when (cleanupException is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
-            {
-                logger.LogError(cleanupException, "Failed to remove provisional download {DownloadId} after client submission failure", downloadId);
-            }
         }
 
         public async Task<bool> RemoveFromQueueAsync(string downloadId, string? downloadClientId = null, bool force = false)

--- a/listenarr.application/Downloads/Submission/DownloadSubmissionFailureHandler.cs
+++ b/listenarr.application/Downloads/Submission/DownloadSubmissionFailureHandler.cs
@@ -1,0 +1,77 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Application.Downloads.Submission
+{
+    /// <summary>
+    /// Cleans up after a download the client never accepted. The provisional Download row is
+    /// removed because no client item backs it, so a history event is the only place the
+    /// attempt can be recorded. Without one, a rejected grab leaves no trace at all and the
+    /// next automatic search repeats it with nothing to show the user why.
+    /// </summary>
+    internal static class DownloadSubmissionFailureHandler
+    {
+        public static async Task RecordRejectedSubmissionAsync(
+            string downloadId,
+            string downloadClientId,
+            string title,
+            Exception failure,
+            IDownloadHistoryService downloadHistoryService,
+            ILogger logger)
+        {
+            if (string.IsNullOrEmpty(downloadClientId))
+            {
+                return;
+            }
+
+            try
+            {
+                await downloadHistoryService.RecordDownloadFailedAsync(
+                    downloadId,
+                    downloadClientId,
+                    title,
+                    failure.Message);
+            }
+            catch (Exception historyException) when (historyException is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
+            {
+                logger.LogWarning(
+                    historyException,
+                    "Failed to record rejected submission for download {DownloadId} in history (non-critical)",
+                    downloadId);
+            }
+        }
+
+        public static async Task RemoveProvisionalDownloadAsync(
+            string downloadId,
+            IDownloadRepository downloadRepository,
+            ILogger logger)
+        {
+            try
+            {
+                await downloadRepository.RemoveAsync(downloadId);
+                logger.LogInformation("Removed provisional download {DownloadId} after client submission failed", downloadId);
+            }
+            catch (Exception cleanupException) when (cleanupException is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
+            {
+                logger.LogError(cleanupException, "Failed to remove provisional download {DownloadId} after client submission failure", downloadId);
+            }
+        }
+    }
+}

--- a/listenarr.application/Downloads/Submission/DownloadSubmissionFailureHandler.cs
+++ b/listenarr.application/Downloads/Submission/DownloadSubmissionFailureHandler.cs
@@ -21,13 +21,21 @@ using Microsoft.Extensions.Logging;
 namespace Listenarr.Application.Downloads.Submission
 {
     /// <summary>
-    /// Cleans up after a download the client never accepted. The provisional Download row is
-    /// removed because no client item backs it, so a history event is the only place the
-    /// attempt can be recorded. Without one, a rejected grab leaves no trace at all and the
-    /// next automatic search repeats it with nothing to show the user why.
+    /// Cleans up after a submission that did not yield a trackable download. Two paths reach
+    /// here and both are handled the same way. The client can refuse the release outright, and
+    /// it can accept it while returning no usable identifier, which leaves us nothing to poll
+    /// the queue with even though the download may well be running. Either way the provisional
+    /// Download row is removed because no item we can find backs it, so a history event is the
+    /// only place the attempt can be recorded. Without one the grab leaves no trace at all and
+    /// the next automatic search repeats it with nothing to show the user why.
     /// </summary>
     internal static class DownloadSubmissionFailureHandler
     {
+        /// <summary>
+        /// Writes the failed attempt to history before the provisional row is removed. The
+        /// message carried here is the exception's own, so the no-identifier case reads as the
+        /// client returning no verified identifier rather than as a refusal.
+        /// </summary>
         public static async Task RecordRejectedSubmissionAsync(
             string downloadId,
             string downloadClientId,
@@ -43,11 +51,17 @@ namespace Listenarr.Application.Downloads.Submission
 
             try
             {
+                // The message comes from the download client and lands in a durable, user-visible
+                // row, so it goes through the same helper the rest of the codebase uses for client
+                // and user supplied text. It strips newlines, which is what makes a crafted release
+                // title or an HTML error page able to forge log lines, and caps the length so a
+                // whole error page is not stored twice. It does not redact an absolute container
+                // path, and a client that reports one in its error string will still put it here.
                 await downloadHistoryService.RecordDownloadFailedAsync(
                     downloadId,
                     downloadClientId,
                     title,
-                    failure.Message);
+                    LogRedaction.SanitizeText(failure.Message));
             }
             catch (Exception historyException) when (historyException is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
             {

--- a/tests/Features/Application/Downloads/Submission/DownloadServiceTests.cs
+++ b/tests/Features/Application/Downloads/Submission/DownloadServiceTests.cs
@@ -103,6 +103,10 @@ namespace Listenarr.Tests.Features.Application.Downloads.Submission
                 .ThrowsAsync(new DownloadClientSubmissionException("Unable to obtain a verified hash from the torrent metadata."));
 
             var historyMock = new Mock<IDownloadHistoryService>(MockBehavior.Strict);
+            historyMock
+                .Setup(h => h.RecordDownloadFailedAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()))
+                .Returns(Task.CompletedTask);
             var notificationMock = new Mock<INotificationService>(MockBehavior.Strict);
             _services.AddSingleton(gatewayMock.Object);
             _services.AddSingleton(historyMock.Object);
@@ -126,8 +130,56 @@ namespace Listenarr.Tests.Features.Application.Downloads.Submission
 
             Assert.Equal(initialDownloadCount, (await _downloadRepository.GetAllAsync()).Count);
             gatewayMock.VerifyAll();
-            historyMock.VerifyNoOtherCalls();
+            historyMock.Verify(
+                h => h.RecordGrabbedAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<DownloadProtocol>(), It.IsAny<Guid?>()),
+                Times.Never);
             notificationMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task SendToDownloadClientAsync_WhenClientRejectsSubmission_RecordsFailedAttemptInHistory()
+        {
+            var rejection = new DownloadClientSubmissionException("qBittorrent rejected the torrent with HTTP 409.");
+            var gatewayMock = new Mock<IDownloadClientGateway>(MockBehavior.Strict);
+            gatewayMock
+                .Setup(g => g.AddAsync(
+                    It.Is<DownloadClientConfiguration>(client => client.Id == "qb-1"),
+                    It.IsAny<PreparedDownloadSubmission>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(rejection);
+
+            var historyMock = new Mock<IDownloadHistoryService>(MockBehavior.Strict);
+            historyMock
+                .Setup(h => h.RecordDownloadFailedAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()))
+                .Returns(Task.CompletedTask);
+            _services.AddSingleton(gatewayMock.Object);
+            _services.AddSingleton(historyMock.Object);
+
+            Init();
+            await InitData();
+            var downloadService = _provider.GetRequiredService<DownloadService>();
+            var searchResult = new SearchResult
+            {
+                Title = "Artemis",
+                Artist = "Andy Weir",
+                DownloadType = "Torrent",
+                MagnetLink = "magnet:?xt=urn:btih:ABCDEF1234567890ABCDEF1234567890ABCDEF12",
+                Size = 123456789
+            };
+
+            await Assert.ThrowsAsync<DownloadClientSubmissionException>(
+                () => downloadService.SendToDownloadClientAsync(searchResult, _client.Id));
+
+            historyMock.Verify(
+                h => h.RecordDownloadFailedAsync(
+                    It.Is<string>(id => !string.IsNullOrWhiteSpace(id)),
+                    "qb-1",
+                    "Artemis",
+                    rejection.Message),
+                Times.Once);
         }
 
         [Fact]
@@ -142,6 +194,10 @@ namespace Listenarr.Tests.Features.Application.Downloads.Submission
                 .ReturnsAsync(new DownloadClientSubmissionResult(string.Empty));
 
             var historyMock = new Mock<IDownloadHistoryService>(MockBehavior.Strict);
+            historyMock
+                .Setup(h => h.RecordDownloadFailedAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()))
+                .Returns(Task.CompletedTask);
             var notificationMock = new Mock<INotificationService>(MockBehavior.Strict);
             _services.AddSingleton(gatewayMock.Object);
             _services.AddSingleton(historyMock.Object);
@@ -165,7 +221,11 @@ namespace Listenarr.Tests.Features.Application.Downloads.Submission
 
             Assert.Equal(initialDownloadCount, (await _downloadRepository.GetAllAsync()).Count);
             gatewayMock.VerifyAll();
-            historyMock.VerifyNoOtherCalls();
+            historyMock.Verify(
+                h => h.RecordGrabbedAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                    It.IsAny<DownloadProtocol>(), It.IsAny<Guid?>()),
+                Times.Never);
             notificationMock.VerifyNoOtherCalls();
         }
 

--- a/tests/Features/Application/Downloads/Submission/DownloadServiceTests.cs
+++ b/tests/Features/Application/Downloads/Submission/DownloadServiceTests.cs
@@ -226,6 +226,16 @@ namespace Listenarr.Tests.Features.Application.Downloads.Submission
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                     It.IsAny<DownloadProtocol>(), It.IsAny<Guid?>()),
                 Times.Never);
+            // A blank external id leaves nothing to track, so this path records a failure too.
+            // Stubbing RecordDownloadFailedAsync without asserting it would let that behaviour
+            // change silently, which is what the replaced VerifyNoOtherCalls used to prevent.
+            historyMock.Verify(
+                h => h.RecordDownloadFailedAsync(
+                    It.Is<string>(id => !string.IsNullOrWhiteSpace(id)),
+                    "qb-1",
+                    "Artemis",
+                    "The download client did not return a verified download identifier."),
+                Times.Once);
             notificationMock.VerifyNoOtherCalls();
         }
 

--- a/tests/Features/Application/Downloads/Submission/DownloadServiceTests.cs
+++ b/tests/Features/Application/Downloads/Submission/DownloadServiceTests.cs
@@ -183,6 +183,56 @@ namespace Listenarr.Tests.Features.Application.Downloads.Submission
         }
 
         [Fact]
+        public async Task SendToDownloadClientAsync_SanitizesTheClientMessageItWritesToHistory()
+        {
+            // The client's own error text lands in a durable row the user can read. A download
+            // client that answers with an HTML error page, or a release title carried back into
+            // the message, can put newlines and several kilobytes into it. Passing failure.Message
+            // straight through stores that verbatim, twice, and lets a newline forge log lines.
+            var rawMessage = "SABnzbd error: cannot write to\n/incomplete/downloads " + new string('x', 400);
+            var rejection = new DownloadClientSubmissionException(rawMessage);
+            var gatewayMock = new Mock<IDownloadClientGateway>(MockBehavior.Strict);
+            gatewayMock
+                .Setup(g => g.AddAsync(
+                    It.Is<DownloadClientConfiguration>(client => client.Id == "qb-1"),
+                    It.IsAny<PreparedDownloadSubmission>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(rejection);
+
+            string? recordedMessage = null;
+            var historyMock = new Mock<IDownloadHistoryService>(MockBehavior.Strict);
+            historyMock
+                .Setup(h => h.RecordDownloadFailedAsync(
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>()))
+                .Callback<string, string, string, string?>((_, _, _, message) => recordedMessage = message)
+                .Returns(Task.CompletedTask);
+            _services.AddSingleton(gatewayMock.Object);
+            _services.AddSingleton(historyMock.Object);
+
+            Init();
+            await InitData();
+            var downloadService = _provider.GetRequiredService<DownloadService>();
+            var searchResult = new SearchResult
+            {
+                Title = "Artemis",
+                Artist = "Andy Weir",
+                DownloadType = "Torrent",
+                MagnetLink = "magnet:?xt=urn:btih:ABCDEF1234567890ABCDEF1234567890ABCDEF12",
+                Size = 123456789
+            };
+
+            await Assert.ThrowsAsync<DownloadClientSubmissionException>(
+                () => downloadService.SendToDownloadClientAsync(searchResult, _client.Id));
+
+            Assert.NotNull(recordedMessage);
+            Assert.DoesNotContain("\n", recordedMessage!);
+            Assert.DoesNotContain("\r", recordedMessage!);
+            Assert.True(recordedMessage!.Length <= 203, $"recorded message was {recordedMessage.Length} characters");
+            Assert.NotEqual(rawMessage, recordedMessage);
+            Assert.StartsWith("SABnzbd error: cannot write to", recordedMessage!);
+        }
+
+        [Fact]
         public async Task SendToDownloadClientAsync_WhenClientReturnsBlankExternalId_RemovesProvisionalDownloadAndDoesNotRecordGrab()
         {
             var gatewayMock = new Mock<IDownloadClientGateway>(MockBehavior.Strict);


### PR DESCRIPTION
# Record a failed grab in history when the download client rejects it

## What this fixes

When a download client refuses a submission, the attempt disappears completely. No `Download` row, no history event, nothing on the book to say it was tried. The next automatic search runs the same grab and fails the same way, and from the UI the book looks like it was never searched.

Two separate steps cause it, and each one looks reasonable on its own:

- `DownloadService.cs:350` removes the provisional `Download` row when the client throws. Right on its own: no client item backs the row, and leaving it would produce the stuck `ImportPending` records described in #758.
- `RecordGrabbedAsync` is only reached at `DownloadService.cs:374`, after the client has accepted. The comment above it is deliberate, and history should not claim a grab that never happened.

Between the two, nothing is written. `IDownloadHistoryService.RecordDownloadFailedAsync` already exists and is currently only wired to client-side failures from `DownloadMonitorService.cs:381`, which is the path for a download that failed after the client accepted it. A submission the client never accepted never gets there.

## Where this diverges from Sonarr, deliberately

I should be straight about this rather than claim precedent I do not have.

Sonarr does not record failed grabs either. There is no `GrabFailed` in `EpisodeHistoryEventType` or `DownloadHistoryEventType`, and `Sonarr.Core/Download/DownloadService.cs` has no `IHistoryService` dependency at all. Every catch arm logs and rethrows, and `ProcessDownloadDecisions` turns most of them into `Skipped` with nothing persisted. Sonarr reaches the same end state by never creating a record, where Listenarr creates one and deletes it.

So this is a proposal, not a port. My reasoning for it: Listenarr already has a `DownloadFailed` history event and an Activity view that surfaces it, this is the only failure path that writes nothing to either, and #838's blocklist would need a record like this to exist before it had anything to key on. If you would rather match Sonarr and stay silent here, that is a coherent answer and I will drop it.

## What changed

Record a `DownloadFailed` event before removing the provisional row.

Cancellation is left as it was. A shutdown is not a release failure and should not appear in a user's history as one, so the `OperationCanceledException` path still only removes the row.

`RemoveProvisionalDownloadAsync` moves out of `DownloadService` into a new `DownloadSubmissionFailureHandler` next to the new call, matching `DownloadRecordFactory` and `DownloadDuplicateGuard`, which are already internal static helpers in the same namespace. That keeps `DownloadService.cs` under the 500 line architecture budget: it was 498, now 487.

The history write is wrapped so that a history failure cannot raise a second exception on a path already handling one, matching how the success-path history call at `DownloadService.cs:381` is guarded.

## Scope, and one open question

This makes the failure visible. It does not stop it repeating. Nothing consults history to suppress a re-grab.

The open question: a qBittorrent 5.2 duplicate rejection comes through this same path, and Sonarr/Sonarr#8854 decided a duplicate should be a quiet skip rather than a failure. If Listenarr follows that, a 409 probably should not write a `DownloadFailed` row, and this would want a carve-out. I have filed the 409 behaviour separately as #881, since it needs a decision first.

## Tests

- New: `SendToDownloadClientAsync_WhenClientRejectsSubmission_RecordsFailedAttemptInHistory`. Confirmed it fails with the production change reverted (`Expected invocation on the mock once, but was 0 times`) and passes with it.
- The two existing submission-failure tests asserted `historyMock.VerifyNoOtherCalls()`. Their names say `DoesNotRecordGrab` and that is still what they check, now stated directly as `RecordGrabbedAsync` with `Times.Never` rather than as no calls at all.
- Full suite: 3030 passed, 0 failed, 125 skipped, including the 45 architecture tests.
