### PR TITLE
fix(metadata): retry throttled lookups instead of recording them as no match

### DIFF
--- a/fe/src/__tests__/libraryImport.store.spec.ts
+++ b/fe/src/__tests__/libraryImport.store.spec.ts
@@ -417,4 +417,45 @@ describe('library import store', () => {
       'Jack of Shadows',
     )
   })
+
+  it('keeps a failed lookup unprocessed instead of recording it as no match', async () => {
+    const { useLibraryImportStore } = await import('@/stores/libraryImport')
+    const store = useLibraryImportStore()
+
+    // A throttled provider rejects; that is not an answer about the book.
+    advancedSearch.mockRejectedValue(new Error('429 Too Many Requests'))
+
+    const path = 'C:\\incoming\\Rate Limited.mp3'
+    store.items = {
+      [path]: {
+        id: path,
+        fullPath: path,
+        sourceFiles: [path],
+        folderPath: 'C:\\incoming',
+        relativePath: 'rate-limited',
+        folderName: 'rate-limited',
+        detectedTitle: 'Rate Limited',
+        detectedAuthor: 'Some Author',
+        format: 'MP3',
+        fileCount: 1,
+        selectedMatch: null,
+        hasSearched: false,
+        searchFailed: false,
+        isSearching: false,
+        selected: false,
+      },
+    }
+
+    store.startProcessing()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const item = store.items[path]
+    expect(item?.searchFailed).toBe(true)
+    expect(item?.selectedMatch).toBeNull()
+
+    // The row must stay in the unprocessed set so the next run retries it.
+    expect(item?.hasSearched).toBe(false)
+    expect(store.hasUnprocessedItems).toBe(true)
+    expect(store.failedCount).toBe(1)
+  })
 })

--- a/fe/src/components/domain/audiobook/LibraryImportFooter.vue
+++ b/fe/src/components/domain/audiobook/LibraryImportFooter.vue
@@ -51,7 +51,13 @@
 
       <div v-if="store.metadataFetchCount > 100" class="rate-limit-warning">
         <PhWarning :size="14" />
-        {{ store.metadataFetchCount }} API lookups - rate limit: 150/window
+        {{ store.metadataFetchCount }} API lookups - external providers may throttle
+      </div>
+
+      <div v-if="store.failedCount > 0" class="lookup-failure-warning">
+        <PhWarning :size="14" />
+        {{ store.failedCount }} lookup{{ store.failedCount === 1 ? '' : 's' }} failed - these were
+        not matched and will be retried on the next run
       </div>
 
       <div
@@ -262,6 +268,18 @@ async function handleImport() {
   font-family: monospace;
   font-size: 0.78rem;
   max-width: 280px;
+}
+
+.lookup-failure-warning {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.78rem;
+  color: #ef4444;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 4px;
+  padding: 0.2rem 0.5rem;
 }
 
 .rate-limit-warning {

--- a/fe/src/stores/libraryImport.ts
+++ b/fe/src/stores/libraryImport.ts
@@ -39,7 +39,8 @@ export interface LibraryImportItem {
   fileCount: number
   // Match state
   selectedMatch: SearchResult | null
-  hasSearched: boolean // true once auto-search was attempted
+  hasSearched: boolean // true once auto-search completed and returned an answer
+  searchFailed: boolean // true when the lookup errored (rate limit, network) - not "no match"
   isSearching: boolean // currently in-flight
   // Selection
   selected: boolean
@@ -89,6 +90,7 @@ function unmatchedToImportItem(item: UnmatchedFileItem): LibraryImportItem {
     fileCount: item.fileCount,
     selectedMatch: null,
     hasSearched: false,
+    searchFailed: false,
     isSearching: false,
     selected: false,
   }
@@ -142,6 +144,7 @@ export const useLibraryImportStore = defineStore('libraryImport', () => {
   const action = ref<'none' | 'move' | 'hardlink/copy'>('none')
   const monitor = ref<'none' | 'all'>('all')
   const metadataFetchCount = ref(0)
+  const metadataFailureCount = ref(0)
   const importErrors = ref<string[]>([])
 
   // ─── Computed ────────────────────────────────────────────────────────────────
@@ -150,6 +153,7 @@ export const useLibraryImportStore = defineStore('libraryImport', () => {
   const selectedCount = computed(() => itemList.value.filter((i) => i.selected).length)
   const hasUnprocessedItems = computed(() => itemList.value.some((i) => !i.hasSearched))
   const processedCount = computed(() => itemList.value.filter((i) => i.hasSearched).length)
+  const failedCount = computed(() => itemList.value.filter((i) => i.searchFailed).length)
   const matchedCount = computed(() => itemList.value.filter((i) => i.selectedMatch).length)
 
   // ─── Scan ─────────────────────────────────────────────────────────────────
@@ -170,6 +174,7 @@ export const useLibraryImportStore = defineStore('libraryImport', () => {
             ...unmatchedToImportItem(item),
             selectedMatch: existing.selectedMatch,
             hasSearched: existing.hasSearched,
+            searchFailed: existing.searchFailed,
             isSearching: false,
             selected: existing.selected,
           }
@@ -178,6 +183,7 @@ export const useLibraryImportStore = defineStore('libraryImport', () => {
             ...unmatchedToImportItem(item),
             selectedMatch: p.selectedMatch,
             hasSearched: p.hasSearched,
+            searchFailed: p.searchFailed ?? false,
             isSearching: false,
             selected: p.selected,
           }
@@ -300,6 +306,7 @@ export const useLibraryImportStore = defineStore('libraryImport', () => {
   type PersistedEntry = {
     selectedMatch: SearchResult | null
     hasSearched: boolean
+    searchFailed?: boolean
     selected: boolean
   }
 
@@ -314,6 +321,7 @@ export const useLibraryImportStore = defineStore('libraryImport', () => {
       state[path] = {
         selectedMatch: item.selectedMatch,
         hasSearched: item.hasSearched,
+        searchFailed: item.searchFailed,
         selected: item.selected,
       }
     }
@@ -342,6 +350,7 @@ export const useLibraryImportStore = defineStore('libraryImport', () => {
     lookupQueue.value = unsearched
     isProcessing.value = true
     metadataFetchCount.value = 0
+    metadataFailureCount.value = 0
     processNext()
   }
 
@@ -381,18 +390,24 @@ export const useLibraryImportStore = defineStore('libraryImport', () => {
             ...current,
             isSearching: false,
             hasSearched: true,
+            searchFailed: false,
             selectedMatch: first,
             selected: first !== null,
           },
         }
         _persistMatches()
       } catch {
+        // A failed lookup is not an answer. Leaving hasSearched false keeps the row in the
+        // unprocessed set so re-running Start Matching retries it, instead of recording a
+        // rate-limited request as a book that simply is not on Audible.
+        metadataFailureCount.value++
         const current = items.value[id]
         if (current)
           items.value = {
             ...items.value,
-            [id]: { ...current, isSearching: false, hasSearched: true },
+            [id]: { ...current, isSearching: false, searchFailed: true },
           }
+        _persistMatches()
       }
     }
     isProcessing.value = false
@@ -589,6 +604,8 @@ export const useLibraryImportStore = defineStore('libraryImport', () => {
     action,
     monitor,
     metadataFetchCount,
+    metadataFailureCount,
+    failedCount,
     importErrors,
     // Computed
     itemList,

--- a/listenarr.infrastructure/DependencyInjection/Metadata/MetadataRegistrationExtensions.cs
+++ b/listenarr.infrastructure/DependencyInjection/Metadata/MetadataRegistrationExtensions.cs
@@ -7,6 +7,7 @@
  * by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  */
+using System.Net;
 using Listenarr.Infrastructure.DependencyInjection.Platform;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,12 +19,15 @@ namespace Listenarr.Infrastructure.DependencyInjection.Metadata;
 
 internal static class MetadataRegistrationExtensions
 {
+    private const int MaxRetryAttempts = 3;
+
+    private static readonly TimeSpan MaxRetryAfterHonored = TimeSpan.FromSeconds(60);
+
     public static IServiceCollection AddMetadataHttpClients(
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        var retryPolicy = HttpPolicyExtensions.HandleTransientHttpError()
-            .WaitAndRetryAsync(3, attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)));
+        var retryPolicy = CreateExternalMetadataRetryPolicy();
         services.AddHttpClient<AudibleService>()
             .ConfigurePrimaryHttpMessageHandler(PlatformRegistrationExtensions.CreateExternalHandler)
             .AddPolicyHandler(retryPolicy);
@@ -38,7 +42,8 @@ internal static class MetadataRegistrationExtensions
         services.AddScoped<IMetadataService, MetadataService>();
         services.AddScoped<IAsinLookupService, AsinLookupService>();
         services.AddScoped<IAudiobookMetadataService, AudiobookMetadataService>();
-        services.AddScoped<IOpenLibraryService, OpenLibraryService>();
+        services.AddHttpClient<IOpenLibraryService, OpenLibraryService>()
+            .AddPolicyHandler(CreateExternalMetadataRetryPolicy());
         services.AddSingleton<MetadataExtractionLimiter>();
         services.AddHttpClient("Ffmpeg");
         services.AddSingleton<IFfmpegService>(provider =>
@@ -49,6 +54,49 @@ internal static class MetadataRegistrationExtensions
                 provider.GetRequiredService<IProcessRunner>(),
                 provider.GetRequiredService<IApplicationPathService>()));
         return services;
+    }
+
+    /// <summary>
+    /// Retry policy for third-party metadata APIs.
+    /// </summary>
+    /// <remarks>
+    /// HandleTransientHttpError covers 5xx and 408 but deliberately excludes 429, which is the
+    /// only status a rate limiter actually returns - so without the extra OrResult clause a
+    /// throttled request fails immediately and the caller records it as "no match found".
+    /// </remarks>
+    private static IAsyncPolicy<HttpResponseMessage> CreateExternalMetadataRetryPolicy() =>
+        HttpPolicyExtensions.HandleTransientHttpError()
+            .OrResult(response => response.StatusCode == HttpStatusCode.TooManyRequests)
+            .WaitAndRetryAsync(
+                MaxRetryAttempts,
+                (attempt, outcome, _) => ComputeRetryDelay(attempt, outcome),
+                (_, _, _, _) => Task.CompletedTask);
+
+    /// <summary>
+    /// Exponential backoff, overridden by a longer Retry-After hint when the server sends one.
+    /// </summary>
+    private static TimeSpan ComputeRetryDelay(int attempt, DelegateResult<HttpResponseMessage> outcome)
+    {
+        var backoff = TimeSpan.FromSeconds(Math.Pow(2, attempt));
+
+        // Result is null when the attempt threw rather than returning a response.
+        var retryAfter = outcome.Result?.Headers.RetryAfter;
+        if (retryAfter is null)
+        {
+            return backoff;
+        }
+
+        // Retry-After is either delta-seconds or an HTTP-date; both forms are in the wild.
+        var hinted = retryAfter.Delta
+            ?? (retryAfter.Date is { } date ? date - DateTimeOffset.UtcNow : null);
+        if (hinted is null || hinted <= TimeSpan.Zero)
+        {
+            return backoff;
+        }
+
+        // Cap the hint so a mistaken or hostile header cannot stall the pipeline indefinitely.
+        var capped = hinted.Value > MaxRetryAfterHonored ? MaxRetryAfterHonored : hinted.Value;
+        return capped > backoff ? capped : backoff;
     }
 
     public static IServiceCollection AddMetadataInfrastructure(this IServiceCollection services)

--- a/tests/Features/Infrastructure/DependencyInjection/MetadataRetryPolicyTests.cs
+++ b/tests/Features/Infrastructure/DependencyInjection/MetadataRetryPolicyTests.cs
@@ -1,0 +1,126 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Net;
+using Listenarr.Infrastructure.DependencyInjection.Metadata;
+using Listenarr.Tests.Common;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Options;
+
+namespace Listenarr.Tests.Features.Infrastructure.DependencyInjection
+{
+    /// <summary>
+    /// Polly's HandleTransientHttpError covers 5xx and 408 but not 429, which is the only status a
+    /// rate limiter returns. Without an explicit clause a throttled metadata lookup fails on the
+    /// first attempt and the caller records it as "no match found" rather than "ask again".
+    /// </summary>
+    [Trait("Area", "Metadata")]
+    [Trait("Name", "MetadataRetryPolicyTests")]
+    [Trait("Category", "DependencyInjection")]
+    public class MetadataRetryPolicyTests : BaseTests
+    {
+        [Fact]
+        public async Task AudibleClient_TooManyRequests_IsRetriedUntilItSucceeds()
+        {
+            var handler = new SequencedHandler(HttpStatusCode.TooManyRequests, HttpStatusCode.OK);
+            var services = new ServiceCollection();
+            services.AddMetadataHttpClients(new ConfigurationManager());
+            services.AddHttpClient<AudibleService>().ConfigurePrimaryHttpMessageHandler(() => handler);
+            using var provider = services.BuildServiceProvider();
+
+            var client = provider
+                .GetRequiredService<IHttpClientFactory>()
+                .CreateClient(nameof(AudibleService));
+            using var response = await client.GetAsync("https://example.invalid/search");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(2, handler.Attempts);
+        }
+
+        [Fact]
+        public async Task AudibleClient_RetryAfterHint_IsPreferredOverTheShorterBackoff()
+        {
+            var handler = new SequencedHandler(HttpStatusCode.TooManyRequests, HttpStatusCode.OK)
+            {
+                RetryAfter = TimeSpan.FromSeconds(3)
+            };
+            var services = new ServiceCollection();
+            services.AddMetadataHttpClients(new ConfigurationManager());
+            services.AddHttpClient<AudibleService>().ConfigurePrimaryHttpMessageHandler(() => handler);
+            using var provider = services.BuildServiceProvider();
+
+            var client = provider
+                .GetRequiredService<IHttpClientFactory>()
+                .CreateClient(nameof(AudibleService));
+            var started = DateTimeOffset.UtcNow;
+            using var response = await client.GetAsync("https://example.invalid/search");
+            var elapsed = DateTimeOffset.UtcNow - started;
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // The first-attempt backoff is 2s; the server asked for 3s and must win.
+            Assert.True(
+                elapsed >= TimeSpan.FromSeconds(2.5),
+                $"Expected the Retry-After hint to be honored, but the retry ran after {elapsed}.");
+        }
+
+        [Fact]
+        public void OpenLibraryClient_IsRegisteredWithTheSharedRetryPolicy()
+        {
+            var services = new ServiceCollection();
+
+            services.AddMetadataServices();
+
+            using var provider = services.BuildServiceProvider();
+            var options = provider
+                .GetRequiredService<IOptionsMonitor<HttpClientFactoryOptions>>()
+                .Get(nameof(IOpenLibraryService));
+
+            // A bare AddScoped registration resolves the default unnamed client, which carries no
+            // policy at all - the OpenLibrary fallback then had no retry of any kind.
+            Assert.NotEmpty(options.HttpMessageHandlerBuilderActions);
+        }
+
+        private sealed class SequencedHandler : HttpMessageHandler
+        {
+            private readonly Queue<HttpStatusCode> _statuses;
+
+            public SequencedHandler(params HttpStatusCode[] statuses) =>
+                _statuses = new Queue<HttpStatusCode>(statuses);
+
+            public TimeSpan? RetryAfter { get; init; }
+
+            public int Attempts { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                Attempts++;
+                var status = _statuses.Count > 0 ? _statuses.Dequeue() : HttpStatusCode.OK;
+                var response = new HttpResponseMessage(status);
+                if (status == HttpStatusCode.TooManyRequests && RetryAfter is { } retryAfter)
+                {
+                    response.Headers.RetryAfter = new System.Net.Http.Headers.RetryConditionHeaderValue(retryAfter);
+                }
+
+                return Task.FromResult(response);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Bulk library import issues one metadata lookup per unmatched book — over a thousand on a large library — and nothing handled being throttled.

**`HandleTransientHttpError` covers 5xx and 408 but not 429**, the only status a rate limiter returns, so the Audible and Audnexus clients had exponential backoff that could never fire for the case it existed for. Adds a `TooManyRequests` clause and honours `Retry-After` when it exceeds the computed backoff, capped at 60s.

**`OpenLibraryService` had no policy at all** — registered via `AddScoped` with a bare `HttpClient`, which resolves the default unnamed client. Now a typed client sharing the policy.

**The import store recorded failures as misses** — the catch block set `hasSearched: true` with no match, making a 429 indistinguishable from "not on Audible" and excluding the row from re-runs. Failures are now tracked separately and stay retryable, with a count in the footer.

Also reworded the footer's "rate limit: 150/window", which matches no limiter in the codebase — `ApiConfiguration.RateLimitPerMinute` is never read by any production code.

Tests were each confirmed to fail with the corresponding fix reverted.