### PR TITLE
fix(audible): tell a failed catalog lookup apart from a confirmed zero-match

### DIFF
--- a/listenarr.api/Features/Search/SearchController.cs
+++ b/listenarr.api/Features/Search/SearchController.cs
@@ -368,6 +368,17 @@ namespace Listenarr.Api.Features.Search
                     return NotFound("No results found");
                 }
 
+                // Audible did not answer. Returning the empty result would be a 200 that
+                // says "this book is not in the catalogue", which is a different claim and
+                // one a caller acts on differently. 503 says try again instead.
+                if (result.ProviderUnavailable)
+                {
+                    _logger.LogWarning(
+                        "Audible did not answer for query: {Query}; reporting unavailable rather than zero matches",
+                        LogRedaction.SanitizeText(query));
+                    return StatusCode(503, "The Audible catalog did not respond. This is not a confirmed zero-match; retry shortly.");
+                }
+
                 return Ok(result);
             }
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)

--- a/listenarr.api/Features/Search/SearchController.cs
+++ b/listenarr.api/Features/Search/SearchController.cs
@@ -350,6 +350,11 @@ namespace Listenarr.Api.Features.Search
         /// Search the Audible catalog for audiobooks.
         /// </summary>
         [HttpGet("audible")]
+        [ProducesResponseType(typeof(AudibleSearchResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<ActionResult<AudibleSearchResponse>> SearchAudible(
             [FromQuery] string query,
             [FromQuery] string region = "us",
@@ -376,7 +381,7 @@ namespace Listenarr.Api.Features.Search
                     _logger.LogWarning(
                         "Audible did not answer for query: {Query}; reporting unavailable rather than zero matches",
                         LogRedaction.SanitizeText(query));
-                    return StatusCode(503, "The Audible catalog did not respond. This is not a confirmed zero-match; retry shortly.");
+                    return StatusCode(StatusCodes.Status503ServiceUnavailable, "The Audible catalog did not respond. This is not a confirmed zero-match; retry shortly.");
                 }
 
                 return Ok(result);

--- a/listenarr.application/Metadata/Audible/AudibleMetadata.cs
+++ b/listenarr.application/Metadata/Audible/AudibleMetadata.cs
@@ -31,7 +31,18 @@ namespace Listenarr.Application.Metadata.Audible
     public class AudibleGenre { public string? Asin { get; set; } public string? Name { get; set; } public string? Type { get; set; } }
     public class AudibleSeries { public string? Asin { get; set; } public string? Name { get; set; } public string? Position { get; set; } }
 
-    public class AudibleSearchResponse { public List<AudibleSearchResult>? Results { get; set; } public int? TotalResults { get; set; } }
+    public class AudibleSearchResponse
+    {
+        public List<AudibleSearchResult>? Results { get; set; }
+        public int? TotalResults { get; set; }
+
+        /// <summary>
+        /// True when Audible did not answer, so an empty <see cref="Results"/> means the
+        /// lookup failed rather than the catalogue having nothing. Callers that treat an
+        /// empty list as "this book does not exist" need to check this first.
+        /// </summary>
+        public bool ProviderUnavailable { get; set; }
+    }
 
     public class AudibleSearchResult
     {

--- a/listenarr.application/Metadata/Audible/AudibleProductSearchWorkflow.cs
+++ b/listenarr.application/Metadata/Audible/AudibleProductSearchWorkflow.cs
@@ -173,7 +173,10 @@ namespace Listenarr.Application.Metadata.Audible
                 query, title, author, narrator, publisher,
                 page, limit, safeRegion, language, sortBy, returnRawProducts);
 
-            if (result.Results.Count == 0)
+            // A failed call returns zero results, so without the check the diacritics
+            // retry fires against an Audible that just timed out and spends the caller's
+            // remaining budget on a second request that fails the same way.
+            if (result.Results.Count == 0 && !result.ProviderUnavailable)
             {
                 var hasDiacritics =
                     HasDiacritics(query) || HasDiacritics(title) ||
@@ -220,7 +223,10 @@ namespace Listenarr.Application.Metadata.Audible
             using var doc = await _apiClient.GetJsonDocumentAsync(url, safeRegion, includeLocaleHeaders: false, timeoutSeconds: 10);
             if (doc == null)
             {
-                return new SearchProductsDirectResponse();
+                // The client already logged why. What matters here is not losing the fact
+                // that it failed: an empty response with no marker is indistinguishable
+                // from Audible answering "no such book".
+                return new SearchProductsDirectResponse { ProviderUnavailable = true };
             }
 
             var root = doc.RootElement;
@@ -254,7 +260,8 @@ namespace Listenarr.Application.Metadata.Audible
             return new AudibleSearchResponse
             {
                 Results = response.Results,
-                TotalResults = response.TotalResults
+                TotalResults = response.TotalResults,
+                ProviderUnavailable = response.ProviderUnavailable
             };
         }
 

--- a/listenarr.application/Metadata/Audible/AudibleService.cs
+++ b/listenarr.application/Metadata/Audible/AudibleService.cs
@@ -289,7 +289,8 @@ namespace Listenarr.Application.Metadata.Audible
             return new AudibleSearchResponse
             {
                 Results = response.Results,
-                TotalResults = response.TotalResults
+                TotalResults = response.TotalResults,
+                ProviderUnavailable = response.ProviderUnavailable
             };
         }
 

--- a/listenarr.application/Metadata/Audible/SearchProductsDirectResponse.cs
+++ b/listenarr.application/Metadata/Audible/SearchProductsDirectResponse.cs
@@ -25,5 +25,15 @@ namespace Listenarr.Application.Metadata.Audible
         public List<AudibleSearchResult> Results { get; set; } = new();
         public int TotalResults { get; set; }
         public List<JsonElement>? RawProducts { get; set; }
+
+        /// <summary>
+        /// Audible did not answer, so an empty <see cref="Results"/> means "not known"
+        /// rather than "not in the catalogue".
+        ///
+        /// Without this the two are the same object. A per-call timeout returns an empty
+        /// response that is byte for byte what a genuine zero-match produces, and every
+        /// caller downstream has to guess.
+        /// </summary>
+        public bool ProviderUnavailable { get; set; }
     }
 }

--- a/tests/Features/Api/Features/Search/SearchControllerAudibleUnavailableTests.cs
+++ b/tests/Features/Api/Features/Search/SearchControllerAudibleUnavailableTests.cs
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+using Listenarr.Tests.Common;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Listenarr.Tests.Features.Api.Features.Search
@@ -24,7 +25,9 @@ namespace Listenarr.Tests.Features.Api.Features.Search
     /// GET /search/audible has to keep apart: a failed lookup and a catalogue that really
     /// holds nothing. Without the second one, a 503 on every empty result would pass.
     /// </summary>
-    public class SearchControllerAudibleUnavailableTests
+    [Trait("Name", "SearchControllerAudibleUnavailableTests")]
+    [Trait("Category", "Api")]
+    public class SearchControllerAudibleUnavailableTests : BaseTests
     {
         [Fact]
         public async Task SearchAudible_WhenTheProviderDidNotAnswer_Returns503()

--- a/tests/Features/Api/Features/Search/SearchControllerAudibleUnavailableTests.cs
+++ b/tests/Features/Api/Features/Search/SearchControllerAudibleUnavailableTests.cs
@@ -1,0 +1,80 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Microsoft.AspNetCore.Mvc;
+
+namespace Listenarr.Tests.Features.Api.Features.Search
+{
+    /// <summary>
+    /// The flag only earns its keep if the endpoint acts on it. These cover the two answers
+    /// GET /search/audible has to keep apart: a failed lookup and a catalogue that really
+    /// holds nothing. Without the second one, a 503 on every empty result would pass.
+    /// </summary>
+    public class SearchControllerAudibleUnavailableTests
+    {
+        [Fact]
+        public async Task SearchAudible_WhenTheProviderDidNotAnswer_Returns503()
+        {
+            var controller = BuildController(new AudibleSearchResponse
+            {
+                Results = new List<AudibleSearchResult>(),
+                TotalResults = 0,
+                ProviderUnavailable = true
+            });
+
+            var result = await controller.SearchAudible("dune");
+
+            var status = Assert.IsType<ObjectResult>(result.Result);
+            Assert.Equal(503, status.StatusCode);
+        }
+
+        [Fact]
+        public async Task SearchAudible_WhenTheCatalogueAnsweredWithNothing_Returns200()
+        {
+            var controller = BuildController(new AudibleSearchResponse
+            {
+                Results = new List<AudibleSearchResult>(),
+                TotalResults = 0
+            });
+
+            var result = await controller.SearchAudible("dune");
+
+            Assert.IsType<OkObjectResult>(result.Result);
+        }
+
+        private static SearchController BuildController(AudibleSearchResponse response)
+        {
+            var controller = new SearchController(
+                Mock.Of<ISearchService>(),
+                Mock.Of<ILogger<SearchController>>(),
+                new StubAudibleService(response),
+                Mock.Of<IAudiobookMetadataService>());
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext()
+            };
+            return controller;
+        }
+
+        private sealed class StubAudibleService(AudibleSearchResponse response) : AudibleService(new HttpClient(), Mock.Of<ILogger<AudibleService>>())
+        {
+            public override Task<AudibleSearchResponse?> SearchBooksAsync(
+                string query, int page = 1, int limit = 50, string region = "us", string? language = null)
+                => Task.FromResult<AudibleSearchResponse?>(response);
+        }
+    }
+}

--- a/tests/Features/Application/Metadata/Audible/AudibleProviderUnavailableTests.cs
+++ b/tests/Features/Application/Metadata/Audible/AudibleProviderUnavailableTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+using Listenarr.Application.Metadata.Audible;
+using Listenarr.Tests.Common;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Listenarr.Tests.Features.Application.Metadata.Audible;
+
+/// <summary>
+/// A timeout and a genuine zero-match both produce an empty result set. These assert the
+/// two can still be told apart afterwards, which is the whole point: a caller that reads
+/// an empty list as "this book is not in the catalogue" is wrong half the time otherwise.
+/// </summary>
+[Trait("Name", "AudibleProviderUnavailableTests")]
+[Trait("Category", "Application")]
+public sealed class AudibleProviderUnavailableTests : BaseTests
+{
+    [Fact]
+    public async Task SearchProductsDirectAsync_WhenAudibleDoesNotAnswer_MarksTheResultUnavailable()
+    {
+        var workflow = BuildWorkflow(new StallingHandler());
+
+        var result = await workflow.SearchProductsDirectAsync(
+            query: "any", title: null, author: null, narrator: null, publisher: null,
+            page: 1, limit: 10, region: "us", language: null, sortBy: "Relevance");
+
+        Assert.True(result.ProviderUnavailable);
+        Assert.Empty(result.Results);
+    }
+
+    [Fact]
+    public async Task SearchProductsDirectAsync_WhenAudibleAnswersWithNothing_IsAConfirmedZeroMatch()
+    {
+        // The control for the test above. If ProviderUnavailable were set unconditionally
+        // on any empty result, this would fail, and the flag would mean nothing.
+        var workflow = BuildWorkflow(new EmptyCatalogHandler());
+
+        var result = await workflow.SearchProductsDirectAsync(
+            query: "any", title: null, author: null, narrator: null, publisher: null,
+            page: 1, limit: 10, region: "us", language: null, sortBy: "Relevance");
+
+        Assert.False(result.ProviderUnavailable);
+        Assert.Empty(result.Results);
+    }
+
+    [Fact]
+    public async Task SearchProductsDirectAsync_WhenAudibleDoesNotAnswer_DoesNotSpendTheBudgetOnADiacriticsRetry()
+    {
+        // A failed call returns zero results, which used to look exactly like a miss worth
+        // retrying without diacritics. That second request fails the same way and costs the
+        // caller another full timeout.
+        var handler = new StallingHandler();
+        var workflow = BuildWorkflow(handler);
+
+        await workflow.SearchProductsDirectAsync(
+            query: null, title: "Les Mis\u00e9rables", author: null,
+            narrator: null, publisher: null,
+            page: 1, limit: 10, region: "us", language: null, sortBy: "Relevance");
+
+        Assert.Equal(1, handler.Requests);
+    }
+
+    private static AudibleProductSearchWorkflow BuildWorkflow(HttpMessageHandler handler)
+    {
+        var client = new AudibleApiClient(new HttpClient(handler), NullLogger.Instance);
+        return new AudibleProductSearchWorkflow(
+            client,
+            (_, _, _, _) => Task.FromResult<AudibleBookResponse?>(null),
+            NullLogger.Instance);
+    }
+
+    /// <summary>Never answers inside the call's own timeout, which is what a real timeout looks like.</summary>
+    private sealed class StallingHandler : HttpMessageHandler
+    {
+        public int Requests { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests++;
+            await Task.Delay(TimeSpan.FromMinutes(5), cancellationToken);
+            return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+        }
+    }
+
+    /// <summary>Answers promptly, with a catalogue that genuinely holds nothing.</summary>
+    private sealed class EmptyCatalogHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(new { products = Array.Empty<object>() }))
+            });
+        }
+    }
+}

--- a/tests/Features/Application/Metadata/Audible/AudibleProviderUnavailableTests.cs
+++ b/tests/Features/Application/Metadata/Audible/AudibleProviderUnavailableTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Listenarr.Application.Metadata.Audible;
 using Listenarr.Tests.Common;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -59,6 +58,53 @@ public sealed class AudibleProviderUnavailableTests : BaseTests
         Assert.Equal(1, handler.Requests);
     }
 
+    [Theory]
+    [InlineData(500)]
+    [InlineData(503)]
+    [InlineData(429)]
+    public async Task SearchProductsDirectAsync_WhenAudibleRejectsTheCall_MarksTheResultUnavailable(int statusCode)
+    {
+        // A timeout is only one of the ways the call fails. A 5xx and a rate-limit answer are
+        // just as much "not known" as "not in the catalogue", and each of them also arrives as
+        // an empty result set. Only the timeout was covered, so a change to the client that
+        // turned a 500 into an empty document would have gone unnoticed.
+        var workflow = BuildWorkflow(new StatusCodeHandler((System.Net.HttpStatusCode)statusCode));
+
+        var result = await workflow.SearchProductsDirectAsync(
+            query: "any", title: null, author: null, narrator: null, publisher: null,
+            page: 1, limit: 10, region: "us", language: null, sortBy: "Relevance");
+
+        Assert.True(result.ProviderUnavailable);
+        Assert.Empty(result.Results);
+    }
+
+    [Fact]
+    public async Task SearchProductsDirectAsync_WhenTheBodyWillNotParse_MarksTheResultUnavailable()
+    {
+        var workflow = BuildWorkflow(new MalformedBodyHandler());
+
+        var result = await workflow.SearchProductsDirectAsync(
+            query: "any", title: null, author: null, narrator: null, publisher: null,
+            page: 1, limit: 10, region: "us", language: null, sortBy: "Relevance");
+
+        Assert.True(result.ProviderUnavailable);
+        Assert.Empty(result.Results);
+    }
+
+    [Fact]
+    public async Task SearchProductsDirectAsync_WhenTheRequestNeverLeaves_MarksTheResultUnavailable()
+    {
+        // Name resolution and connection refusal both surface as HttpRequestException.
+        var workflow = BuildWorkflow(new TransportFailureHandler());
+
+        var result = await workflow.SearchProductsDirectAsync(
+            query: "any", title: null, author: null, narrator: null, publisher: null,
+            page: 1, limit: 10, region: "us", language: null, sortBy: "Relevance");
+
+        Assert.True(result.ProviderUnavailable);
+        Assert.Empty(result.Results);
+    }
+
     private static AudibleProductSearchWorkflow BuildWorkflow(HttpMessageHandler handler)
     {
         var client = new AudibleApiClient(new HttpClient(handler), NullLogger.Instance);
@@ -80,6 +126,35 @@ public sealed class AudibleProviderUnavailableTests : BaseTests
             await Task.Delay(TimeSpan.FromMinutes(5), cancellationToken);
             return new HttpResponseMessage(System.Net.HttpStatusCode.OK);
         }
+    }
+
+    /// <summary>Answers promptly, and refuses.</summary>
+    private sealed class StatusCodeHandler(System.Net.HttpStatusCode statusCode) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(statusCode));
+    }
+
+    /// <summary>Answers 200 with something that is not JSON.</summary>
+    private sealed class MalformedBodyHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"products\": [ truncated")
+            });
+        }
+    }
+
+    /// <summary>Never reaches Audible at all.</summary>
+    private sealed class TransportFailureHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new HttpRequestException("Name or service not known");
     }
 
     /// <summary>Answers promptly, with a catalogue that genuinely holds nothing.</summary>


### PR DESCRIPTION
Half of #877, and the half that does not wait on anything.

## What it fixes

An Audible call that times out returns an empty result set identical to Audible answering "no such book". The per-call `CancellationTokenSource` fires, `AudibleApiClient` logs a warning and returns null, and `SearchProductsCoreAsync` turns that null into `new SearchProductsDirectResponse()`. From there nothing can tell the two apart, and a caller reasonably reads an empty list as an absence. The report behind #877 was an external script doing exactly that.

`SearchProductsDirectResponse` now carries `ProviderUnavailable`, set where the null is currently discarded. It rides through both `ToSearchResponse` copies onto `AudibleSearchResponse`, and `GET /search/audible` answers 503 instead of a 200 that makes a false claim about the catalogue. The field is additive, so a client that ignores it sees what it saw before.

## The obvious patch does not work, and it is worth saying why

Adding `.Or<TaskCanceledException>()` to the existing Polly policy looks like the fix and changes nothing. `AudibleApiClient` passes its own token into `SendAsync`, and `PolicyHttpMessageHandler` hands that token to `policy.ExecuteAsync`, so the retry engine holds an already-cancelled token before it can make a second attempt. That is measured at the message handler in #877 rather than reasoned about.

Nothing here touches Polly. The retry half of #877 is left alone deliberately: it interacts with #635's planned refactor of `AudibleApiClient`, and picking per-attempt durations needs Audible latency figures I do not have.

## A flag rather than an exception

Readarr throws at this boundary, and I looked at doing the same. `BookInfoProxy` rethrows as `BookInfoException` and `SearchController.Search` has no try/catch, so a provider failure reaches the error handler.

Throwing from `SearchProductsCoreAsync` here would reach fifteen call sites across series lookup, author-catalog paging and several fallback cascades inside this same workflow, all of which currently degrade to an empty page and carry on. That is a much larger behaviour change than the contract fix needs, and not one I would make while #635 is open. If you would rather have the exception, it is a small change from here and the flag goes away.

## One thing that fell out of reading it

`SearchProductsDirectAsync` retries with diacritics stripped whenever a result comes back empty. A timeout comes back empty, so it was spending the caller's remaining budget on a second request that failed the same way, inside a 10 second budget the existing 2, 4 and 8 second backoff already overruns. It checks the flag first now.

## What this does not fix

`POST /api/v1/search` still collapses the two. Carrying the signal through `SearchService.IntelligentSearchAsync` means changing its return type, which is a larger contract decision than this. That is the endpoint the original report came from, so this is a partial answer to #877 and I would rather say so than let it read as closed.

## Tests

Three: the failure case, a control on a promptly answered empty catalogue so the flag cannot be set unconditionally, and the diacritics budget. Each was checked by reverting its own half of the production change.

The first version of the diacritics test was worthless. It passed with the guard removed, because the title I picked had no diacritics in it, so the retry never fired either way. It uses an accented title now and fails as it should. Mentioning it because a test that cannot fail looks exactly like one that passes.

Full unfiltered suite: 3121 passed, 0 failed, 130 skipped.

Checked against canary `a630572e`.
