### PR TITLE
feat(ui): make the monitored-state pill toggle monitoring

### DIFF
--- a/fe/src/components/base/Pill.vue
+++ b/fe/src/components/base/Pill.vue
@@ -59,17 +59,39 @@ interface Props {
   variant?: VariantType
   size?: 'small' | 'medium' | 'large'
   outlined?: boolean
+  /**
+   * Render as a button so the pill can toggle the state it displays.
+   * Defaults to false, keeping the plain span for read-only pills.
+   */
+  interactive?: boolean
+  disabled?: boolean
 }
 
 withDefaults(defineProps<Props>(), {
   variant: 'default',
   size: 'medium',
   outlined: false,
+  interactive: false,
+  disabled: false,
 })
+
+// Declared explicitly rather than relying on attribute fallthrough: the template
+// has v-if/v-else roots, so binding the listener here keeps the behaviour obvious
+// and stops the same handler also arriving as a fallthrough attribute.
+const emit = defineEmits<{ click: [MouseEvent] }>()
 </script>
 
 <template>
-  <span :class="['pill', `pill-${variant}`, `pill-${size}`, { outlined }]">
+  <button
+    v-if="interactive"
+    type="button"
+    :disabled="disabled"
+    :class="['pill', `pill-${variant}`, `pill-${size}`, { outlined, interactive }]"
+    @click="emit('click', $event)"
+  >
+    <slot />
+  </button>
+  <span v-else :class="['pill', `pill-${variant}`, `pill-${size}`, { outlined }]">
     <slot />
   </span>
 </template>
@@ -84,6 +106,30 @@ withDefaults(defineProps<Props>(), {
   white-space: nowrap;
   transition: all 0.2s;
   border: 1px solid transparent;
+}
+
+/* Interactive pills render as a button; reset the UA styles the span never had. */
+button.pill {
+  font: inherit;
+  color: inherit;
+}
+
+.pill.interactive {
+  cursor: pointer;
+}
+
+.pill.interactive:hover:not(:disabled) {
+  filter: brightness(1.15);
+}
+
+.pill.interactive:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.pill.interactive:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
 }
 
 /* Size variants */

--- a/fe/src/views/library/CollectionView.vue
+++ b/fe/src/views/library/CollectionView.vue
@@ -50,8 +50,17 @@
           </div>
 
           <div class="status-badges author-hero-badges">
-            <Pill :variant="isCurrentAuthorMonitored ? 'primary' : 'default'">
-              <component :is="isCurrentAuthorMonitored ? PhEye : PhEyeSlash" />
+            <Pill
+              interactive
+              :variant="isCurrentAuthorMonitored ? 'primary' : 'default'"
+              :disabled="authorMonitoringBusy || authorMetadataRefreshBusy"
+              :title="
+                isCurrentAuthorMonitored ? 'Stop monitoring this author' : 'Monitor this author'
+              "
+              @click="toggleAuthorMonitoring"
+            >
+              <PhArrowClockwise v-if="authorMonitoringBusy" class="spin-icon" />
+              <component v-else :is="isCurrentAuthorMonitored ? PhEye : PhEyeSlash" />
               {{ isCurrentAuthorMonitored ? 'Monitoring Author' : 'Not Monitored' }}
             </Pill>
             <Pill variant="success"> {{ authorLibraryCount }} in library </Pill>
@@ -167,8 +176,17 @@
           </div>
 
           <div class="status-badges author-hero-badges">
-            <Pill :variant="isCurrentSeriesMonitored ? 'primary' : 'default'">
-              <component :is="isCurrentSeriesMonitored ? PhEye : PhEyeSlash" />
+            <Pill
+              interactive
+              :variant="isCurrentSeriesMonitored ? 'primary' : 'default'"
+              :disabled="seriesMonitoringBusy || seriesMetadataRefreshBusy"
+              :title="
+                isCurrentSeriesMonitored ? 'Stop monitoring this series' : 'Monitor this series'
+              "
+              @click="toggleSeriesMonitoring"
+            >
+              <PhArrowClockwise v-if="seriesMonitoringBusy" class="spin-icon" />
+              <component v-else :is="isCurrentSeriesMonitored ? PhEye : PhEyeSlash" />
               {{ isCurrentSeriesMonitored ? 'Monitoring Series' : 'Not Monitored' }}
             </Pill>
             <Pill variant="success"> {{ seriesLibraryCount }} in library </Pill>


### PR DESCRIPTION
On the author and series collection pages, the **"Monitoring Author" / "Not Monitored" pill sits in the hero where people look, but is inert.** The control that actually toggles is a toolbar button — measured at `y: 669` on a 1200px-wide window, below the fold behind the entire hero section. The page reads as having no way to monitor.

`Pill` gains an optional `interactive` prop that renders a `<button>` instead of a `<span>`, defaulting to `false` so the six existing read-only usages are unchanged.

The `click` emit is declared explicitly rather than left to attribute fallthrough, since the template now has `v-if`/`v-else` roots.

Verified in a browser:

| Step | Result |
|---|---|
| Renders | `<BUTTON>`, `cursor: pointer`, `y: 259` — above the fold |
| Click | `POST /api/v1/authors/monitoring` fired |
| Busy | pill disabled during the request |
| Complete | label → "Monitoring Author", variant → `pill-primary` |
| Click again | back to "Not Monitored" |

No Vue fallthrough warning in the console.