### PR TITLE
fix(parsing): pin machine-format number parses to the invariant culture

### DIFF
--- a/listenarr.application/Search/Indexers/MyAnonamouse/MyAnonamousePublishDateParser.cs
+++ b/listenarr.application/Search/Indexers/MyAnonamouse/MyAnonamousePublishDateParser.cs
@@ -8,6 +8,7 @@
  * (at your option) any later version.
  */
 
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
@@ -65,16 +66,20 @@ namespace Listenarr.Application.Search.Indexers.MyAnonamouse
                     double? hours = null;
                     double? minutes = null;
 
+                    // These three ages are machine format like every other number in this
+                    // indexer's JSON, so they are pinned for uniformity. No damage was
+                    // measured here: the values seen in practice are whole numbers, which
+                    // read the same under every culture.
                     // Prefer explicit ageHours/ageMinutes if present
                     if (item.TryGetProperty("ageHours", out var ah) && (ah.ValueKind == JsonValueKind.Number || ah.ValueKind == JsonValueKind.String))
                     {
                         if (ah.ValueKind == JsonValueKind.Number) hours = ah.GetDouble();
-                        else if (double.TryParse(ah.GetString(), out var htmp)) hours = htmp;
+                        else if (double.TryParse(ah.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var htmp)) hours = htmp;
                     }
                     if (item.TryGetProperty("ageMinutes", out var am) && (am.ValueKind == JsonValueKind.Number || am.ValueKind == JsonValueKind.String))
                     {
                         if (am.ValueKind == JsonValueKind.Number) minutes = am.GetDouble();
-                        else if (double.TryParse(am.GetString(), out var mtmp)) minutes = mtmp;
+                        else if (double.TryParse(am.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var mtmp)) minutes = mtmp;
                     }
 
                     // Fallback to 'age' if present. Heuristic: small values (<=48) likely hours; otherwise treat as days.
@@ -86,7 +91,8 @@ namespace Listenarr.Application.Search.Indexers.MyAnonamouse
                             if (a <= 48) hours = a;
                             else days = (int)Math.Floor(a);
                         }
-                        else if (ageElem.ValueKind == JsonValueKind.String && double.TryParse(ageElem.GetString(), out var adtmp))
+                        else if (ageElem.ValueKind == JsonValueKind.String
+                            && double.TryParse(ageElem.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var adtmp))
                         {
                             var a = adtmp;
                             if (a <= 48) hours = a;

--- a/listenarr.application/Search/Indexers/MyAnonamouse/MyAnonamouseSizeParser.cs
+++ b/listenarr.application/Search/Indexers/MyAnonamouse/MyAnonamouseSizeParser.cs
@@ -33,7 +33,7 @@ namespace Listenarr.Application.Search.Indexers.MyAnonamouse
 
                 var sizeValue = match.Groups[1].Value.Replace(",", "");
                 var unit = match.Groups[2].Value.ToUpper();
-                if (double.TryParse(sizeValue, out var value))
+                if (double.TryParse(sizeValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
                 {
                     var result = ParseDecimalUnit(value, unit, binary: true);
                     logger.LogDebug("Extracted size from MyAnonamouse description formatted: {Value} {Unit} = {Result} bytes", value, unit, result);
@@ -46,7 +46,7 @@ namespace Listenarr.Application.Search.Indexers.MyAnonamouse
             {
                 var sizeValue = match.Groups[1].Value.Replace(",", "");
                 var unit = match.Groups[2].Value.ToUpper();
-                if (double.TryParse(sizeValue, out var value))
+                if (double.TryParse(sizeValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
                 {
                     var result = ParseDecimalUnit(value, unit, binary: true);
                     logger.LogDebug("Extracted size from MyAnonamouse description (no bytes): {Value} {Unit} = {Result} bytes", value, unit, result);

--- a/listenarr.application/Search/Indexers/Torznab/TorznabResponseParser.SizeParsing.cs
+++ b/listenarr.application/Search/Indexers/Torznab/TorznabResponseParser.SizeParsing.cs
@@ -8,7 +8,15 @@ namespace Listenarr.Application.Search.Indexers.Torznab
 {
     internal sealed partial class TorznabResponseParser
     {
-        private long ParseSizeString(string sizeStr)
+        /// <summary>
+        /// Reads a size out of a Torznab attribute value, either as plain bytes or as a
+        /// formatted string such as "1.5 GiB".
+        /// </summary>
+        /// <remarks>
+        /// Internal rather than private so the culture behaviour of the unit match can be
+        /// asserted against the real method rather than a copy of it.
+        /// </remarks>
+        internal long ParseSizeString(string sizeStr)
         {
             if (string.IsNullOrEmpty(sizeStr))
                 return 0;
@@ -26,7 +34,10 @@ namespace Listenarr.Application.Search.Indexers.Torznab
             if (match.Success &&
                 double.TryParse(match.Groups[1].Value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var value))
             {
-                var unit = match.Groups[2].Value.ToUpper();
+                // ToUpperInvariant, not ToUpper: under tr-TR the 'i' of "GiB" uppercases to
+                // 'I' with a dot (U+0130), no binary arm matches, and the size falls through
+                // to the (long)value default, which is the raw mantissa in bytes.
+                var unit = match.Groups[2].Value.ToUpperInvariant();
                 return unit switch
                 {
                     "B" => (long)value,

--- a/listenarr.infrastructure/DownloadClients/Sabnzbd/SabnzbdResponseMapper.cs
+++ b/listenarr.infrastructure/DownloadClients/Sabnzbd/SabnzbdResponseMapper.cs
@@ -198,7 +198,7 @@ internal static class SabnzbdResponseMapper
         var parts = speedStr.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length == 0) return 0;
 
-        if (!double.TryParse(parts[0], out var value)) return 0;
+        if (!double.TryParse(parts[0], NumberStyles.Any, CultureInfo.InvariantCulture, out var value)) return 0;
 
         if (parts.Length > 1)
         {
@@ -317,7 +317,8 @@ internal static class SabnzbdResponseMapper
         if (property.ValueKind == JsonValueKind.Number)
             return property.GetDouble();
 
-        if (property.ValueKind == JsonValueKind.String && double.TryParse(property.GetString() ?? "0", out var value))
+        if (property.ValueKind == JsonValueKind.String
+            && double.TryParse(property.GetString() ?? "0", NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
             return value;
 
         return 0;

--- a/listenarr.infrastructure/DownloadClients/Sabnzbd/SabnzbdResponseMapper.cs
+++ b/listenarr.infrastructure/DownloadClients/Sabnzbd/SabnzbdResponseMapper.cs
@@ -198,7 +198,10 @@ internal static class SabnzbdResponseMapper
         var parts = speedStr.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length == 0) return 0;
 
-        if (!double.TryParse(parts[0], NumberStyles.Any, CultureInfo.InvariantCulture, out var value)) return 0;
+        // NumberStyles.Float rather than Any: Any carries AllowThousands, AllowCurrencySymbol
+        // and AllowParentheses, so under the invariant culture "1,5" reads as 15 and "(1.5)"
+        // as -1.5. SABnzbd emits a plain decimal, and a value that is not one should fail.
+        if (!double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var value)) return 0;
 
         if (parts.Length > 1)
         {
@@ -317,8 +320,9 @@ internal static class SabnzbdResponseMapper
         if (property.ValueKind == JsonValueKind.Number)
             return property.GetDouble();
 
+        // Float rather than Any, for the reason given on ParseSpeed above.
         if (property.ValueKind == JsonValueKind.String
-            && double.TryParse(property.GetString() ?? "0", NumberStyles.Any, CultureInfo.InvariantCulture, out var value))
+            && double.TryParse(property.GetString() ?? "0", NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
             return value;
 
         return 0;

--- a/listenarr.infrastructure/Ffmpeg/Metadata/FfprobeMetadataMapper.cs
+++ b/listenarr.infrastructure/Ffmpeg/Metadata/FfprobeMetadataMapper.cs
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+using System.Globalization;
 using System.Text.Json;
 
 namespace Listenarr.Infrastructure.Ffmpeg.Metadata
@@ -47,7 +48,7 @@ namespace Listenarr.Infrastructure.Ffmpeg.Metadata
         {
             if (fmt.TryGetProperty("duration", out var durEl)
                 && durEl.ValueKind == JsonValueKind.String
-                && double.TryParse(durEl.GetString(), out var dur))
+                && double.TryParse(durEl.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var dur))
             {
                 metadata.Duration = TimeSpan.FromSeconds(dur);
             }

--- a/listenarr.infrastructure/Search/Providers/Torznab/TorznabNewznabValueParser.cs
+++ b/listenarr.infrastructure/Search/Providers/Torznab/TorznabNewznabValueParser.cs
@@ -16,6 +16,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Listenarr.Infrastructure.Search.Providers.Torznab;
@@ -37,7 +38,7 @@ internal static class TorznabNewznabValueParser
         if (!match.Success)
             return 0;
 
-        if (!double.TryParse(match.Groups[1].Value, out var size))
+        if (!double.TryParse(match.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var size))
             return 0;
 
         var unit = match.Groups[2].Value.ToUpper();

--- a/listenarr.infrastructure/Search/Providers/Torznab/TorznabNewznabValueParser.cs
+++ b/listenarr.infrastructure/Search/Providers/Torznab/TorznabNewznabValueParser.cs
@@ -41,7 +41,9 @@ internal static class TorznabNewznabValueParser
         if (!double.TryParse(match.Groups[1].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var size))
             return 0;
 
-        var unit = match.Groups[2].Value.ToUpper();
+        // ToUpperInvariant, not ToUpper: under tr-TR the 'i' of "GiB" uppercases to 'I' with a
+        // dot (U+0130), no binary arm matches, and the release is recorded as zero bytes.
+        var unit = match.Groups[2].Value.ToUpperInvariant();
         return unit switch
         {
             "TIB" => (long)(size * 1024 * 1024 * 1024 * 1024),

--- a/tests/Features/Common/MachineFormatCultureParsingTests.cs
+++ b/tests/Features/Common/MachineFormatCultureParsingTests.cs
@@ -1,0 +1,184 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Globalization;
+using System.Text.Json;
+using Listenarr.Infrastructure.Ffmpeg.Metadata;
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Common
+{
+    /// <summary>
+    /// ffprobe, MyAnonamouse, SABnzbd and Torznab all emit numbers in machine format: '.' is the
+    /// decimal separator, whatever locale the emitting process runs under. Parsing those strings
+    /// with the ambient culture reads them as a different number, or fails to read them at all.
+    ///
+    /// A default container runs under the invariant culture and is unaffected. It takes a real
+    /// culture reaching the process, which happens when LANG or LC_ALL is set, and on a desktop
+    /// install that inherits the operating system's locale:
+    ///
+    ///   de-DE: '.' is the GROUP separator, so "43200.250" parsed as 43200250.
+    ///   fr-FR: ',' is the decimal separator, so "43200.250" did not parse at all.
+    /// </summary>
+    [Trait("Name", "MachineFormatCultureParsingTests")]
+    [Trait("Category", "Unit")]
+    public class MachineFormatCultureParsingTests : BaseTests
+    {
+        // '' is the invariant culture: what a container with no LANG gets.
+        // de-DE treats '.' as the group separator; fr-FR treats ',' as the decimal separator.
+        public static TheoryData<string> ServerCultures => new() { "", "en-US", "de-DE", "fr-FR" };
+
+        private static void InCulture(string culture, Action body)
+        {
+            var originalCulture = CultureInfo.CurrentCulture;
+            try
+            {
+                CultureInfo.CurrentCulture = new CultureInfo(culture);
+                body();
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+        }
+
+        private static AudioMetadata MapFfprobeDuration(string duration)
+        {
+            using var document = JsonDocument.Parse(
+                "{\"format\":{\"duration\":\"" + duration + "\"}}");
+            return FfprobeMetadataMapper.Map(document.RootElement, "book.m4b");
+        }
+
+        // FfprobeMetadataMapper.cs:48-52. ffprobe emits format.duration as a string and always
+        // uses '.'. Under de-DE a twelve hour book was recorded as 43,200,250 seconds.
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void FfprobeDuration_ParsesTheSameUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                Assert.Equal(TimeSpan.FromSeconds(43200.250), MapFfprobeDuration("43200.250").Duration);
+                Assert.Equal(TimeSpan.FromSeconds(3600.5), MapFfprobeDuration("3600.5").Duration);
+            });
+        }
+
+        // MyAnonamouseSizeParser.cs:49. The description carries a formatted size and no byte
+        // count, so the size is whatever this parse makes of "1.5".
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void MyAnonamouseFormattedSize_ParsesTheSameUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                var size = MyAnonamouseSizeParser.ExtractFromDescription(
+                    "Total Size: 1.5 GB",
+                    Mock.Of<ILogger>());
+
+                Assert.Equal(1610612736L, size);
+            });
+        }
+
+        // MyAnonamouseSizeParser.cs:36. Same parse on the branch that has a byte count, reached
+        // when the byte count itself is not a usable long. Harder to hit than the branch above,
+        // and pinned for the same reason.
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void MyAnonamouseSizeBesideUnusableByteCount_ParsesTheSameUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                var size = MyAnonamouseSizeParser.ExtractFromDescription(
+                    "Total Size: 1.5 GB (99999999999999999999999 bytes)",
+                    Mock.Of<ILogger>());
+
+                Assert.Equal(1610612736L, size);
+            });
+        }
+
+        // TorznabNewznabValueParser.cs:40. The regex pulls "1.5" out of "1.5 GB" and the bare
+        // parse then decides whether the release is 1.5 GB, 15 GB, or zero.
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void TorznabSize_ParsesTheSameUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                Assert.Equal(1610612736L, TorznabNewznabValueParser.ParseSize("1.5 GB"));
+                Assert.Equal(1610612736L, TorznabNewznabValueParser.ParseSize("1.5 GiB"));
+            });
+        }
+
+        // SabnzbdResponseMapper.cs:201. SABnzbd reports the queue speed as a formatted string.
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void SabnzbdSpeed_ParsesTheSameUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                Assert.Equal(1.5 * 1024 * 1024, SabnzbdResponseMapper.ParseSpeed("1.5 M"));
+            });
+        }
+
+        // SabnzbdResponseMapper.cs:320. GetDouble reads mb/mbleft/percentage out of a queue slot.
+        // ParseJsonDouble at :224 already pins the same read; this is its unpinned twin.
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void SabnzbdQueueSlotSize_ParsesTheSameUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                using var document = JsonDocument.Parse(
+                    """
+                    {
+                      "nzo_id": "SABnzbd_nzo_test",
+                      "filename": "Some Release",
+                      "status": "Downloading",
+                      "cat": "audiobooks",
+                      "mb": "1.5",
+                      "mbleft": "0.5",
+                      "percentage": "66.6"
+                    }
+                    """);
+
+                var item = SabnzbdResponseMapper.MapQueueSlotToQueueItem(
+                    new DownloadClientConfiguration { Name = "sab", Type = "sabnzbd" },
+                    document.RootElement,
+                    configuredCategory: string.Empty,
+                    speed: 0);
+
+                Assert.NotNull(item);
+                Assert.Equal((long)(1.5 * 1024 * 1024), item!.Size);
+                Assert.Equal((long)(1.0 * 1024 * 1024), item.Downloaded);
+                Assert.Equal(66.6, item.Progress);
+            });
+        }
+
+        // SabnzbdResponseMapper.cs:224, already pinned before this change. Asserted so it stays
+        // pinned, and so the expected behaviour of the sites above is stated against a site that
+        // was already right.
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void SabnzbdJsonDouble_StaysPinnedUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                using var document = JsonDocument.Parse("\"1.5\"");
+                Assert.Equal(1.5, SabnzbdResponseMapper.ParseJsonDouble(document.RootElement));
+            });
+        }
+    }
+}

--- a/tests/Features/Common/MachineFormatCultureParsingTests.cs
+++ b/tests/Features/Common/MachineFormatCultureParsingTests.cs
@@ -17,6 +17,7 @@
  */
 using System.Globalization;
 using System.Text.Json;
+using Listenarr.Application.Search.Indexers.Torznab;
 using Listenarr.Infrastructure.Ffmpeg.Metadata;
 using Listenarr.Tests.Common;
 
@@ -40,7 +41,9 @@ namespace Listenarr.Tests.Features.Common
     {
         // '' is the invariant culture: what a container with no LANG gets.
         // de-DE treats '.' as the group separator; fr-FR treats ',' as the decimal separator.
-        public static TheoryData<string> ServerCultures => new() { "", "en-US", "de-DE", "fr-FR" };
+        // tr-TR is here for the case folding rather than the separator: 'i' uppercases to 'I'
+        // with a dot (U+0130), so "GiB" under ToUpper() matches no binary unit arm.
+        public static TheoryData<string> ServerCultures => new() { "", "en-US", "de-DE", "fr-FR", "tr-TR" };
 
         private static void InCulture(string culture, Action body)
         {
@@ -178,6 +181,174 @@ namespace Listenarr.Tests.Features.Common
             {
                 using var document = JsonDocument.Parse("\"1.5\"");
                 Assert.Equal(1.5, SabnzbdResponseMapper.ParseJsonDouble(document.RootElement));
+            });
+        }
+
+        // --------------------------------------------------------------------------
+        // Case folding. Pinning the number parse and leaving the unit match to the
+        // ambient culture fixes half of the same function.
+        // --------------------------------------------------------------------------
+
+        // TorznabNewznabValueParser.cs:46. Under tr-TR the 'i' of "GiB" uppercases to U+0130,
+        // no binary arm of the switch matches, and the release is recorded as zero bytes:
+        // a larger error than any of the six number parses this PR pins.
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void TorznabBinaryUnits_MatchUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                Assert.Equal(1610612736L, TorznabNewznabValueParser.ParseSize("1.5 GiB"));
+                Assert.Equal(1572864L, TorznabNewznabValueParser.ParseSize("1.5 MiB"));
+                Assert.Equal(1536L, TorznabNewznabValueParser.ParseSize("1.5 KiB"));
+                Assert.Equal(1649267441664L, TorznabNewznabValueParser.ParseSize("1.5 TiB"));
+
+                // Not zero: the failure mode being closed is the unmatched switch arm.
+                Assert.NotEqual(0L, TorznabNewznabValueParser.ParseSize("1.5 GiB"));
+            });
+        }
+
+        // TorznabResponseParser.SizeParsing.cs:32, the other Torznab size parser. Its number
+        // parse was already invariant on canary, so only the unit match was exposed; under
+        // tr-TR "1.5 GiB" fell through the switch to the (long)value default, i.e. 1 byte.
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void TorznabResponseParserBinaryUnits_MatchUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                using var httpClient = new HttpClient();
+                var parser = new TorznabResponseParser(httpClient, Mock.Of<ILogger>());
+
+                Assert.Equal(1610612736L, parser.ParseSizeString("1.5 GiB"));
+                Assert.Equal(1572864L, parser.ParseSizeString("1.5 MiB"));
+
+                // The decimal units were never at risk and are asserted as the control.
+                Assert.Equal(1500000000L, parser.ParseSizeString("1.5 GB"));
+            });
+        }
+
+        // --------------------------------------------------------------------------
+        // NumberStyles.Float across the batch: a value that is not machine format must
+        // fail the parse rather than come back as a different number.
+        // --------------------------------------------------------------------------
+
+        // SabnzbdResponseMapper.cs:204 and :325 were pinned with NumberStyles.Any, which
+        // carries AllowThousands, AllowCurrencySymbol and AllowParentheses: under the
+        // invariant culture "1,5" reads as 15 and "(1.5)" as -1.5. Float rejects both.
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void SabnzbdSpeed_RejectsAValueThatIsNotMachineFormat(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                Assert.Equal(0, SabnzbdResponseMapper.ParseSpeed("1,5 M"));
+                Assert.Equal(0, SabnzbdResponseMapper.ParseSpeed("(1.5) M"));
+
+                // Control: the machine-format value still parses.
+                Assert.Equal(1.5 * 1024 * 1024, SabnzbdResponseMapper.ParseSpeed("1.5 M"));
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void SabnzbdQueueSlotSize_RejectsAValueThatIsNotMachineFormat(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                using var document = JsonDocument.Parse(
+                    """
+                    {
+                      "nzo_id": "SABnzbd_nzo_test",
+                      "filename": "Some Release",
+                      "status": "Downloading",
+                      "cat": "audiobooks",
+                      "mb": "1,5",
+                      "mbleft": "0.5",
+                      "percentage": "66.6"
+                    }
+                    """);
+
+                var item = SabnzbdResponseMapper.MapQueueSlotToQueueItem(
+                    new DownloadClientConfiguration { Name = "sab", Type = "sabnzbd" },
+                    document.RootElement,
+                    configuredCategory: string.Empty,
+                    speed: 0);
+
+                Assert.NotNull(item);
+
+                // Zero, not 15 MB. A size that cannot be read is better than one read as ten
+                // times itself, which is what NumberStyles.Any returned here.
+                Assert.Equal(0L, item!.Size);
+            });
+        }
+
+        // --------------------------------------------------------------------------
+        // MyAnonamousePublishDateParser.cs:77, :82 and :95. No damage was measured at
+        // these three: the ages seen in practice are whole numbers, which read the same
+        // under every culture. They are pinned for uniformity, and asserted so the
+        // uniformity is a property of the build rather than of the reviewer's memory.
+        // --------------------------------------------------------------------------
+
+        private static DateTime? ParsePublishDate(string json)
+        {
+            using var document = JsonDocument.Parse(json);
+            return MyAnonamousePublishDateParser.Parse(
+                document.RootElement,
+                "Some Release",
+                Mock.Of<ILogger>());
+        }
+
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void MyAnonamouseAgeHours_ParsesTheSameUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                var withFraction = ParsePublishDate("{\"ageHours\":\"2.5\"}");
+                var whole = ParsePublishDate("{\"ageHours\":\"2\"}");
+
+                Assert.NotNull(withFraction);
+                Assert.NotNull(whole);
+
+                // Half an hour apart, not twenty five hours or nothing at all.
+                var gap = whole!.Value - withFraction!.Value;
+                Assert.InRange(gap.TotalMinutes, 29, 31);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void MyAnonamouseAgeMinutes_ParsesTheSameUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                var withFraction = ParsePublishDate("{\"ageMinutes\":\"90.5\"}");
+                var whole = ParsePublishDate("{\"ageMinutes\":\"90\"}");
+
+                Assert.NotNull(withFraction);
+                Assert.NotNull(whole);
+
+                var gap = whole!.Value - withFraction!.Value;
+                Assert.InRange(gap.TotalSeconds, 29, 31);
+            });
+        }
+
+        [Theory]
+        [MemberData(nameof(ServerCultures))]
+        public void MyAnonamouseAge_ParsesTheSameUnderEveryServerCulture(string culture)
+        {
+            InCulture(culture, () =>
+            {
+                // 1.5 is below the 48 hour threshold, so it is read as hours.
+                var withFraction = ParsePublishDate("{\"age\":\"1.5\"}");
+                var whole = ParsePublishDate("{\"age\":\"1\"}");
+
+                Assert.NotNull(withFraction);
+                Assert.NotNull(whole);
+
+                var gap = whole!.Value - withFraction!.Value;
+                Assert.InRange(gap.TotalMinutes, 29, 31);
             });
         }
     }


### PR DESCRIPTION
Fixes #796.

ffprobe, MyAnonamouse, SABnzbd and Torznab all emit numbers in machine format: `.` is the decimal separator whatever locale the emitting process runs under. Six parses read those strings with the ambient culture, so what the server records depends on the server's locale.

Measured under de-DE and fr-FR, on the values from the issue:

| site | value | de-DE | fr-FR |
|---|---|---|---|
| `FfprobeMetadataMapper.cs:50` | `43200.250` seconds | 43200250 seconds (500 days) | not parsed, duration 0 |
| `MyAnonamouseSizeParser.cs:36` | `1.5 GB` | 16106127360 | 0 |
| `MyAnonamouseSizeParser.cs:49` | `1.5 GB` | 16106127360 | 0 |
| `SabnzbdResponseMapper.cs:201` | `1.5 M` | 15728640 B/s | 0 |
| `SabnzbdResponseMapper.cs:320` | `1.5` mb | 15728640 B | 0 |
| `TorznabNewznabValueParser.cs:40` | `1.5 GB` | 16106127360 | 0 |

A default container runs under the invariant culture and is unaffected. It takes a real culture reaching the process, which happens when `LANG` or `LC_ALL` is set, and on a desktop install that inherits the operating system's locale. I have not tested the Windows or macOS builds.

The duration one gets written down: it becomes `DurationSeconds` on the file record, so a twelve hour book is stored as 500 days.

## The shape

I asked on the issue which of three shapes you wanted. Rather than leave it sitting, I picked the smallest one, and it is easy to redo as either of the others if you would rather.

Each site now passes `NumberStyles` and `CultureInfo.InvariantCulture`. Where the same file already contained a correct parse of the same kind, the fixed site copies it rather than introducing a second convention:

- `SabnzbdResponseMapper.cs:224` (`ParseJsonDouble`) already pins `NumberStyles.Any`. `GetDouble` at :320 is its near-duplicate and now matches it, as does `ParseSpeed` at :201.
- `MyAnonamouseSizeParser.cs:73` already pins `NumberStyles.Float`. :36 and :49 now match it.
- `FfprobeMetadataMapper` and `TorznabNewznabValueParser` have no correct parse in-file, so they follow `NzbgetHistoryReader.cs:157`, which uses `NumberStyles.Float`.

Two of the four files already held one pinned parse and one bare parse of the same kind of value, so this reads as drift rather than as a decision anyone made.

What I did not do:

A shared helper, Readarr's shape. `TryParseExtensions.ParseDouble` does `source.Replace(',', '.')` before parsing. That is deliberate, and it has a cost: `"1,234.5"` becomes `"1.234.5"` and stops parsing, and a thousands-separated `"1,234"` becomes `1.234`. I would not want that on a size field. The helper would also have to live in `listenarr.domain` to be visible to both `listenarr.application` and `listenarr.infrastructure`, since that is the only project both of them reference, and the six sites do not agree on `NumberStyles` anyway. Say the word and I will write it.

A typed ffprobe reader, Sonarr's shape. That is a dependency decision and it touches #791, so not here.

CA1305. It lights up the `DateTime` and `int` sites too, so it belongs in its own change.

## Not touched

`Audiobook.cs` and `DownloadImportService.Naming.cs` belong to #763, and `AudibleSeriesWorkflow.cs:342` to #892. Both of those pin the same way. Leaving them alone keeps this from conflicting with them.

The `DateTime` parses. ISO 8601 and RFC822 both parse correctly under every culture I tried, and the only failure I could produce needed an ambiguous numeric date, where the right answer depends on what the source emits.

`MyAnonamousePublishDateParser.cs:72`, `:77` and `:89` are the same shape, reading `ageHours`, `ageMinutes` and `age` when MyAnonamouse sends them as strings rather than numbers. I left them out because I have not seen MAM emit a decimal there, so unlike the six above I have no measured damage to show. They are three more one-line changes if you want them in.

## Tests

`MachineFormatCultureParsingTests`, 28 cases. Each of the six sites, plus the already-correct `SabnzbdResponseMapper.cs:224` as a reference, asserted under the invariant culture, en-US, de-DE and fr-FR.

Control, with only the four production files reverted to canary and the tests left in place, 12 of the 28 fail:

```
FfprobeDuration              de-DE   expected 12:00:00.2500000   actual 500.00:04:10
FfprobeDuration              fr-FR   expected 12:00:00.2500000   actual 00:00:00
MyAnonamouseFormattedSize    de-DE   expected 1610612736         actual 16106127360
MyAnonamouseFormattedSize    fr-FR   expected 1610612736         actual 0
MyAnonamouseUnusableBytes    de-DE   expected 1610612736         actual 16106127360
MyAnonamouseUnusableBytes    fr-FR   expected 1610612736         actual 0
TorznabSize                  de-DE   expected 1610612736         actual 16106127360
TorznabSize                  fr-FR   expected 1610612736         actual 0
SabnzbdSpeed                 de-DE   expected 1572864            actual 15728640
SabnzbdSpeed                 fr-FR   expected 1572864            actual 0
SabnzbdQueueSlotSize         de-DE   expected 1572864            actual 15728640
SabnzbdQueueSlotSize         fr-FR   expected 1572864            actual 0
```

With the fix in place all 28 pass. The invariant and en-US cases pass on both sides, so a stock container never saw any of this.

Full suite 3067 passed, 0 failed, 127 skipped, on canary `d25b3e11` (1.3.3).

One note on the line numbers. The issue cites v1.2.2, three releases back, but all six sites are unmoved: those four files are byte identical to `4555ad21`. The two sites the issue set aside have moved. `Audiobook.cs:108` is now `:101`, and `DownloadImportService.cs:371` is now `DownloadImportService.Naming.cs:54` since that file was split.
