### PR TITLE
Add a safe compatibility path for opaque FUSE imports

### DIFF
--- a/listenarr.application/Downloads/Contracts/IDownloadImportService.cs
+++ b/listenarr.application/Downloads/Contracts/IDownloadImportService.cs
@@ -1,7 +1,12 @@
 
+using Listenarr.Domain.Common;
+
 namespace Listenarr.Application.Downloads.Contracts
 {
-    public sealed record DownloadImportOptions(bool ForceArchiveExtraction = false);
+    public sealed record DownloadImportOptions(
+        bool ForceArchiveExtraction = false,
+        FileSystemCaseSensitivityMode SourceCaseSensitivityMode =
+            FileSystemCaseSensitivityMode.Auto);
 
     /// <summary>
     /// Download import responsible for processing a given download importation

--- a/listenarr.application/Downloads/Import/DownloadImportService.PathSemantics.cs
+++ b/listenarr.application/Downloads/Import/DownloadImportService.PathSemantics.cs
@@ -4,6 +4,40 @@ namespace Listenarr.Application.Downloads.Import;
 
 public partial class DownloadImportService
 {
+    private static FileSystemCaseSensitivityMode ResolveSourceCaseSensitivityMode(
+        DownloadImportOptions? options,
+        bool extractedArchives)
+    {
+        // Extraction can mix the client's endpoint with Listenarr's staging
+        // endpoint. One mode cannot describe both, so use Auto for the full set.
+        return extractedArchives
+            ? FileSystemCaseSensitivityMode.Auto
+            : options?.SourceCaseSensitivityMode
+                ?? FileSystemCaseSensitivityMode.Auto;
+    }
+
+    private async Task<(
+        string? RootPath,
+        FileSystemPathSemantics? Semantics,
+        StringComparer Comparer)> ResolveSourceSemanticsAsync(
+            IReadOnlyCollection<string> candidateFiles,
+            FileSystemCaseSensitivityMode mode,
+            CancellationToken cancellationToken)
+    {
+        var rootPath = FileUtils.GetCommonDirectory(candidateFiles);
+        if (string.IsNullOrWhiteSpace(rootPath))
+        {
+            return (rootPath, null, StringComparer.Ordinal);
+        }
+
+        var semantics = await ResolvePathSemanticsAsync(
+            rootPath,
+            mode,
+            "Source filesystem identity is unavailable.",
+            cancellationToken);
+        return (rootPath, semantics, semantics.Comparer);
+    }
+
     private async Task<FileSystemSemanticsResolution> ResolveDestinationResolutionAsync(
         string basePath,
         CancellationToken cancellationToken)
@@ -209,12 +243,13 @@ public partial class DownloadImportService
 
     private async Task<FileSystemPathSemantics> ResolvePathSemanticsAsync(
         string path,
+        FileSystemCaseSensitivityMode mode,
         string defaultReason,
         CancellationToken cancellationToken)
     {
         var resolution = await semanticsResolver.ResolveAsync(
             path,
-            FileSystemCaseSensitivityMode.Auto,
+            mode,
             cancellationToken);
         return resolution.State == PathIdentityState.Valid
             ? resolution.Semantics

--- a/listenarr.application/Downloads/Import/DownloadImportService.cs
+++ b/listenarr.application/Downloads/Import/DownloadImportService.cs
@@ -97,6 +97,7 @@ namespace Listenarr.Application.Downloads.Import
             try
             {
                 var completedFileAction = settings.CompletedFileAction;
+                var extractedArchives = false;
 
                 if (settings.ExtractArchives || options?.ForceArchiveExtraction == true)
                 {
@@ -106,7 +107,8 @@ namespace Listenarr.Application.Downloads.Import
                         .ToList();
                     files = [.. files.Where(file => !archives.Contains(file))];
                     files.AddRange(await archiveImportExtractor.ExtractAsync(archives));
-                    if (archives.Count > 0 && completedFileAction == FileAction.HardlinkCopy)
+                    extractedArchives = archives.Count > 0;
+                    if (extractedArchives && completedFileAction == FileAction.HardlinkCopy)
                     {
                         completedFileAction = FileAction.Copy;
                         logger.LogWarning($"Audiobook {audiobook.Id} contains archives thus Hard link mode is impossible: Completed action switched to copy");
@@ -116,17 +118,14 @@ namespace Listenarr.Application.Downloads.Import
                 var results = recoveredResults;
                 var folderPattern = settings.FolderNamingPattern;
                 var candidateFiles = files.Where(file => !FileUtils.IsBlacklistedFile(file, settings.ImportBlacklistExtensions)).ToList();
-                var sourceRootPath = FileUtils.GetCommonDirectory(candidateFiles);
-                FileSystemPathSemantics? sourceSemantics = null;
-                var sourcePathComparer = StringComparer.Ordinal;
-                if (!string.IsNullOrWhiteSpace(sourceRootPath))
-                {
-                    sourceSemantics = await ResolvePathSemanticsAsync(
-                        sourceRootPath,
-                        "Source filesystem identity is unavailable.",
+                var sourceCaseSensitivityMode = ResolveSourceCaseSensitivityMode(
+                    options,
+                    extractedArchives);
+                var (sourceRootPath, sourceSemantics, sourcePathComparer) =
+                    await ResolveSourceSemanticsAsync(
+                        candidateFiles,
+                        sourceCaseSensitivityMode,
                         ct);
-                    sourcePathComparer = sourceSemantics.Value.Comparer;
-                }
                 var sourceFiles = candidateFiles.Distinct(sourcePathComparer).ToList();
                 sourceRootPath = FileUtils.GetCommonDirectory(sourceFiles);
                 var plannedAudioFiles = MultiFileImportPlanner.BuildPlans(
@@ -170,6 +169,7 @@ namespace Listenarr.Application.Downloads.Import
                         var fileSourceSemantics = sourceSemantics
                             ?? await ResolvePathSemanticsAsync(
                                 file,
+                                sourceCaseSensitivityMode,
                                 "Source filesystem identity is unavailable.",
                                 ct);
                         if (!FileUtils.IsAudioFile(file))

--- a/listenarr.domain/Common/FileSystemObjectIdentityTrustMode.cs
+++ b/listenarr.domain/Common/FileSystemObjectIdentityTrustMode.cs
@@ -1,0 +1,11 @@
+namespace Listenarr.Domain.Common;
+
+/// <summary>
+/// Controls whether opaque platform evidence may identify any pinned filesystem object.
+/// </summary>
+public enum FileSystemObjectIdentityTrustMode
+{
+    Auto,
+    Trusted,
+    Untrusted
+}

--- a/listenarr.domain/Downloads/DownloadClientConfiguration.cs
+++ b/listenarr.domain/Downloads/DownloadClientConfiguration.cs
@@ -1,9 +1,13 @@
 using System.Text.Json;
+using Listenarr.Domain.Common;
 
 namespace Listenarr.Domain.Downloads
 {
     public class DownloadClientConfiguration
     {
+        public const string SourceCaseSensitivityModeSetting =
+            "sourceCaseSensitivityMode";
+
         public string Id { get; set; } = Guid.NewGuid().ToString();
         public string Name { get; set; } = string.Empty;
         public string Type { get; set; } = string.Empty; // "qbittorrent", "transmission", "sabnzbd", "nzbget"
@@ -43,6 +47,30 @@ namespace Listenarr.Domain.Downloads
             }
 
             return defaultInterval;
+        }
+
+        public FileSystemCaseSensitivityMode GetSourceCaseSensitivityMode()
+        {
+            var settings = Settings;
+            if (!settings.TryGetValue(
+                    SourceCaseSensitivityModeSetting,
+                    out var configuredValue))
+            {
+                return FileSystemCaseSensitivityMode.Auto;
+            }
+
+            var value = configuredValue?.ToString() ?? string.Empty;
+            foreach (var name in Enum.GetNames<FileSystemCaseSensitivityMode>())
+            {
+                if (string.Equals(name, value, StringComparison.OrdinalIgnoreCase))
+                {
+                    return Enum.Parse<FileSystemCaseSensitivityMode>(name);
+                }
+            }
+
+            var descriptor = !string.IsNullOrWhiteSpace(Name) ? Name : Id;
+            throw new InvalidOperationException(
+                $"Download client '{descriptor}' setting '{SourceCaseSensitivityModeSetting}' must be Auto, Sensitive, or Insensitive; received '{value}'.");
         }
     }
 }

--- a/listenarr.infrastructure/Downloads/Processing/DownloadProcessingJobProcessor.cs
+++ b/listenarr.infrastructure/Downloads/Processing/DownloadProcessingJobProcessor.cs
@@ -18,6 +18,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using System.Text.Json;
+using Listenarr.Domain.Common;
 
 namespace Listenarr.Infrastructure.Downloads.Processing
 {
@@ -277,11 +278,19 @@ namespace Listenarr.Infrastructure.Downloads.Processing
                 try
                 {
                     var downloadImportService = scope.ServiceProvider.GetRequiredService<IDownloadImportService>();
-                    var importOptions = isDirectDownload && string.Equals(
+                    var forceArchiveExtraction = isDirectDownload && string.Equals(
                         download.GetMetadataString(DirectDownloadMetadataKeys.RequiresArchiveExtraction),
                         bool.TrueString,
-                        StringComparison.OrdinalIgnoreCase)
-                        ? new DownloadImportOptions(ForceArchiveExtraction: true)
+                        StringComparison.OrdinalIgnoreCase);
+                    var sourceCaseSensitivityMode =
+                        client?.GetSourceCaseSensitivityMode()
+                        ?? FileSystemCaseSensitivityMode.Auto;
+                    var importOptions = forceArchiveExtraction
+                        || sourceCaseSensitivityMode
+                            != FileSystemCaseSensitivityMode.Auto
+                        ? new DownloadImportOptions(
+                            forceArchiveExtraction,
+                            sourceCaseSensitivityMode)
                         : null;
                     results = await downloadImportService.ImportDownloadFilesAsync(
                         audiobook,

--- a/listenarr.infrastructure/FileSystem/FileSystemSemanticsResolver.Interop.cs
+++ b/listenarr.infrastructure/FileSystem/FileSystemSemanticsResolver.Interop.cs
@@ -46,31 +46,8 @@ public sealed partial class FileSystemSemanticsResolver
         ulong request,
         out int flags);
 
-    [DllImport("libc", EntryPoint = "fstatfs", SetLastError = true)]
-    private static extern int FStatFsUnix(int descriptor, IntPtr buffer);
-
     [DllImport("libc", EntryPoint = "pathconf", SetLastError = true)]
     private static extern long PathConfUnix(
         [MarshalAs(UnmanagedType.LPUTF8Str)] string path,
         int name);
-
-    private static long? TryGetLinuxFileSystemType(int descriptor)
-    {
-        var buffer = Marshal.AllocHGlobal(LinuxStatFsBufferBytes);
-        try
-        {
-            if (FStatFsUnix(descriptor, buffer) != 0)
-            {
-                return null;
-            }
-
-            return IntPtr.Size == sizeof(long)
-                ? Marshal.ReadInt64(buffer)
-                : Marshal.ReadInt32(buffer);
-        }
-        finally
-        {
-            Marshal.FreeHGlobal(buffer);
-        }
-    }
 }

--- a/listenarr.infrastructure/FileSystem/FileSystemSemanticsResolver.cs
+++ b/listenarr.infrastructure/FileSystem/FileSystemSemanticsResolver.cs
@@ -24,7 +24,6 @@ public sealed partial class FileSystemSemanticsResolver : IFileSystemSemanticsRe
     private const long LinuxF2fsSuperMagic = 0xf2f52010L;
     private const long LinuxTmpfsSuperMagic = 0x01021994L;
     private const long LinuxBcachefsSuperMagic = 0xca451a4eL;
-    private const int LinuxStatFsBufferBytes = 256;
     // Darwin bsd/sys/unistd.h: _PC_CASE_SENSITIVE.
     private const int MacPathConfCaseSensitive = 11;
 
@@ -411,7 +410,7 @@ public sealed partial class FileSystemSemanticsResolver : IFileSystemSemanticsRe
                 true,
                 flags,
                 0,
-                TryGetLinuxFileSystemType(descriptor));
+                LinuxFileSystemType.TryGet(descriptor));
         }
 
         return new LinuxFilesystemFlagsProbe(

--- a/listenarr.infrastructure/FileSystem/LinuxFileSystemType.cs
+++ b/listenarr.infrastructure/FileSystem/LinuxFileSystemType.cs
@@ -1,0 +1,35 @@
+using System.Runtime.InteropServices;
+
+namespace Listenarr.Infrastructure.FileSystem;
+
+internal static class LinuxFileSystemType
+{
+    internal const long FuseSuperMagic = 0x65735546L;
+
+    private const int StatFsBufferBytes = 256;
+
+    internal static long? TryGet(int descriptor)
+    {
+        var buffer = Marshal.AllocHGlobal(StatFsBufferBytes);
+        try
+        {
+            if (FStatFs(descriptor, buffer) != 0)
+            {
+                return null;
+            }
+
+            // Linux statfs begins with a native long f_type. The remaining
+            // fields are architecture-specific and intentionally not mirrored.
+            return IntPtr.Size == sizeof(long)
+                ? Marshal.ReadInt64(buffer)
+                : Marshal.ReadInt32(buffer);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    [DllImport("libc", EntryPoint = "fstatfs", SetLastError = true)]
+    private static extern int FStatFs(int descriptor, IntPtr buffer);
+}

--- a/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.LinuxObjectIdentity.cs
+++ b/listenarr.infrastructure/FileSystem/PinnedDirectoryCreation.LinuxObjectIdentity.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using Listenarr.Domain.Common;
 using Microsoft.Win32.SafeHandles;
 
 namespace Listenarr.Infrastructure.FileSystem;
@@ -24,24 +25,31 @@ internal sealed partial class PinnedDirectoryCreation
     private static IReadOnlyList<string> GetLinuxGenerationIdentityCandidates(
         SafeFileHandle handle)
     {
-        var candidates = new List<string>(2);
-        var fileHandle = TryGetLinuxFileHandleIdentity(
-            handle,
-            LinuxAtEmptyPath | LinuxAtHandleFid,
-            retryWithoutHandleFid: true);
-        if (!string.IsNullOrWhiteSpace(fileHandle))
-        {
-            candidates.Add($"fh:{fileHandle}");
-        }
+        // This PoC deliberately leaves the final carrier open: a root folder,
+        // storage endpoint, or mount provider can later select an explicit mode.
+        const FileSystemObjectIdentityTrustMode trustMode =
+            FileSystemObjectIdentityTrustMode.Auto;
+        var fileSystemType = LinuxFileSystemType.TryGet(
+            handle.DangerousGetHandle().ToInt32());
+        var trustsFileHandle = CanUseLinuxFileHandleAsDurableGeneration(
+            trustMode,
+            fileSystemType);
+        var fileHandle = trustsFileHandle
+            ? TryGetLinuxFileHandleIdentity(
+                handle,
+                LinuxAtEmptyPath | LinuxAtHandleFid,
+                retryWithoutHandleFid: true)
+            : null;
+        var hasInodeGeneration = false;
+        var inodeGeneration = 0U;
 
         try
         {
-            if (TryGetLinuxInodeGeneration(handle, out var generation))
-            {
-                candidates.Add(FormattableString.Invariant($"gen:{generation:x8}"));
-            }
+            hasInodeGeneration = TryGetLinuxInodeGeneration(
+                handle,
+                out inodeGeneration);
         }
-        catch (Win32Exception) when (candidates.Count > 0)
+        catch (Win32Exception) when (!string.IsNullOrWhiteSpace(fileHandle))
         {
             // A second, supplementary capability failing unexpectedly must not
             // invalidate a strong identity already obtained from this pinned
@@ -49,7 +57,75 @@ internal sealed partial class PinnedDirectoryCreation
             // still fail closed because their candidate will be absent.
         }
 
+        return CreateLinuxGenerationIdentityCandidatesFromEvidence(
+            fileHandle,
+            hasInodeGeneration,
+            inodeGeneration,
+            trustMode,
+            fileSystemType);
+    }
+
+    internal static IReadOnlyList<string>
+        CreateLinuxGenerationIdentityCandidatesFromEvidence(
+            string? fileHandle,
+            bool hasInodeGeneration,
+            uint inodeGeneration,
+            FileSystemObjectIdentityTrustMode trustMode,
+            long? fileSystemType)
+    {
+        var candidates = new List<string>(2);
+        var hasFileHandle = !string.IsNullOrWhiteSpace(fileHandle);
+        var trustsFileHandle = CanUseLinuxFileHandleAsDurableGeneration(
+            trustMode,
+            fileSystemType);
+        if (hasFileHandle && trustsFileHandle)
+        {
+            candidates.Add($"fh:{fileHandle}");
+        }
+        if (hasInodeGeneration)
+        {
+            candidates.Add(FormattableString.Invariant(
+                $"gen:{inodeGeneration:x8}"));
+        }
+
+        if (candidates.Count == 0 && !trustsFileHandle)
+        {
+            throw new PlatformNotSupportedException(
+                CreateUntrustedLinuxFileHandleReason(trustMode, fileSystemType));
+        }
+
         return candidates;
+    }
+
+    internal static bool CanUseLinuxFileHandleAsDurableGeneration(
+        FileSystemObjectIdentityTrustMode trustMode,
+        long? fileSystemType) =>
+        trustMode switch
+        {
+            FileSystemObjectIdentityTrustMode.Trusted => true,
+            FileSystemObjectIdentityTrustMode.Untrusted => false,
+            FileSystemObjectIdentityTrustMode.Auto =>
+                fileSystemType.HasValue
+                && fileSystemType.Value != LinuxFileSystemType.FuseSuperMagic,
+            _ => throw new ArgumentOutOfRangeException(nameof(trustMode))
+        };
+
+    private static string CreateUntrustedLinuxFileHandleReason(
+        FileSystemObjectIdentityTrustMode trustMode,
+        long? fileSystemType)
+    {
+        if (trustMode == FileSystemObjectIdentityTrustMode.Auto
+            && fileSystemType == LinuxFileSystemType.FuseSuperMagic)
+        {
+            return "Opaque FUSE file-handle persistence is not trusted automatically, and the filesystem exposes no independent inode generation.";
+        }
+
+        if (trustMode == FileSystemObjectIdentityTrustMode.Auto)
+        {
+            return "Opaque Linux file-handle persistence is not trusted automatically when the filesystem type is unavailable, and the filesystem exposes no independent inode generation.";
+        }
+
+        return "Opaque Linux file-handle persistence is disabled by the filesystem object identity trust policy, and the filesystem exposes no independent inode generation.";
     }
 
     private static string? TryGetLinuxFileHandleIdentity(

--- a/tests/Features/Application/Downloads/Import/DownloadImportServiceTests.cs
+++ b/tests/Features/Application/Downloads/Import/DownloadImportServiceTests.cs
@@ -350,6 +350,61 @@ namespace Listenarr.Tests.Features.Application.Downloads.Import
         }
 
         [Fact]
+        public async Task ImportDownloadFilesAsync_ExplicitSourceMode_BypassesUnavailableAuto()
+        {
+            await _applicationSettingsRepository.SaveAsync(
+                new ApplicationSettingsBuilder()
+                    .WithCopyFileOnCompleted()
+                    .WithoutMetadataProcessing()
+                    .WithFileNamingPattern("{Title}")
+                    .WithMultiFileNamingPattern("{Title}")
+                    .Build());
+            var destination = FileService.GetTempDirectory(
+                "explicit-source-semantics-library");
+            var sourceDirectory = FileService.GetTempDirectory(
+                "explicit-source-semantics-download");
+            var sourceFile = await FileService.GetFileAsync(
+                sourceDirectory,
+                "chapter.mp3");
+            var audiobook = await _audiobookRepository.AddAsync(
+                new AudiobookBuilder()
+                    .WithTitle("Explicit Source Semantics")
+                    .WithBasePath(destination)
+                    .Build());
+            var resolver = new RejectAutoAtPathSemanticsResolver(
+                _provider.GetRequiredService<IFileSystemSemanticsResolver>(),
+                sourceDirectory);
+            var service = ActivatorUtilities.CreateInstance<DownloadImportService>(
+                _provider,
+                resolver);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.ImportDownloadFilesAsync(audiobook, [sourceFile]));
+            var result = Assert.Single(await service.ImportDownloadFilesAsync(
+                audiobook,
+                [sourceFile],
+                options: new DownloadImportOptions(
+                    SourceCaseSensitivityMode:
+                        FileSystemCaseSensitivityMode.Sensitive)));
+
+            Assert.True(result.Success);
+            Assert.Contains(
+                resolver.Calls,
+                call => string.Equals(
+                        call.Path,
+                        sourceDirectory,
+                        StringComparison.Ordinal)
+                    && call.Mode == FileSystemCaseSensitivityMode.Auto);
+            Assert.Contains(
+                resolver.Calls,
+                call => string.Equals(
+                        call.Path,
+                        sourceDirectory,
+                        StringComparison.Ordinal)
+                    && call.Mode == FileSystemCaseSensitivityMode.Sensitive);
+        }
+
+        [Fact]
         public async Task ImportDownloadFilesAsync_StaleAudiobookArgument_UsesCurrentPersistedBasePath()
         {
             var oldBasePath = FileService.GetTempDirectory("download-import-stale-old");
@@ -877,14 +932,18 @@ namespace Listenarr.Tests.Features.Application.Downloads.Import
         }
 
         [Fact]
-        [Trait("Scenario", "ForcedArchiveExtractionImportsContainedFile")]
-        public async Task ArchiveExtraction_ForcedByDownloadPlan_ImportsWhenGlobalSettingIsDisabled()
+        [Trait("Scenario", "ForcedArchiveExtractionMixedSourcesUseAutoSemantics")]
+        public async Task ArchiveExtraction_ForcedByDownloadPlan_MixedSourcesUseAutoSemantics()
         {
             // Given
             var destinationDirectory = FileService.GetTempDirectory("forced-archive-destination");
             var inner = FileService.GetTempDirectory("forced-archive-inner");
             _ = await FileService.GetFileAsync(inner, "forced-audio.mp3");
-            var zipPath = Path.Join(FileService.GetTempPath(), "forced-release.zip");
+            var clientDirectory = FileService.GetTempDirectory("forced-archive-client");
+            var looseAudioPath = await FileService.GetFileAsync(
+                clientDirectory,
+                "loose-audio.mp3");
+            var zipPath = Path.Join(clientDirectory, "forced-release.zip");
             ZipFile.CreateFromDirectory(inner, zipPath);
             var audiobook = await CreateAudiobook();
             audiobook.BasePath = Path.Join(destinationDirectory, "Fake Author/Fake Title/Forced Archive");
@@ -897,17 +956,33 @@ namespace Listenarr.Tests.Features.Application.Downloads.Import
                 .Build());
 
             // When
-            var downloadImportService = _provider.GetRequiredService<IDownloadImportService>();
-            await downloadImportService.ImportDownloadFilesAsync(
+            var resolver = new RecordingSemanticsResolver(
+                _provider.GetRequiredService<IFileSystemSemanticsResolver>());
+            var downloadImportService = ActivatorUtilities
+                .CreateInstance<DownloadImportService>(_provider, resolver);
+            var results = await downloadImportService.ImportDownloadFilesAsync(
                 audiobook,
-                [zipPath],
+                [zipPath, looseAudioPath],
                 CancellationToken.None,
-                new DownloadImportOptions(ForceArchiveExtraction: true));
+                new DownloadImportOptions(
+                    ForceArchiveExtraction: true,
+                    SourceCaseSensitivityMode:
+                        FileSystemCaseSensitivityMode.Sensitive));
 
             // Then
-            var expected = Path.Join(audiobook.BasePath, "forced-audio.mp3");
-            Assert.True(File.Exists(expected));
-            Assert.Single(await _audiobookFileRepository.GetAllAsync());
+            Assert.True(File.Exists(Path.Join(audiobook.BasePath, "forced-audio.mp3")));
+            Assert.True(File.Exists(Path.Join(audiobook.BasePath, "loose-audio.mp3")));
+            Assert.Equal(2, results.Count);
+            Assert.Equal(2, (await _audiobookFileRepository.GetAllAsync()).Count);
+            var sourceRoot = FileUtils.GetCommonDirectory(
+                results.Select(result => result.SourcePath!).ToList());
+            Assert.Contains(
+                resolver.Calls,
+                call => string.Equals(
+                        call.Path,
+                        sourceRoot,
+                        StringComparison.Ordinal)
+                    && call.Mode == FileSystemCaseSensitivityMode.Auto);
         }
 
         [Fact]
@@ -1690,6 +1765,36 @@ namespace Listenarr.Tests.Features.Application.Downloads.Import
                 CancellationToken cancellationToken = default)
             {
                 Calls.Add((path, mode));
+                return inner.ResolveAsync(path, mode, cancellationToken);
+            }
+        }
+
+        private sealed class RejectAutoAtPathSemanticsResolver(
+            IFileSystemSemanticsResolver inner,
+            string rejectedPath) : IFileSystemSemanticsResolver
+        {
+            public List<(string Path, FileSystemCaseSensitivityMode Mode)> Calls { get; } = [];
+
+            public ValueTask<FileSystemSemanticsResolution> ResolveAsync(
+                string path,
+                FileSystemCaseSensitivityMode mode =
+                    FileSystemCaseSensitivityMode.Auto,
+                CancellationToken cancellationToken = default)
+            {
+                Calls.Add((path, mode));
+                if (string.Equals(path, rejectedPath, StringComparison.Ordinal)
+                    && mode == FileSystemCaseSensitivityMode.Auto)
+                {
+                    return ValueTask.FromResult(
+                        new FileSystemSemanticsResolution(
+                            new FileSystemPathSemantics(
+                                FileSystemPathSemantics.CurrentHostDefault.Syntax,
+                                FileSystemCaseSensitivity.Unknown),
+                            PathIdentityState.Unavailable,
+                            path,
+                            "Auto source semantics intentionally unavailable for this test."));
+                }
+
                 return inner.ResolveAsync(path, mode, cancellationToken);
             }
         }

--- a/tests/Features/Domain/Downloads/DownloadClientConfigurationTests.cs
+++ b/tests/Features/Domain/Downloads/DownloadClientConfigurationTests.cs
@@ -1,0 +1,65 @@
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Domain.Downloads;
+
+[Trait("Name", "DownloadClientConfigurationTests")]
+[Trait("Category", "Domain")]
+public sealed class DownloadClientConfigurationTests
+    : BaseTests
+{
+    [Fact]
+    public void SourceCaseSensitivityMode_MissingSetting_DefaultsToAuto()
+    {
+        var client = new DownloadClientConfiguration();
+
+        Assert.Equal(
+            FileSystemCaseSensitivityMode.Auto,
+            client.GetSourceCaseSensitivityMode());
+    }
+
+    [Theory]
+    [InlineData("Auto", FileSystemCaseSensitivityMode.Auto)]
+    [InlineData("sensitive", FileSystemCaseSensitivityMode.Sensitive)]
+    [InlineData("INSENSITIVE", FileSystemCaseSensitivityMode.Insensitive)]
+    public void SourceCaseSensitivityMode_ValidName_IsParsed(
+        string configuredValue,
+        FileSystemCaseSensitivityMode expected)
+    {
+        var client = new DownloadClientConfiguration
+        {
+            Settings = new Dictionary<string, object>
+            {
+                [DownloadClientConfiguration.SourceCaseSensitivityModeSetting] =
+                    configuredValue
+            }
+        };
+
+        Assert.Equal(expected, client.GetSourceCaseSensitivityMode());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("1")]
+    [InlineData("detect")]
+    public void SourceCaseSensitivityMode_InvalidValue_FailsClearly(string value)
+    {
+        var client = new DownloadClientConfiguration
+        {
+            Name = "Test client",
+            Settings = new Dictionary<string, object>
+            {
+                [DownloadClientConfiguration.SourceCaseSensitivityModeSetting] =
+                    value
+            }
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => client.GetSourceCaseSensitivityMode());
+
+        Assert.Contains(
+            DownloadClientConfiguration.SourceCaseSensitivityModeSetting,
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.Contains("Auto, Sensitive, or Insensitive", exception.Message);
+    }
+}

--- a/tests/Features/Infrastructure/Downloads/Processing/DownloadProcessingJobProcessorTests.cs
+++ b/tests/Features/Infrastructure/Downloads/Processing/DownloadProcessingJobProcessorTests.cs
@@ -233,7 +233,76 @@ namespace Listenarr.Tests.Features.Infrastructure.Downloads.Processing
                 It.Is<Audiobook>(item => item.Id == audiobook.Id),
                 It.Is<List<string>>(files => files.Contains(archivePath)),
                 It.IsAny<CancellationToken>(),
-                It.Is<DownloadImportOptions>(options => options.ForceArchiveExtraction)), Times.Once);
+                It.Is<DownloadImportOptions>(options =>
+                    options.ForceArchiveExtraction
+                    && options.SourceCaseSensitivityMode
+                        == FileSystemCaseSensitivityMode.Auto)), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("Sensitive")]
+        public async Task Import_ClientSourceCaseSensitivityMode_IsCarriedIntoOptions(
+            string? configuredMode)
+        {
+            var importService = new Mock<IDownloadImportService>();
+            importService
+                .Setup(service => service.ImportDownloadFilesAsync(
+                    It.IsAny<Audiobook>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<DownloadImportOptions?>()))
+                .ReturnsAsync((Audiobook _, List<string> files,
+                    CancellationToken _, DownloadImportOptions? _) =>
+                    [ImportResult.ImportSuccess(
+                        FileAction.Copy,
+                        files[0],
+                        files[0],
+                        wasRegisteredToAudiobook: true)]);
+            Init(builder => builder.WithSingleton<IDownloadImportService>(
+                importService.Object));
+            var sourceDirectory = FileService.GetTempDirectory(
+                "client-source-semantics");
+            var sourceFile = await FileService.GetFileAsync(
+                sourceDirectory,
+                "book.m4b");
+            downloadClientGatewayMock.SourceFiles = [sourceFile];
+            var clientBuilder = new DownloadClientConfigurationBuilder();
+            if (configuredMode != null)
+            {
+                clientBuilder.WithSettings(
+                    DownloadClientConfiguration.SourceCaseSensitivityModeSetting,
+                    configuredMode);
+            }
+            var client = await _downloadClientConfigurationRepository.SaveAsync(
+                clientBuilder.Build());
+            var audiobook = await CreateAudiobook();
+            var download = await _downloadRepository.AddAsync(
+                new DownloadBuilder()
+                    .WithAudiobook(audiobook)
+                    .WithDownloadClientConfiguration(client)
+                    .WithPath(sourceDirectory)
+                    .WithCompletedStatus(DateTime.UtcNow)
+                    .Build());
+            await _downloadProcessingJobRepository.AddAsync(
+                new DownloadProcessingJobBuilder()
+                    .WithDownload(download)
+                    .Build());
+
+            await _provider.GetRequiredService<DownloadProcessingJobProcessor>()
+                .ProcessQueueAsync(CancellationToken.None);
+
+            importService.Verify(service => service.ImportDownloadFilesAsync(
+                It.Is<Audiobook>(item => item.Id == audiobook.Id),
+                It.Is<List<string>>(files => files.Contains(sourceFile)),
+                It.IsAny<CancellationToken>(),
+                It.Is<DownloadImportOptions?>(options =>
+                    configuredMode == null
+                        ? options == null
+                        : options != null
+                            && options.SourceCaseSensitivityMode
+                                == FileSystemCaseSensitivityMode.Sensitive)),
+                Times.Once);
         }
 
         [Fact]

--- a/tests/Features/Infrastructure/FileSystem/DirectoryObjectIdentityResolverTests.cs
+++ b/tests/Features/Infrastructure/FileSystem/DirectoryObjectIdentityResolverTests.cs
@@ -125,6 +125,26 @@ public sealed class DirectoryObjectIdentityResolverTests : BaseTests
     }
 
     [Fact]
+    public async Task ResolveAsync_TrustPolicyRejection_IsObservableAsIdentityUnsupported()
+    {
+        var directory = FileService.GetTempDirectory(
+            "directory-object-identity-trust-policy");
+        const string reason =
+            "Opaque FUSE file-handle persistence is not trusted automatically.";
+        var resolver = new DirectoryObjectIdentityResolver(
+            nativeIdentityCandidatesResolver: static _ =>
+                throw new PlatformNotSupportedException(reason));
+
+        var resolution = await resolver.ResolveAsync(directory);
+
+        Assert.False(resolution.IsAvailable);
+        Assert.Equal(
+            DirectoryObjectIdentityFailureKind.IdentityUnsupported,
+            resolution.FailureKind);
+        Assert.Equal(reason, resolution.UnavailableReason);
+    }
+
+    [Fact]
     public async Task ResolveExistingAsync_DifferentNativeGeneration_IsUnavailable()
     {
         var directory = FileService.GetTempDirectory("directory-object-identity-recreated");

--- a/tests/Features/Infrastructure/FileSystem/DockerStorageCapabilityContractTests.cs
+++ b/tests/Features/Infrastructure/FileSystem/DockerStorageCapabilityContractTests.cs
@@ -6,6 +6,64 @@ namespace Listenarr.Tests.Features.Infrastructure.FileSystem;
 [Trait("Category", "Infrastructure")]
 public sealed class DockerStorageCapabilityContractTests : BaseTests
 {
+    [Theory]
+    [InlineData(
+        "Auto",
+        LinuxFileSystemType.FuseSuperMagic,
+        false)]
+    [InlineData(
+        "Auto",
+        0x58465342L,
+        true)]
+    [InlineData(
+        "Auto",
+        null,
+        false)]
+    [InlineData(
+        "Trusted",
+        LinuxFileSystemType.FuseSuperMagic,
+        true)]
+    [InlineData(
+        "Untrusted",
+        0x58465342L,
+        false)]
+    public void LinuxGenerationEvidence_TrustModeChangesOnlyFileHandleAdmission(
+        string trustModeName,
+        long? fileSystemType,
+        bool expectsFileHandle)
+    {
+        var trustMode = Enum.Parse<FileSystemObjectIdentityTrustMode>(trustModeName);
+        var candidates = PinnedDirectoryCreation
+            .CreateLinuxGenerationIdentityCandidatesFromEvidence(
+                "00000001:01020304",
+                hasInodeGeneration: true,
+                inodeGeneration: 0,
+                trustMode,
+                fileSystemType);
+
+        Assert.Equal(expectsFileHandle, candidates.Contains("fh:00000001:01020304"));
+        Assert.Contains("gen:00000000", candidates);
+    }
+
+    [Theory]
+    [InlineData(LinuxFileSystemType.FuseSuperMagic, "FUSE file-handle persistence")]
+    [InlineData(null, "filesystem type is unavailable")]
+    public void LinuxGenerationEvidence_AutoWithoutIndependentGeneration_FailsClearly(
+        long? fileSystemType,
+        string expectedReason)
+    {
+        var exception = Assert.Throws<PlatformNotSupportedException>(() =>
+            PinnedDirectoryCreation.CreateLinuxGenerationIdentityCandidatesFromEvidence(
+                "00000081:01020304",
+                hasInodeGeneration: false,
+                inodeGeneration: 0,
+                FileSystemObjectIdentityTrustMode.Auto,
+                fileSystemType));
+
+        Assert.Contains(expectedReason, exception.Message);
+        Assert.Contains("not trusted automatically", exception.Message);
+    }
+
     [Fact]
     public void Restart_StrongFileHandleThenBirthTimeOnly_FailsClosedRatherThanDowngradingAuthority()
     {


### PR DESCRIPTION
## Summary

This is a compact proof of concept for #836. It addresses two independent
filesystem boundaries exposed by an unattended download import on an Unraid
user share:

1. Linux can return an opaque file handle without proving that the backing
   filesystem provides the persistence guarantees required for durable object
   identity.
2. A translated download source outside the configured library root can require
   explicit case semantics when read-only automatic detection is inconclusive.

The implementation deliberately adds generic policy and carrier seams instead
of special-casing Unraid, `shfs`, a download-client vendor, or a mount path. It
makes unattended imports safe and functional through Listenarr's existing
compatibility copy-and-retain path.

This is proposed as an **interim compatibility path**, not as the final hardlink
solution for Unraid. Its purpose is to unblock affected imports without granting
destructive authority from identity evidence that was reproduced as unstable.
It gives the project room to design verified hardlink publication for weak
storage separately. Until then, affected `HardlinkCopy` imports complete as
full copies and retain their sources, with the time and storage cost described
below.

## Reproduced failure sequence

The download client completed successfully, and Listenarr could enumerate and
probe every source file. Import then failed before publication because the
library root no longer matched its persisted physical identity. Confirming the
root only helped temporarily: the opaque `fuse.shfs` handle changed after the
same directory was looked up again, so Listenarr treated the unchanged path as
a different directory.

Making FUSE identity fail closed allowed the root to enter Listenarr's existing
limited-storage contract, but exposed a second boundary. The translated local
download source is outside the library root and still resolved case semantics
with `Auto`. On `fuse.shfs`, the flags ioctl was unsupported and the read-only
existing-entry probe was inconclusive, so import stopped before publication.

With the final PoC image, the library root and translated source were configured
explicitly as `Sensitive`. The same unattended workflow then completed: four
release artifacts were compatibility-published, the audio file was registered,
the follow-up scan completed, and all source files were retained.

## Why this design

The initial working prototype inferred case behavior from the exact
`fuse.shfs` mount subtype. That solved the reproduced system but coupled generic
filesystem code to one Unraid implementation. It was removed.

The final design instead separates two questions:

- whether opaque filesystem-object evidence is trusted for durable identity;
- which case semantics describe a specific download source endpoint.

Both decisions are named and independently replaceable. The identity decision
is enforced once at the existing Linux generation-candidate funnel, and the
source setting is parsed once per processing job. No per-file probing loop,
trust cache, vendor detection, or downloader-specific branch is introduced.

## Changes

### Filesystem-object identity trust

- Add a named `Auto` / `Trusted` / `Untrusted` trust policy.
- Apply the policy once at the existing Linux generation-candidate funnel, so
  every consumer gets the same result without call-site plumbing.
- Under `Auto`, keep opaque handles on known non-FUSE filesystems, but do not
  probe or persist them on FUSE or when filesystem type is unavailable.
- Preserve an independently available inode generation, including generation
  zero, and retain the target branch's existing FID/fallback behavior.
- Share one uncached `fstatfs` helper with the existing filesystem-semantics
  code. No trust decision is cached.

### Download-source case semantics

- Add an optional named-only download-client setting,
  `sourceCaseSensitivityMode`, defaulting to `Auto` for existing clients.
- Parse it once per processing job and carry it through the import boundary to
  resolution of the translated local source path.
- Fall back to whole-set `Auto` when archive extraction or staging means a file
  set no longer has one trustworthy source endpoint.

## Hardlink behavior and trade-off

Listenarr already contains native Linux hardlink support, and this PoC does not
modify that implementation. The existing publication planner only selects its
durable hardlink path when source object identity is durable and the destination
authorizes filesystem mutation.

The configured action is named `HardlinkCopy`, and Listenarr already treats copy
as its fallback when a hardlink cannot be created. This PoC therefore uses an
existing product fallback rather than inventing a new publication behavior.
However, the distinction still matters: on the affected weak FUSE path the
fallback becomes systematic, so the user's performance and storage goal is not
met even though the import itself succeeds.

Under this PoC, `Auto` does not grant that authority from an opaque FUSE handle.
The planner therefore selects `AdditiveCopyRetainSource`, even when the requested
completed-file action is `HardlinkCopy`. Compatibility publication creates a
new file, copies and flushes all bytes, verifies the destination, registers it,
and retains the source.

The end-to-end validation source and destination were exposed through one
container mount and were physically located on the same backing ZFS pool, so
cross-device layout was not the reason for the fallback. A post-import check
showed different inodes with link count one: the successful result was a full
copy, not a hardlink.

The fallback is not represented internally as a successful hardlink. Each
import result preserves `RequestedAction=HardlinkCopy` and
`EffectiveAction=Copy`, together with `durable_identity_unavailable` and a
compatibility-publication message. Those details are recorded in history,
although the current UI may not make the distinction prominent.

This is a deliberate safety trade-off, not a claim that Unraid cannot support
hardlinks. It means imports take copy time and consume duplicate space while the
source remains present. The unresolved product work is to support verified
hardlink publication on weak storage without treating link success as proof
that later destructive cleanup is safe. That likely requires additional
journaling, verification, policy, and UI work, but not necessarily a rewrite of
the native hardlink implementation. That extension is intentionally outside
this PoC.

## Intentional PoC boundary

This PR demonstrates the architecture and provides a usable mitigation for the
reproduced import without claiming to finish the product design. It can be
reviewed either as a small compatibility change that is safe to ship while the
hardlink path is designed, or as a concrete reference implementation for that
later work. It does not add UI, API schema, migration, automatic Unraid
detection, downloader-specific behavior, or a final choice of where the
identity-trust setting should live.

For validation, `sourceCaseSensitivityMode=Sensitive` was added manually to the
existing download-client settings JSON; no database column was introduced. The
current UI does not carry this unknown property and can remove it when a client
is edited. Likewise, the identity policy currently uses `Auto` at the seam and
does not expose a product-level carrier. These are explicit PoC limitations,
not finished configuration UX.

Maintainer decisions intentionally left open are:

- where an identity-trust carrier belongs, if it should be configurable;
- how source endpoint semantics should be exposed or derived;
- whether weak storage should support verified hardlink publication separately
  from destructive move/source-cleanup authority.

## Testing

- `dotnet format listenarr.slnx --no-restore --verify-no-changes`: passed.
- Full Windows backend run: 3,039 passed and 211 platform tests skipped; the
  same four unrelated baseline failures remained.
- Affected native Linux groups: 167 passed, one Windows-only test skipped, and
  the same four established baseline failures remained.
- The identity commit alone compiled and ran its focused Windows groups with
  48 passed, 15 platform skips, and zero failures.
- Read-only native probes showed that the affected FUSE share and an XFS
  control expose the same raw handle shape. Production policy rejected the
  FUSE handle while retaining usable identity on XFS and ZFS controls.
- Explicit source and library-root semantics both resolved as authoritative
  and case-sensitive on the affected system.
- A production image built successfully, completed fresh-database migrations,
  and returned HTTP 200 in an isolated smoke container.
- One fresh unattended import through SABnzbd completed with zero retries. This
  validates the generic path with the client used to reproduce #836; the code
  contains no SABnzbd-specific branch. Four release artifacts were
  compatibility-published, the audio file was registered and scanned, and all
  four source files were retained. Destructive filesystem authority remained
  disabled.

## Notes

- The production validation used Listenarr's existing weak-storage
  copy-and-retain path; no source-deletion authority was enabled.
- The investigation, design reviews, and implementation were AI-assisted, as
  already disclosed in the issue discussion.
