### PR TITLE
fix(files): file registration records the proc-fd link size (64 bytes) instead of the real file length

### DIFF
--- a/listenarr.application/Audiobooks/Files/AudiobookFileService.PhysicalGeneration.cs
+++ b/listenarr.application/Audiobooks/Files/AudiobookFileService.PhysicalGeneration.cs
@@ -274,10 +274,10 @@ public partial class AudiobookFileService
         string? source,
         bool replaceMetadata)
     {
-        var fileInfo = new FileInfo(registrationLease.MetadataPath);
         var replacement = AudiobookFile.CreateUnresolved(currentFile.Path);
         replacement.AudiobookId = currentFile.AudiobookId;
-        replacement.Size = fileInfo.Exists ? fileInfo.Length : currentFile.Size;
+        replacement.Size = TryGetRegisteredFileLength(registrationLease.MetadataPath)
+            ?? currentFile.Size;
         replacement.DurationSeconds = replaceMetadata
             ? metadata?.Duration.TotalSeconds
             : Math.Abs(metadata?.Duration.TotalSeconds ?? 0) > double.Epsilon

--- a/listenarr.application/Audiobooks/Files/AudiobookFileService.cs
+++ b/listenarr.application/Audiobooks/Files/AudiobookFileService.cs
@@ -327,10 +327,9 @@ namespace Listenarr.Application.Audiobooks.Files
                     cacheIdentity,
                     filePath);
 
-                var fi = new FileInfo(metadataPath);
                 var fileRecord = AudiobookFile.CreateUnresolved(filePath);
                 fileRecord.AudiobookId = audiobook.Id;
-                fileRecord.Size = fi.Exists ? fi.Length : null;
+                fileRecord.Size = TryGetRegisteredFileLength(metadataPath);
                 fileRecord.Source = source;
                 fileRecord.CreatedAt = DateTime.UtcNow;
                 fileRecord.DurationSeconds = meta?.Duration.TotalSeconds;
@@ -441,6 +440,32 @@ namespace Listenarr.Application.Audiobooks.Files
             string.IsNullOrWhiteSpace(path)
                 ? string.Empty
                 : FileSystemPathIdentity.ResolveNativeAbsolutePath(path);
+
+        /// <summary>
+        /// Read the byte length of the file behind a registration metadata path.
+        /// The pinned lease's metadata path is a /proc/self/fd magic link on
+        /// Linux, and FileSystemInfo reads the link inode itself, whose reported
+        /// size is a constant 64 — not the file's length. Opening the path
+        /// follows the link to the pinned file, so the stream length is the real
+        /// size of the exact object the lease holds open.
+        /// </summary>
+        private static long? TryGetRegisteredFileLength(string metadataPath)
+        {
+            try
+            {
+                using var stream = new FileStream(
+                    metadataPath,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete);
+                return stream.Length;
+            }
+            catch (Exception exception) when (exception is IOException
+                or UnauthorizedAccessException or NotSupportedException)
+            {
+                return null;
+            }
+        }
 
         private void LogClaimRejection(
             int audiobookId,


### PR DESCRIPTION
## The bug

Since #717, `AudiobookFileService` reads the registered file's size from the lease's **metadata path** (`new FileInfo(metadataPath).Length`). On Linux that path is a `/proc/self/fd/<n>` magic link, and `FileSystemInfo` stats the **link inode itself** — proc magic symlinks report a constant `st_size` of **64**. Result: every file registered through a pinned lease persists `Size = 64`, regardless of the real file.

Live evidence from my instance (v1.3.0): **361 of 27,912** `AudiobookFiles` rows have `Size = 64` exactly — every one created after the deploy that brought in #717 (sources: `download`, `LibraryScan`, `MetadataRescan`). The UI shows "0 KB" wherever sizes render (the duplicate-ASIN comparison table is where I caught it).

## The fix

Open the metadata path and take the stream length. Opening **follows** the magic link to the exact pinned object the lease holds open, so the size is read from the real file without reintroducing the rename race the metadata path exists to avoid. Applied at both write sites:

- `AudiobookFileService.cs` — initial registration (`Size = null` when the open fails, as before)
- `AudiobookFileService.PhysicalGeneration.cs` — generation-replacement snapshots (falls back to the previously recorded size)

## Notes

- `ExtractMetadataAsync`'s cache key uses `LastWriteTimeUtc` of the same metadata path, which has the same lstat behavior on Linux (the link's mtime, not the file's). It only weakens cache invalidation — the key still includes the physical object identity — so I left it out of scope here; happy to fold it in if you'd like.
- Existing rows with `Size = 64` stay wrong until re-registered; on my instance I'm backfilling them from disk. If you want, a follow-up startup reconciliation could repair `Size = 64` rows whose path resolves, but I didn't want to bundle that policy decision into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)