### PR TITLE
fix(ui): theme the collection card detail text

### DIFF
--- a/fe/src/views/library/CollectionView.vue
+++ b/fe/src/views/library/CollectionView.vue
@@ -3923,7 +3923,8 @@ defineExpose({
 
 .series-bottom-title {
   font-size: 12px;
-  color: #fff;
+  /* Sits on the card surface, not on the cover art, so it must follow the theme. */
+  color: var(--text-color);
   margin: 0 0 4px 0;
   font-weight: 500;
   text-align: center;
@@ -3931,14 +3932,14 @@ defineExpose({
 
 .series-bottom-author {
   font-size: 11px;
-  color: #bfcad6;
+  color: var(--text-muted);
   margin: 0 0 2px 0;
   text-align: center;
 }
 
 .series-bottom-meta {
   font-size: 11px;
-  color: #bfcad6;
+  color: var(--text-muted);
   margin: 0;
   text-align: center;
 }


### PR DESCRIPTION
With item details toggled on (the ⓘ toolbar button), the text under each cover is unreadable in the light theme.

Measured on the rendered page:

| Rule | Colour | On card `#f8f8f8` | Contrast |
|---|---|---|---|
| `.series-bottom-title` | `#fff` | white on near-white | **1.06:1** |
| `.series-bottom-author` | `#bfcad6` | | 1.57:1 |
| `.series-bottom-meta` | `#bfcad6` | | 1.57:1 |

These sit on the card surface, not over the cover art, so they now use the existing `--text-color` / `--text-muted` tokens that `base.css` already defines for both schemes.

**Deliberately scoped to three rules.** A contrast audit over the rendered page flagged exactly these and nothing else. In particular the identically named `.series-bottom-title` in `AudiobooksView` sits on a `rgb(26,26,26)` placard where light text is correct, so it is left alone — the other hardcoded `#fff`/`#bfcad6` values in both files are on dark overlays or coloured badges.