### PR TITLE
feat(search): search by narrator

### DIFF
--- a/fe/src/__tests__/useAdvancedSearch.spec.ts
+++ b/fe/src/__tests__/useAdvancedSearch.spec.ts
@@ -55,6 +55,7 @@ describe('useAdvancedSearch', () => {
         isbn: '',
         series: '',
         asin: '',
+        narrator: '',
       })
     })
 
@@ -258,6 +259,7 @@ describe('useAdvancedSearch', () => {
         isbn: '',
         series: '',
         asin: '',
+        narrator: '',
       })
     })
 
@@ -290,6 +292,7 @@ describe('useAdvancedSearch', () => {
         isbn: '',
         series: '',
         asin: '',
+        narrator: '',
       })
     })
 

--- a/fe/src/composables/useAdvancedSearch.ts
+++ b/fe/src/composables/useAdvancedSearch.ts
@@ -32,6 +32,7 @@ export interface AdvancedSearchParams {
   isbn?: string
   series?: string
   asin?: string
+  narrator?: string
 }
 
 /**
@@ -61,6 +62,7 @@ export const useAdvancedSearch = () => {
     isbn: '',
     series: '',
     asin: '',
+    narrator: '',
   })
 
   // Debounce timer for localStorage saves
@@ -164,6 +166,7 @@ export const useAdvancedSearch = () => {
       isbn: '',
       series: '',
       asin: '',
+      narrator: '',
     }
     // Persist handled by watcher
   }

--- a/fe/src/services/api.ts
+++ b/fe/src/services/api.ts
@@ -569,6 +569,7 @@ class ApiService {
     isbn?: string
     series?: string
     asin?: string
+    narrator?: string
     region?: string
     language?: string
     pagination?: { page?: number; limit?: number }
@@ -583,6 +584,7 @@ class ApiService {
     if (params.isbn) (body as Record<string, unknown>).isbn = params.isbn
     if (params.series) (body as Record<string, unknown>).series = params.series
     if (params.asin) (body as Record<string, unknown>).asin = params.asin
+    if (params.narrator) (body as Record<string, unknown>).narrator = params.narrator
     const region =
       params.region || (params.language ? getRegionFromLanguage(params.language) : undefined)
     if (region) (body as Record<string, unknown>).region = region

--- a/fe/src/views/content/AddNewView.vue
+++ b/fe/src/views/content/AddNewView.vue
@@ -182,6 +182,21 @@
                   />
                 </div>
                 <div class="form-group">
+                  <label for="adv-narrator">Narrator</label>
+                  <input
+                    id="adv-narrator"
+                    aria-label="Narrator"
+                    v-model="advancedSearchParams.narrator"
+                    type="text"
+                    placeholder="e.g., Stephen Fry"
+                    class="form-input"
+                    @keydown.enter.prevent="performAdvancedSearch"
+                  />
+                  <div class="form-hint">
+                    <div>Searches Audible's narrator field, not just the title text.</div>
+                  </div>
+                </div>
+                <div class="form-group">
                   <label for="adv-series">Series</label>
                   <input
                     id="adv-series"
@@ -1809,13 +1824,15 @@ const performAdvancedSearch = async () => {
       series?: string
       isbn?: string
       asin?: string
+      narrator?: string
     }
     const hasAny = Boolean(
       (p.title && p.title.trim()) ||
       (p.author && p.author.trim()) ||
       (p.series && p.series.trim()) ||
       (p.isbn && p.isbn.trim()) ||
-      (p.asin && p.asin.trim()),
+      (p.asin && p.asin.trim()) ||
+      (p.narrator && p.narrator.trim()),
     )
     if (!hasAny) {
       advancedSearchError.value = 'Please enter a search term'
@@ -1837,6 +1854,7 @@ const performAdvancedSearch = async () => {
       if (p.author && p.author.trim()) params.author = p.author.trim()
       if (p.isbn && p.isbn.trim()) params.isbn = p.isbn.trim()
       if (p.asin && p.asin.trim()) params.asin = p.asin.trim()
+      if (p.narrator && p.narrator.trim()) params.narrator = p.narrator.trim()
       params.region = searchLanguage.value
       if (languageFilter) params.language = languageFilter
 

--- a/listenarr.api/Features/Search/StructuredSearchWorkflow.cs
+++ b/listenarr.api/Features/Search/StructuredSearchWorkflow.cs
@@ -111,9 +111,10 @@ namespace Listenarr.Api.Features.Search
                 && string.IsNullOrWhiteSpace(req.Query)
                 && string.IsNullOrWhiteSpace(req.Isbn)
                 && string.IsNullOrWhiteSpace(req.Asin)
-                && string.IsNullOrWhiteSpace(req.Series))
+                && string.IsNullOrWhiteSpace(req.Series)
+                && string.IsNullOrWhiteSpace(req.Narrator))
             {
-                return StructuredSearchWorkflowResult.BadRequest("At least one advanced search parameter (title, author, isbn, asin, series, or query) is required");
+                return StructuredSearchWorkflowResult.BadRequest("At least one advanced search parameter (title, author, narrator, isbn, asin, series, or query) is required");
             }
 
             LogAdvancedRequest(req, region, language);
@@ -128,6 +129,12 @@ namespace Listenarr.Api.Features.Search
             if (seriesResult != null)
             {
                 return seriesResult;
+            }
+
+            var narratorResult = await TryExecuteNarratorSearchAsync(req, region, language, httpContext);
+            if (narratorResult != null)
+            {
+                return narratorResult;
             }
 
             var query = ComposeAdvancedQuery(req);
@@ -329,6 +336,80 @@ namespace Listenarr.Api.Features.Search
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Narrator searches go straight to Audible's narrator field rather than through
+        /// ComposeAdvancedQuery. A composed "NARRATOR:name" string is sent to the provider as
+        /// keywords, where the prefix becomes a literal search token and matches nothing.
+        /// </summary>
+        private async Task<StructuredSearchWorkflowResult?> TryExecuteNarratorSearchAsync(
+            SearchRequest req,
+            string region,
+            string? language,
+            HttpContext httpContext)
+        {
+            if (string.IsNullOrWhiteSpace(req.Narrator))
+            {
+                return null;
+            }
+
+            // Author remains the more selective field, so leave those requests on the
+            // existing path rather than narrowing them to the narrator endpoint.
+            if (!string.IsNullOrWhiteSpace(req.Author))
+            {
+                return null;
+            }
+
+            try
+            {
+                var limit = req.Pagination != null && req.Pagination.Limit > 0
+                    ? Math.Clamp(req.Pagination.Limit, 1, 1000)
+                    : 50;
+                var page = req.Pagination != null && req.Pagination.Page > 0 ? req.Pagination.Page : 1;
+
+                var response = await _audibleService.SearchByNarratorAsync(
+                    req.Narrator.Trim(),
+                    req.Title,
+                    page,
+                    limit,
+                    region,
+                    language);
+
+                var results = response?.Results ?? new List<AudibleSearchResult>();
+                if (results.Count == 0)
+                {
+                    _logger.LogInformation(
+                        "Narrator search for '{Narrator}' returned no results; falling back to unified search",
+                        LogRedaction.SanitizeText(req.Narrator));
+                    return null;
+                }
+
+                // Map through the same converter the series branch uses so the client receives
+                // an identically shaped result regardless of which branch answered.
+                var mapped = new List<object>();
+                foreach (var book in results)
+                {
+                    try
+                    {
+                        mapped.Add(await _responseMapper.MapAudibleSearchResultToOutputAsync(book, region, httpContext));
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+                    {
+                        _logger.LogWarning(ex, "Failed converting narrator result to output for ASIN {Asin}", book.Asin);
+                    }
+                }
+
+                return mapped.Count > 0 ? StructuredSearchWorkflowResult.Ok(mapped) : null;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Narrator search failed for '{Narrator}'; falling back to unified search",
+                    LogRedaction.SanitizeText(req.Narrator));
+                return null;
+            }
         }
 
         private string ComposeAdvancedQuery(SearchRequest req)

--- a/listenarr.application/Metadata/Audible/AudibleProductSearchWorkflow.cs
+++ b/listenarr.application/Metadata/Audible/AudibleProductSearchWorkflow.cs
@@ -37,6 +37,49 @@ namespace Listenarr.Application.Metadata.Audible
             _logger = logger;
         }
 
+        /// <summary>
+        /// Search by narrator using Audible's own narrator field.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately not routed through the keyword composer: a narrator name sent as
+        /// free-text keywords matches the odd title that mentions the name and misses the
+        /// catalogue the narrator actually read.
+        /// </remarks>
+        public async Task<AudibleSearchResponse?> SearchByNarratorAsync(
+            string narrator,
+            string? title,
+            int page,
+            int limit,
+            string region,
+            string? language)
+        {
+            var normalizedNarrator = narrator?.Trim();
+            if (string.IsNullOrWhiteSpace(normalizedNarrator))
+            {
+                return new AudibleSearchResponse
+                {
+                    Results = new List<AudibleSearchResult>(),
+                    TotalResults = 0
+                };
+            }
+
+            var normalizedTitle = string.IsNullOrWhiteSpace(title) ? null : title.Trim();
+
+            var response = await SearchProductsDirectAsync(
+                query: null,
+                title: normalizedTitle,
+                author: null,
+                narrator: normalizedNarrator,
+                publisher: null,
+                page: page,
+                limit: limit,
+                region: region,
+                language: language,
+                sortBy: "Relevance");
+
+            return ToSearchResponse(response);
+        }
+
         public async Task<AudibleSearchResponse?> SearchByTitleAsync(string title, int page, int limit, string region, string? language)
         {
             var normalizedTitle = title?.Trim();

--- a/listenarr.application/Metadata/Audible/AudibleService.cs
+++ b/listenarr.application/Metadata/Audible/AudibleService.cs
@@ -107,6 +107,11 @@ namespace Listenarr.Application.Metadata.Audible
             return await _productSearchWorkflow.SearchByTitleAsync(title, page, limit, region, language);
         }
 
+        public virtual async Task<AudibleSearchResponse?> SearchByNarratorAsync(string narrator, string? title = null, int page = 1, int limit = 50, string region = "us", string? language = null)
+        {
+            return await _productSearchWorkflow.SearchByNarratorAsync(narrator, title, page, limit, region, language);
+        }
+
         public virtual async Task<AudibleSearchResponse?> SearchByTitleAndAuthorAsync(string title, string author, int page = 1, int limit = 50, string region = "us", string? language = null)
         {
             // For advanced title+author searches, prefer the author lookup + /author/books/[ASIN] flow

--- a/listenarr.application/Search/Core/SearchRequest.cs
+++ b/listenarr.application/Search/Core/SearchRequest.cs
@@ -43,6 +43,8 @@ namespace Listenarr.Application.Search.Core
         public string? Isbn { get; set; }
         public string? Series { get; set; }
 
+        public string? Narrator { get; set; }
+
         public Pagination? Pagination { get; set; } = new Pagination();
 
         public string Region { get; set; } = "us";

--- a/tests/Features/Api/Features/Search/SearchControllerUnifiedTests.cs
+++ b/tests/Features/Api/Features/Search/SearchControllerUnifiedTests.cs
@@ -682,6 +682,58 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             Assert.Equal(System.Text.Json.JsonValueKind.Array, arr.ValueKind);
             Assert.True(arr.GetArrayLength() > 0, "Series-only search should return at least one book");
         }
+        [Fact]
+        [Trait("Method", "AdvancedSearch")]
+        public async Task AdvancedSearch_Narrator_UsesTheNarratorFieldNotTheKeywordComposer()
+        {
+            var stubAudible = new StubAudibleService
+            {
+                NarratorResponseToReturn = new AudibleSearchResponse
+                {
+                    Results = new List<AudibleSearchResult>
+                    {
+                        new AudibleSearchResultBuilder().WithAsin("NARR01").WithTitle("Mythos").Build()
+                    },
+                    TotalResults = 1
+                }
+            };
+            var controller = CreateController(audibleService: stubAudible);
+
+            var req = new SearchRequest
+            {
+                Mode = SearchMode.Advanced,
+                Narrator = "Stephen Fry",
+                Pagination = new Pagination { Page = 1, Limit = 10 }
+            };
+            await controller.Search(System.Text.Json.JsonSerializer.SerializeToElement(req));
+
+            // Routed to Audible's narrator field. Going through ComposeAdvancedQuery would send
+            // "NARRATOR:Stephen Fry" as keywords, where the prefix matches nothing.
+            Assert.Equal("SearchByNarratorAsync", stubAudible.LastMethod);
+            Assert.Equal("Stephen Fry", stubAudible.LastNarrator);
+        }
+
+        [Fact]
+        [Trait("Method", "AdvancedSearch")]
+        public async Task AdvancedSearch_NarratorWithAuthor_LeavesTheRequestOnTheAuthorPath()
+        {
+            var stubAudible = new StubAudibleService();
+            var controller = CreateController(audibleService: stubAudible);
+
+            var req = new SearchRequest
+            {
+                Mode = SearchMode.Advanced,
+                Narrator = "Stephen Fry",
+                Author = "J.K. Rowling",
+                Pagination = new Pagination { Page = 1, Limit = 10 }
+            };
+            await controller.Search(System.Text.Json.JsonSerializer.SerializeToElement(req));
+
+            // Author is the more selective field; narrowing to the narrator endpoint would
+            // discard it entirely.
+            Assert.NotEqual("SearchByNarratorAsync", stubAudible.LastMethod);
+        }
+
     }
 
     internal class StubAudibleService : AudibleService
@@ -709,6 +761,18 @@ namespace Listenarr.Tests.Features.Api.Features.Search
             LastPage = page;
             LastLimit = limit;
             return Task.FromResult(ResponseToReturn);
+        }
+
+        public AudibleSearchResponse? NarratorResponseToReturn { get; set; }
+
+        public string? LastNarrator { get; set; }
+
+        public override Task<AudibleSearchResponse?> SearchByNarratorAsync(string narrator, string? title = null, int page = 1, int limit = 50, string region = "us", string? language = null)
+        {
+            LastMethod = "SearchByNarratorAsync";
+            LastNarrator = narrator;
+            LastTitle = title;
+            return Task.FromResult(NarratorResponseToReturn);
         }
 
         public override Task<object?> SearchSeriesByNameAsync(string name, string region = "us")


### PR DESCRIPTION
Adds a **Narrator** field to advanced search, routed to Audible's own narrator parameter.

The provider layer already accepted a narrator argument and threaded it to `parameters["narrator"]` — every call site passed `null`. The missing pieces were a field on `SearchRequest`, a dispatch branch, and a UI input.

**Deliberately not done by adding `NARRATOR:` to `ComposeAdvancedQuery`.** That composes a string handed to the keyword search, where the prefix becomes a literal token and matches nothing. `TryExecuteNarratorSearchAsync` mirrors the existing series branch instead, calling the narrator endpoint directly and falling back to unified search when it returns nothing.

A request carrying both author and narrator stays on the author path — author is more selective, and narrowing to the narrator endpoint would discard it. Both behaviours have tests.

Also fixes `resetAdvancedSearch`, which rebuilds the params object field by field and would otherwise leave a stale narrator behind.

Verified against a live instance:
- `Stephen Fry` → Sherlock Holmes, Mythos, Odyssey, Harry Potter — his catalogue, not titles mentioning his name
- `Jim Dale` → his Harry Potter recordings