### PR TITLE
fix(ui): stop styling unmonitored books as a destructive state

### DIFF
--- a/fe/src/views/library/AudiobooksView.vue
+++ b/fe/src/views/library/AudiobooksView.vue
@@ -3637,9 +3637,11 @@ defineExpose({
 }
 
 .monitored-badge.unmonitored {
-  background-color: rgba(231, 76, 60, 0.2);
-  border-color: rgba(231, 76, 60, 0.4);
-  color: #e74c3c;
+  /* Neutral, not red: an unmonitored or not-yet-added book is a state, not a
+     destructive action. Red stays reserved for delete. */
+  background-color: rgba(148, 163, 184, 0.15);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--text-muted);
 }
 
 .monitored-badge i {

--- a/fe/src/views/library/CollectionView.vue
+++ b/fe/src/views/library/CollectionView.vue
@@ -3716,9 +3716,11 @@ defineExpose({
 }
 
 .monitored-badge.unmonitored {
-  background-color: rgba(231, 76, 60, 0.2);
-  border-color: rgba(231, 76, 60, 0.4);
-  color: #e74c3c;
+  /* Neutral, not red: an unmonitored or not-yet-added book is a state, not a
+     destructive action. Red stays reserved for delete. */
+  background-color: rgba(148, 163, 184, 0.15);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--text-muted);
 }
 
 .monitored-badge i {
@@ -4213,9 +4215,11 @@ defineExpose({
 }
 
 .monitored-badge.unmonitored {
-  background-color: rgba(231, 76, 60, 0.2);
-  border-color: rgba(231, 76, 60, 0.4);
-  color: #e74c3c;
+  /* Neutral, not red: an unmonitored or not-yet-added book is a state, not a
+     destructive action. Red stays reserved for delete. */
+  background-color: rgba(148, 163, 184, 0.15);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--text-muted);
 }
 
 .monitored-badge i {
@@ -4224,8 +4228,11 @@ defineExpose({
 }
 
 .monitored-badge.unmonitored {
-  background: rgba(244, 67, 54, 0.9);
-  color: #fff;
+  /* Neutral, not red: an unmonitored or not-yet-added book is a state, not a
+     destructive action. Red stays reserved for delete. */
+  background-color: rgba(148, 163, 184, 0.15);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--text-muted);
 }
 
 .grid-bottom-details {


### PR DESCRIPTION
The unmonitored badge uses the same red as the delete control, so "Not Added" and "Not Monitored" read with the severity of deleting a file. Both are ordinary states.

| | Before | After |
|---|---|---|
| Not Added / Not Monitored | `rgba(244,67,54,0.9)`, white text | slate `rgba(148,163,184,0.15)`, muted text |
| Monitored | green | green (unchanged) |
| Delete | red | red — now the only red |

The `PhEye` / `PhEyeSlash` icons were already right and are untouched, so the badges now match the author and series pills in the same views.

Worth noting for review: **three separate rules** define `.monitored-badge.unmonitored` in `CollectionView`, and the last one uses a different red plus a shorthand `background`, so it silently overrides the other two. All are updated.