### PR TITLE
fix(metadata): order series positions with an invariant parse

### DIFF
--- a/listenarr.application/Metadata/Audible/AudibleSeriesWorkflow.cs
+++ b/listenarr.application/Metadata/Audible/AudibleSeriesWorkflow.cs
@@ -337,9 +337,22 @@ namespace Listenarr.Application.Metadata.Audible
             return GetString(product, "cover_art_url");
         }
 
-        private static decimal ParseSeriesPosition(string? rawPosition)
+        /// <summary>
+        /// Sort key for a series position. Positions come from Audible's `sequence`/`sort`
+        /// field as a string that always uses '.' as the decimal separator, so the parse is
+        /// invariant: under a server culture where '.' is the group separator, "1.5" would
+        /// otherwise read as 15 and a novella would sort after book 10.
+        /// </summary>
+        /// <remarks>
+        /// A position that is not a decimal at all, such as the "1-4" of an omnibus, still
+        /// sorts last. Internal rather than private so the culture behaviour can be asserted
+        /// directly.
+        /// </remarks>
+        internal static decimal ParseSeriesPosition(string? rawPosition)
         {
-            return decimal.TryParse(rawPosition, out var parsed) ? parsed : decimal.MaxValue;
+            return decimal.TryParse(rawPosition, NumberStyles.Number, CultureInfo.InvariantCulture, out var parsed)
+                ? parsed
+                : decimal.MaxValue;
         }
     }
 }

--- a/listenarr.application/Metadata/Audible/AudibleSeriesWorkflow.cs
+++ b/listenarr.application/Metadata/Audible/AudibleSeriesWorkflow.cs
@@ -347,10 +347,15 @@ namespace Listenarr.Application.Metadata.Audible
         /// A position that is not a decimal at all, such as the "1-4" of an omnibus, still
         /// sorts last. Internal rather than private so the culture behaviour can be asserted
         /// directly.
+        ///
+        /// NumberStyles.Float rather than Number: Number carries AllowThousands, and the
+        /// invariant group separator is ',', so under Number a position written "1,5" parses
+        /// as 15 and sorts after book 10 by the same route this method exists to close.
+        /// Float rejects it, which sends it to the end with the other unorderable positions.
         /// </remarks>
         internal static decimal ParseSeriesPosition(string? rawPosition)
         {
-            return decimal.TryParse(rawPosition, NumberStyles.Number, CultureInfo.InvariantCulture, out var parsed)
+            return decimal.TryParse(rawPosition, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
                 ? parsed
                 : decimal.MaxValue;
         }

--- a/tests/Features/Application/Metadata/SeriesPositionOrderingTests.cs
+++ b/tests/Features/Application/Metadata/SeriesPositionOrderingTests.cs
@@ -16,6 +16,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 using System.Globalization;
+using Listenarr.Tests.Common;
 
 namespace Listenarr.Tests.Features.Application.Metadata
 {
@@ -31,7 +32,9 @@ namespace Listenarr.Tests.Features.Application.Metadata
     ///   de-DE: '.' is the GROUP separator, so "1.5" parsed as 15 and sorted after book 10.
     ///   fr-FR: "1.5" did not parse at all, fell to decimal.MaxValue, and sorted last.
     /// </summary>
-    public class SeriesPositionOrderingTests
+    [Trait("Name", "SeriesPositionOrderingTests")]
+    [Trait("Category", "Unit")]
+    public class SeriesPositionOrderingTests : BaseTests
     {
         private static void InCulture(string culture, Action body)
         {

--- a/tests/Features/Application/Metadata/SeriesPositionOrderingTests.cs
+++ b/tests/Features/Application/Metadata/SeriesPositionOrderingTests.cs
@@ -1,0 +1,99 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Globalization;
+
+namespace Listenarr.Tests.Features.Application.Metadata
+{
+    /// <summary>
+    /// A series position arrives from Audible's `sequence`/`sort` field as a string that always
+    /// uses '.' as the decimal separator. It is sort data, not display text, so it must parse the
+    /// same way on every server.
+    ///
+    /// A default container runs under the invariant culture and was never affected. The bug shows
+    /// up once the process has a real culture, which happens when LANG or LC_ALL is set, and on a
+    /// desktop install that inherits the operating system's locale:
+    ///
+    ///   de-DE: '.' is the GROUP separator, so "1.5" parsed as 15 and sorted after book 10.
+    ///   fr-FR: "1.5" did not parse at all, fell to decimal.MaxValue, and sorted last.
+    /// </summary>
+    public class SeriesPositionOrderingTests
+    {
+        private static void InCulture(string culture, Action body)
+        {
+            var original = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo(culture);
+                body();
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = original;
+            }
+        }
+
+        [Theory]
+        [InlineData("")]        // invariant: what a container with no LANG gets
+        [InlineData("en-US")]
+        [InlineData("de-DE")]   // '.' is the group separator
+        [InlineData("fr-FR")]   // ',' is the decimal separator, '.' parses as nothing
+        public void DecimalPosition_ParsesTheSameUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+                Assert.Equal(1.5m, AudibleSeriesWorkflow.ParseSeriesPosition("1.5")));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("en-US")]
+        [InlineData("de-DE")]
+        [InlineData("fr-FR")]
+        public void SeriesOrder_IsTheSameUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                string[] positions = ["1", "1.5", "2", "10", "1-4"];
+
+                var ordered = positions
+                    .OrderBy(AudibleSeriesWorkflow.ParseSeriesPosition)
+                    .ToArray();
+
+                Assert.Equal(["1", "1.5", "2", "10", "1-4"], ordered);
+            });
+        }
+
+        [Fact]
+        public void WholeNumbersAndZero_Parse()
+        {
+            // "0" is a real position: a prequel sits at position 0 of its series.
+            Assert.Equal(0m, AudibleSeriesWorkflow.ParseSeriesPosition("0"));
+            Assert.Equal(10m, AudibleSeriesWorkflow.ParseSeriesPosition("10"));
+        }
+
+        [Theory]
+        [InlineData("1-4")]     // an omnibus covering books 1 to 4
+        [InlineData("")]
+        [InlineData(null)]
+        public void NonDecimalPosition_StillSortsLast(string? position)
+        {
+            // Deliberate and unchanged: a position that is not a decimal cannot be ordered
+            // numerically, so it goes to the end rather than to the front.
+            Assert.Equal(decimal.MaxValue, AudibleSeriesWorkflow.ParseSeriesPosition(position));
+        }
+    }
+}

--- a/tests/Features/Application/Metadata/SeriesPositionOrderingTests.cs
+++ b/tests/Features/Application/Metadata/SeriesPositionOrderingTests.cs
@@ -98,5 +98,30 @@ namespace Listenarr.Tests.Features.Application.Metadata
             // numerically, so it goes to the end rather than to the front.
             Assert.Equal(decimal.MaxValue, AudibleSeriesWorkflow.ParseSeriesPosition(position));
         }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("en-US")]
+        [InlineData("de-DE")]
+        [InlineData("fr-FR")]
+        public void CommaFormattedPosition_FailsRatherThanChangingMagnitude(string culture)
+        {
+            // NumberStyles.Number carries AllowThousands and the invariant group separator is
+            // ',', so under Number this parses as 15 and a novella sorts after book 10: the
+            // same wrong order the invariant pin exists to prevent, reached a different way.
+            // Float rejects it, so it joins the unorderable positions at the end.
+            InCulture(culture, () =>
+            {
+                Assert.Equal(decimal.MaxValue, AudibleSeriesWorkflow.ParseSeriesPosition("1,5"));
+
+                string[] positions = ["1", "1,5", "2", "10"];
+
+                var ordered = positions
+                    .OrderBy(AudibleSeriesWorkflow.ParseSeriesPosition)
+                    .ToArray();
+
+                Assert.Equal(["1", "2", "10", "1,5"], ordered);
+            });
+        }
     }
 }


### PR DESCRIPTION
Fixes #795.

A series position arrives from Audible's `sequence`/`sort` field as a string that always uses `.` as the decimal separator. `ParseSeriesPosition` parsed it with the ambient culture, so on a server whose culture treats `.` as the group separator the value was read as a different number.

```
de-DE   "1.5" parses as 15          novella sorts after book 10
fr-FR   "1.5" does not parse at all  falls to decimal.MaxValue, sorts last
```

A default container runs under the invariant culture and was never affected, which is why this is easy to miss. It shows up once the process has a real culture, which happens when `LANG` or `LC_ALL` is set and on a desktop install that inherits the operating system's locale.

The parse is now pinned to `CultureInfo.InvariantCulture` with `NumberStyles.Number`. Sort data, parsed the same way everywhere.

## The tiebreak question from the issue, deliberately not answered here

I asked on the issue what should happen to a position that is not a decimal at all, the `1-4` of an omnibus. This PR does not change that: those still sort last, exactly as they do today.

That is not me deciding the question. It is me keeping this change to the part that is unambiguously a bug, so the ordering of omnibus entries stays whatever you decide it should be, separately. If you would rather they sorted first, or kept their catalogue order, that is a different change and I am happy to write it once you say which.

## Tests

`SeriesPositionOrderingTests`, thirteen cases. The parse is asserted directly under `de-DE`, `fr-FR` and the invariant culture, and the ordering is asserted end to end over a mixed series.

Control, with only the parse reverted to the culture-dependent form and everything else left in place:

```
Expected: 1,5                       Actual: 15
Expected: 1,5                       Actual: 79228162514264337593543950335
Expected: ["1", "1.5", "2", "10", "1-4"]
Actual:   ["1", "2", "10", "1.5", "1-4"]
```

That last line is the reported symptom: the novella lands after book 10.

`ParseSeriesPosition` goes from `private` to `internal` so the culture behaviour can be asserted on the method rather than inferred from the ordering. That accessibility change is why a plain revert of the whole commit will not compile; the control above reverts only the parse.

Full suite 3051 passed, 0 failed, 127 skipped, on canary `d25b3e11` (1.3.3).

One housekeeping commit alongside: this branch predated `TestClasses_FollowRepositoryConventions`, so the test class needed `BaseTests` and its traits to satisfy the architecture suite.
