### PR TITLE
feat(import): embed cover art into imported files, behind a setting

### DIFF
--- a/fe/src/__tests__/FeaturesSection.spec.ts
+++ b/fe/src/__tests__/FeaturesSection.spec.ts
@@ -30,7 +30,7 @@ describe('FeaturesSection', () => {
       props: {
         settings: {
           enableMetadataProcessing: false,
-          enableCoverArtDownload: false,
+          embedCoverArtInAudioFiles: false,
           enableNotifications: false,
           showCompletedExternalDownloads: false,
         },
@@ -47,6 +47,6 @@ describe('FeaturesSection', () => {
     await checks[1].setValue(true)
     last =
       wrapper.emitted()['update:settings']![wrapper.emitted()['update:settings']!.length - 1][0]
-    expect(last.enableCoverArtDownload).toBe(true)
+    expect(last.embedCoverArtInAudioFiles).toBe(true)
   })
 })

--- a/fe/src/components/settings/FeaturesSection.vue
+++ b/fe/src/components/settings/FeaturesSection.vue
@@ -27,10 +27,10 @@
       />
 
       <CheckboxCard
-        :modelValue="settings.enableCoverArtDownload"
-        @update:modelValue="updateEnableCoverArtDownload"
-        title="Enable Cover Art Download"
-        description="Download and embed cover art for audiobooks"
+        :modelValue="settings.embedCoverArtInAudioFiles"
+        @update:modelValue="updateEmbedCoverArtInAudioFiles"
+        title="Embed Cover Art In Audio Files"
+        description="Write cover art into audiobook files as they are imported. Rewrites the file, so it is off by default."
       />
 
       <CheckboxCard
@@ -70,8 +70,8 @@ function updateEnableMetadataProcessing(value: boolean) {
   updateField('enableMetadataProcessing', value)
 }
 
-function updateEnableCoverArtDownload(value: boolean) {
-  updateField('enableCoverArtDownload', value)
+function updateEmbedCoverArtInAudioFiles(value: boolean) {
+  updateField('embedCoverArtInAudioFiles', value)
 }
 
 function updateEnableNotifications(value: boolean) {

--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -426,7 +426,7 @@ export interface ApplicationSettings {
   fileNamingPattern: string
   multiFileNamingPattern: string
   enableMetadataProcessing: boolean
-  enableCoverArtDownload: boolean
+  embedCoverArtInAudioFiles: boolean
   audnexusApiUrl: string
   maxConcurrentDownloads: number
   unmatchedScanConcurrency?: number

--- a/listenarr.api/Features/Downloads/ManualImportController.ProcessItem.cs
+++ b/listenarr.api/Features/Downloads/ManualImportController.ProcessItem.cs
@@ -379,16 +379,17 @@ public partial class ManualImportController
                 {
                     try
                     {
-                        await _metadataService.WriteAsinTagAsync(
+                        await _metadataService.WriteImportTagsAsync(
                             registrationLease,
-                            audiobook.Asin);
+                            audiobook.Asin,
+                            audiobook.ImageUrl);
                     }
                     catch (Exception exception) when (exception is not (
                         OutOfMemoryException or StackOverflowException))
                     {
                         _logger.LogWarning(
                             exception,
-                            "Manual import completed, but generation-bound ASIN tag enrichment failed for audiobook {AudiobookId} at {Path}",
+                            "Manual import completed, but generation-bound tag enrichment failed for audiobook {AudiobookId} at {Path}",
                             audiobook.Id,
                             LogRedaction.SanitizeFilePath(destinationPath));
                     }

--- a/listenarr.application/Audiobooks/Contracts/AudioCoverArt.cs
+++ b/listenarr.application/Audiobooks/Contracts/AudioCoverArt.cs
@@ -1,0 +1,53 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+namespace Listenarr.Application.Audiobooks.Contracts
+{
+    /// <summary>
+    /// Cover artwork to embed into an audio file, with the MIME type the container needs
+    /// to record alongside the bytes.
+    /// </summary>
+    public sealed record AudioCoverArt(byte[] Data, string MimeType)
+    {
+        /// <summary>
+        /// Identify the image from its leading bytes rather than trusting a file extension
+        /// or a Content-Type header, neither of which is available by the time the bytes
+        /// reach the tag writer. Returns null when the bytes are not an image this can
+        /// name, because writing artwork under the wrong MIME type produces a file players
+        /// silently refuse to show a cover for.
+        /// </summary>
+        public static AudioCoverArt? FromBytes(byte[]? data)
+        {
+            if (data is null || data.Length < 12)
+            {
+                return null;
+            }
+
+            if (data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF)
+            {
+                return new AudioCoverArt(data, "image/jpeg");
+            }
+
+            if (data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47)
+            {
+                return new AudioCoverArt(data, "image/png");
+            }
+
+            // "RIFF" .... "WEBP"
+            if (data[0] == 0x52 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x46
+                && data[8] == 0x57 && data[9] == 0x45 && data[10] == 0x42 && data[11] == 0x50)
+            {
+                return new AudioCoverArt(data, "image/webp");
+            }
+
+            return null;
+        }
+    }
+}

--- a/listenarr.application/Audiobooks/Contracts/IAudioTagWriter.cs
+++ b/listenarr.application/Audiobooks/Contracts/IAudioTagWriter.cs
@@ -25,5 +25,15 @@ namespace Listenarr.Application.Audiobooks.Contracts
         Task WriteAsinTagAsync(
             IAudiobookFileRegistrationLease registrationLease,
             string asin);
+
+        /// <summary>
+        /// Write the ASIN and, when supplied, embed cover artwork, in a single open and save.
+        /// Splitting these into two calls would rewrite the file twice, and an audiobook is
+        /// commonly several gigabytes.
+        /// </summary>
+        Task WriteTagsAsync(
+            IAudiobookFileRegistrationLease registrationLease,
+            string? asin,
+            AudioCoverArt? coverArt);
     }
 }

--- a/listenarr.application/Metadata/Contracts/IMetadataService.cs
+++ b/listenarr.application/Metadata/Contracts/IMetadataService.cs
@@ -94,6 +94,15 @@ namespace Listenarr.Application.Metadata.Contracts
         /// </summary>
         /// <param name="coverArtUrl">URL of the cover art image</param>
         /// <returns>Image data as byte array or null if failed</returns>
+        /// <summary>
+        /// Write the tags an import should leave behind: always the ASIN, and cover artwork
+        /// as well when <c>EmbedCoverArtInAudioFiles</c> is on. Both go in one open and save.
+        /// </summary>
+        Task WriteImportTagsAsync(
+            IAudiobookFileRegistrationLease registrationLease,
+            string asin,
+            string? coverArtUrl);
+
         Task<byte[]?> DownloadCoverArtAsync(string coverArtUrl);
     }
 }

--- a/listenarr.application/Metadata/Extraction/MetadataService.cs
+++ b/listenarr.application/Metadata/Extraction/MetadataService.cs
@@ -256,6 +256,51 @@ namespace Listenarr.Application.Metadata.Extraction
                 asin);
         }
 
+        public async Task WriteImportTagsAsync(
+            IAudiobookFileRegistrationLease registrationLease,
+            string asin,
+            string? coverArtUrl)
+        {
+            ArgumentNullException.ThrowIfNull(registrationLease);
+
+            var coverArt = await ResolveCoverArtAsync(coverArtUrl);
+            await _audioTagWriter.WriteTagsAsync(registrationLease, asin, coverArt);
+        }
+
+        /// <summary>
+        /// Fetch and identify cover artwork, but only when the setting asks for it.
+        ///
+        /// The setting is read first so that an instance with embedding off never makes the
+        /// request at all: this runs on the import path, and a network round trip per file
+        /// is not something to spend when the result would be discarded. Any failure to
+        /// resolve artwork returns null rather than throwing, because a missing cover must
+        /// not fail an import that has otherwise succeeded.
+        /// </summary>
+        private async Task<AudioCoverArt?> ResolveCoverArtAsync(string? coverArtUrl)
+        {
+            if (string.IsNullOrWhiteSpace(coverArtUrl))
+            {
+                return null;
+            }
+
+            var settings = await _configurationService.GetApplicationSettingsAsync();
+            if (settings?.EmbedCoverArtInAudioFiles != true)
+            {
+                return null;
+            }
+
+            var bytes = await DownloadCoverArtAsync(coverArtUrl);
+            var coverArt = AudioCoverArt.FromBytes(bytes);
+            if (coverArt is null && bytes is not null)
+            {
+                _logger.LogDebug(
+                    "Cover art from {Url} was not a recognised image, so nothing was embedded",
+                    LogRedaction.SanitizeUrl(coverArtUrl));
+            }
+
+            return coverArt;
+        }
+
         public async Task<byte[]?> DownloadCoverArtAsync(string coverArtUrl)
         {
             try

--- a/listenarr.domain/Configuration/ApplicationSettings.cs
+++ b/listenarr.domain/Configuration/ApplicationSettings.cs
@@ -60,7 +60,28 @@ namespace Listenarr.Domain.Configuration
         public string MultiFileNamingPattern { get; set; } = "{Title}-{DiskNumber:00}-{ChapterNumber:00}";
 
         public bool EnableMetadataProcessing { get; set; } = true;
+        /// <summary>
+        /// Embed cover artwork into audio files as they are imported.
+        ///
+        /// This replaces EnableCoverArtDownload, which was persisted from the day the
+        /// Settings page was added and never read by anything. Reusing that column would
+        /// have inherited a stored true on every existing instance, since the value came
+        /// from a property initialiser rather than from anyone choosing it, and embedding
+        /// rewrites the audio file. A new column starts false for everyone, so the
+        /// behaviour is opt-in on upgrade rather than something an operator discovers.
+        /// </summary>
+        /// <summary>
+        /// Dead flag, kept only so this change stays a single additive migration.
+        ///
+        /// Persisted since the Settings page was added and never read by anything. Its
+        /// stored value is true on every existing instance because that was the property
+        /// initialiser, not because an operator chose it, which is why the embedding
+        /// behaviour below is governed by a new column instead of this one. Dropping it is
+        /// a separate mechanical change.
+        /// </summary>
         public bool EnableCoverArtDownload { get; set; } = true;
+
+        public bool EmbedCoverArtInAudioFiles { get; set; } = false;
         public string AudnexusApiUrl { get; set; } = "https://api.audnex.us";
         public int MaxConcurrentDownloads { get; set; } = 3;
         public int PollingIntervalSeconds { get; set; } = 30;

--- a/listenarr.infrastructure/Library/Files/TagLibAudioTagWriter.cs
+++ b/listenarr.infrastructure/Library/Files/TagLibAudioTagWriter.cs
@@ -52,9 +52,15 @@ namespace Listenarr.Infrastructure.Library.Files
         public Task WriteAsinTagAsync(
             IAudiobookFileRegistrationLease registrationLease,
             string asin)
+            => WriteTagsAsync(registrationLease, asin, coverArt: null);
+
+        public Task WriteTagsAsync(
+            IAudiobookFileRegistrationLease registrationLease,
+            string? asin,
+            AudioCoverArt? coverArt)
         {
             ArgumentNullException.ThrowIfNull(registrationLease);
-            if (string.IsNullOrWhiteSpace(asin))
+            if (string.IsNullOrWhiteSpace(asin) && coverArt is null)
             {
                 return Task.CompletedTask;
             }
@@ -70,22 +76,56 @@ namespace Listenarr.Infrastructure.Library.Files
             {
                 using var file = TagLib.File.Create(
                     new RegistrationLeaseFileAbstraction(registrationLease));
-                ApplyAsinTag(file, asin);
+
+                if (!string.IsNullOrWhiteSpace(asin))
+                {
+                    ApplyAsinTag(file, asin);
+                }
+
+                var wroteCover = coverArt is not null && ApplyCoverArt(file, coverArt);
                 file.Save();
                 _logger.LogDebug(
-                    "Wrote ASIN tag '{Asin}' to generation-bound file {File}",
-                    asin,
-                    LogRedaction.SanitizeFilePath(registrationLease.PublicPath));
+                    "Wrote tags to generation-bound file {File}. ASIN: {Asin}, cover art embedded: {Cover}",
+                    LogRedaction.SanitizeFilePath(registrationLease.PublicPath),
+                    asin ?? "(none)",
+                    wroteCover);
             }
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
             {
                 _logger.LogWarning(
                     ex,
-                    "Failed to write ASIN tag to generation-bound file {File} - import will continue",
+                    "Failed to write tags to generation-bound file {File} - import will continue",
                     LogRedaction.SanitizeFilePath(registrationLease.PublicPath));
             }
 
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Replace the file's embedded pictures with the supplied artwork.
+        ///
+        /// Replacing rather than appending: a file that already carries a cover and gains a
+        /// second one shows whichever the player happens to pick first, which looks like a
+        /// bug to whoever asked for the artwork to be corrected. Returns false when the
+        /// container reports no tag to write into, so the caller can say so rather than
+        /// claim a write that did not happen.
+        /// </summary>
+        private static bool ApplyCoverArt(TagLib.File file, AudioCoverArt coverArt)
+        {
+            if (file.Tag is null)
+            {
+                return false;
+            }
+
+            var picture = new TagLib.Picture(new TagLib.ByteVector(coverArt.Data))
+            {
+                Type = TagLib.PictureType.FrontCover,
+                MimeType = coverArt.MimeType,
+                Description = "Cover"
+            };
+
+            file.Tag.Pictures = new TagLib.IPicture[] { picture };
+            return true;
         }
 
         private static void ApplyAsinTag(TagLib.File file, string asin)

--- a/listenarr.infrastructure/Persistence/Migrations/20260828190320_AddEmbedCoverArtInAudioFilesSetting.Designer.cs
+++ b/listenarr.infrastructure/Persistence/Migrations/20260828190320_AddEmbedCoverArtInAudioFilesSetting.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Listenarr.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Listenarr.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ListenArrDbContext))]
-    partial class ListenArrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260828190320_AddEmbedCoverArtInAudioFilesSetting")]
+    partial class AddEmbedCoverArtInAudioFilesSetting
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/listenarr.infrastructure/Persistence/Migrations/20260828190320_AddEmbedCoverArtInAudioFilesSetting.cs
+++ b/listenarr.infrastructure/Persistence/Migrations/20260828190320_AddEmbedCoverArtInAudioFilesSetting.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Listenarr.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmbedCoverArtInAudioFilesSetting : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "EmbedCoverArtInAudioFiles",
+                table: "ApplicationSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmbedCoverArtInAudioFiles",
+                table: "ApplicationSettings");
+        }
+    }
+}

--- a/tests/Features/Api/Features/Downloads/ManualImportControllerTests.cs
+++ b/tests/Features/Api/Features/Downloads/ManualImportControllerTests.cs
@@ -2250,9 +2250,10 @@ namespace Listenarr.Tests.Features.Api.Features.Downloads
                     Format = "mp3",
                     BitRate = 128000
                 });
-            metadata.Setup(service => service.WriteAsinTagAsync(
+            metadata.Setup(service => service.WriteImportTagsAsync(
                     It.IsAny<IAudiobookFileRegistrationLease>(),
-                    book.Asin))
+                    book.Asin,
+                    It.IsAny<string?>()))
                 .ThrowsAsync(new IOException("simulated tag failure"));
             var controller = GetController(
                 book,
@@ -2297,9 +2298,10 @@ namespace Listenarr.Tests.Features.Api.Features.Downloads
                 "audio",
                 await File.ReadAllTextAsync(
                     Path.Join(destinationRoot, "Tagged Book.mp3")));
-            metadata.Verify(service => service.WriteAsinTagAsync(
+            metadata.Verify(service => service.WriteImportTagsAsync(
                 It.IsAny<IAudiobookFileRegistrationLease>(),
-                book.Asin), Times.Once);
+                book.Asin,
+                It.IsAny<string?>()), Times.Once);
             metadata.Verify(service => service.WriteAsinTagAsync(
                 It.IsAny<string>(),
                 It.IsAny<string>()), Times.Never);

--- a/tests/Features/Application/Audiobooks/Contracts/AudioCoverArtTests.cs
+++ b/tests/Features/Application/Audiobooks/Contracts/AudioCoverArtTests.cs
@@ -1,0 +1,33 @@
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Application.Audiobooks.Contracts;
+
+[Trait("Name", "AudioCoverArtTests")]
+[Trait("Category", "Application")]
+public sealed class AudioCoverArtTests : BaseTests
+{
+    [Fact]
+    public void FromBytes_NamesTheImageTypeFromItsLeadingBytes()
+    {
+        var jpeg = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        var png = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0, 0, 0, 0 };
+        var webp = new byte[] { 0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50 };
+
+        Assert.Equal("image/jpeg", AudioCoverArt.FromBytes(jpeg)!.MimeType);
+        Assert.Equal("image/png", AudioCoverArt.FromBytes(png)!.MimeType);
+        Assert.Equal("image/webp", AudioCoverArt.FromBytes(webp)!.MimeType);
+    }
+
+    [Fact]
+    public void FromBytes_RefusesAnythingItCannotName()
+    {
+        // An indexer or a metadata source can answer an image request with an HTML error
+        // page. Embedding that under image/jpeg produces a file whose cover silently fails
+        // to render, which is harder to diagnose than no cover at all.
+        var html = "<!DOCTYPE html><html><body>404"u8.ToArray();
+
+        Assert.Null(AudioCoverArt.FromBytes(html));
+        Assert.Null(AudioCoverArt.FromBytes(null));
+        Assert.Null(AudioCoverArt.FromBytes([0xFF, 0xD8]));
+    }
+}

--- a/tests/Features/Application/Metadata/Extraction/MetadataServiceTests.cs
+++ b/tests/Features/Application/Metadata/Extraction/MetadataServiceTests.cs
@@ -173,6 +173,112 @@ namespace Listenarr.Tests.Features.Application.Metadata.Extraction
             Assert.Equal(1, metadata.DiscNumber);
         }
 
+        [Fact]
+        public async Task WriteImportTagsAsync_WhenCoverArtIsDisabled_WritesTheAsinAndNoArtwork()
+        {
+            var writer = new Mock<IAudioTagWriter>();
+            var handler = new CountingImageHandler();
+            var service = CreateTagWritingService(writer.Object, handler, enableCoverArt: false);
+
+            await service.WriteImportTagsAsync(
+                Mock.Of<IAudiobookFileRegistrationLease>(),
+                "B0TESTASIN",
+                "https://images.example.com/cover.jpg");
+
+            writer.Verify(
+                w => w.WriteTagsAsync(
+                    It.IsAny<IAudiobookFileRegistrationLease>(),
+                    "B0TESTASIN",
+                    null),
+                Times.Once);
+
+            // The setting is checked before the request, so a disabled instance does not pay
+            // for a fetch whose result it would throw away.
+            Assert.Equal(0, handler.Requests);
+        }
+
+        [Fact]
+        public async Task WriteImportTagsAsync_WhenCoverArtIsEnabled_EmbedsTheFetchedArtwork()
+        {
+            var writer = new Mock<IAudioTagWriter>();
+            var handler = new CountingImageHandler();
+            var service = CreateTagWritingService(writer.Object, handler, enableCoverArt: true);
+
+            await service.WriteImportTagsAsync(
+                Mock.Of<IAudiobookFileRegistrationLease>(),
+                "B0TESTASIN",
+                "https://images.example.com/cover.jpg");
+
+            writer.Verify(
+                w => w.WriteTagsAsync(
+                    It.IsAny<IAudiobookFileRegistrationLease>(),
+                    "B0TESTASIN",
+                    It.Is<AudioCoverArt>(art => art.MimeType == "image/jpeg")),
+                Times.Once);
+            Assert.Equal(1, handler.Requests);
+        }
+
+        [Fact]
+        public async Task WriteImportTagsAsync_WhenTheResponseIsNotAnImage_StillWritesTheAsin()
+        {
+            // An image host answering with an error page must not cost the import its ASIN
+            // tag, and must not embed the error page as a cover.
+            var writer = new Mock<IAudioTagWriter>();
+            var handler = new CountingImageHandler(body: "<html>nope</html>"u8.ToArray());
+            var service = CreateTagWritingService(writer.Object, handler, enableCoverArt: true);
+
+            await service.WriteImportTagsAsync(
+                Mock.Of<IAudiobookFileRegistrationLease>(),
+                "B0TESTASIN",
+                "https://images.example.com/cover.jpg");
+
+            writer.Verify(
+                w => w.WriteTagsAsync(
+                    It.IsAny<IAudiobookFileRegistrationLease>(),
+                    "B0TESTASIN",
+                    null),
+                Times.Once);
+        }
+
+        private sealed class CountingImageHandler(byte[]? body = null) : HttpMessageHandler
+        {
+            private readonly byte[] _body = body ?? [0xFF, 0xD8, 0xFF, 0xE0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+            public int Requests { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                Requests++;
+                return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(_body)
+                });
+            }
+        }
+
+        private static MetadataService CreateTagWritingService(
+            IAudioTagWriter writer,
+            HttpMessageHandler handler,
+            bool enableCoverArt)
+        {
+            var configuration = new Mock<IConfigurationService>();
+            configuration.Setup(service => service.GetApplicationSettingsAsync())
+                .ReturnsAsync(new ApplicationSettings
+                {
+                    EmbedCoverArtInAudioFiles = enableCoverArt
+                });
+
+            return new MetadataService(
+                new HttpClient(handler),
+                configuration.Object,
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<MetadataService>.Instance,
+                Mock.Of<IFfmpegService>(),
+                writer,
+                Mock.Of<IFileSystem>());
+        }
+
         private static MetadataService CreateMetadataService(
             IFfmpegService ffmpegService)
         {

--- a/tests/Features/Infrastructure/Library/Files/TagLibAudioTagWriterTests.cs
+++ b/tests/Features/Infrastructure/Library/Files/TagLibAudioTagWriterTests.cs
@@ -8,6 +8,20 @@ namespace Listenarr.Tests.Features.Infrastructure.Library.Files;
 public sealed class TagLibAudioTagWriterTests : BaseTests
 {
     [Fact]
+    public async Task WriteTagsAsync_WithNothingToWrite_DoesNotTouchTheFile()
+    {
+        // The gate lives above this, in MetadataService, which passes a null cover when the
+        // setting is off. If both are absent there is nothing to write, and opening a
+        // multi-gigabyte file to save it unchanged is the cost worth avoiding.
+        var lease = new Mock<IAudiobookFileRegistrationLease>(MockBehavior.Strict);
+        var writer = new TagLibAudioTagWriter(Mock.Of<ILogger<TagLibAudioTagWriter>>());
+
+        await writer.WriteTagsAsync(lease.Object, asin: null, coverArt: null);
+
+        lease.VerifyNoOtherCalls();
+    }
+
+    [Fact]
     public async Task WriteAsinTagAsync_ScanOnlyLease_DoesNotRequestMetadataStreams()
     {
         var lease = new Mock<IAudiobookFileRegistrationLease>(MockBehavior.Strict);

--- a/tests/Features/Infrastructure/Persistence/SqliteMigrationSchemaTests.cs
+++ b/tests/Features/Infrastructure/Persistence/SqliteMigrationSchemaTests.cs
@@ -42,6 +42,8 @@ public class SqliteMigrationSchemaTests : BaseTests
         "20260821141235_AddCompatibilityFilePublication";
     private const string WeakStorageVerifiedCleanupMigrationId =
         "20260825021432_AddWeakStorageVerifiedCleanup";
+    private const string EmbedCoverArtSettingMigrationId =
+        "20260828190320_AddEmbedCoverArtInAudioFilesSetting";
 
     private static (SqliteConnection Connection, ListenArrDbContext Context)
         CreateMigratedSqliteContext()
@@ -199,7 +201,8 @@ public class SqliteMigrationSchemaTests : BaseTests
                 MoveJobRelocationForeignKeyMigrationId,
                 FileMutationParentGenerationProofsMigrationId,
                 CompatibilityFilePublicationMigrationId,
-                WeakStorageVerifiedCleanupMigrationId
+                WeakStorageVerifiedCleanupMigrationId,
+                EmbedCoverArtSettingMigrationId
             ],
             postCanary);
         Assert.Contains("20251124102000_AddMoveJobSourcePath", applied);

--- a/tests/Mocks/MetadataServiceMock.cs
+++ b/tests/Mocks/MetadataServiceMock.cs
@@ -76,5 +76,17 @@ namespace Listenarr.Tests.Mocks
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>Records what an import asked to be written, so a test can assert on it.</summary>
+        public List<(string Asin, string? CoverArtUrl)> ImportTagWrites { get; } = [];
+
+        public Task WriteImportTagsAsync(
+            IAudiobookFileRegistrationLease registrationLease,
+            string asin,
+            string? coverArtUrl)
+        {
+            ImportTagWrites.Add((asin, coverArtUrl));
+            return Task.CompletedTask;
+        }
     }
 }


### PR DESCRIPTION
Closes #833, if you want the setting kept. I offered this as a branch on that issue rather than a PR because the default is a judgement call. Opening it now so it is reviewable, with that question still genuinely open.

## What #833 found

`EnableCoverArtDownload` has been persisted since the Settings page was added and read by nothing. One declaration, no reader anywhere in the backend, and a checkbox saying "Download and embed cover art for audiobooks" that describes neither half of what happens.

## The direction, and why it is not the obvious one

Checking the family first changed my answer. Readarr, Lidarr and Sonarr have no toggle at all for downloading cover images for the UI: `MediaCoverService` takes `IConfigFileProvider` only for `UrlBase`. The boolean of this exact shape is Lidarr's `EmbedCoverArt` (`ConfigService.cs:308`, read at `AudioTagService.cs:117`), labelled "Embed Cover Art In Audio Files". So in that family a flag like this governs embedding, not fetching.

That also rules out the change I would otherwise have made. Gating the existing image cache looked cheapest, but `ImageCacheService` cannot tell an audiobook cover from an author or series image, so a checkbox reading "cover art for audiobooks" would have silently blanked author and series artwork.

## Off by default, deliberately not matching Lidarr

Lidarr defaults `EmbedCoverArt` to true, but hides it behind `WriteAudioTags`, which defaults to `No`, so nothing embeds out of the box there. Listenarr has no equivalent master switch and its ASIN write is unconditional, so porting the default without the gate would be more aggressive than the setting it copies.

This is the part I am least sure you will agree with. It is a one-line change if you would rather it defaulted on.

## Why a new column rather than wiring the old one

`EnableCoverArtDownload` is true on every existing instance because that was the property initialiser, not because an operator chose it. Two approaches did not survive:

- a data migration flipping the stored value, which `MigrationProvenanceArchitectureTests` forbids outright
- renaming the column, which EF scaffolds as `RenameColumn` and therefore preserves the stored true, so every existing install would silently start rewriting audio files on upgrade

`EmbedCoverArtInAudioFiles` is added with `defaultValue: false`, so existing rows are off by construction. The dead flag is left in place so this stays a single additive scaffold. Dropping it is a separate mechanical change and I did not want it riding along with behaviour.

## Scope

Manual import only, which is where the one existing tag write lives. Artwork and the ASIN go in one open and save, since a second pass would rewrite a file that is often several gigabytes twice. The automatic import path writes no tags at all today and is untouched, and nothing rewrites artwork for files already in the library.

The bytes are identified from their leading bytes rather than trusted from a URL or a `Content-Type`, because an image host answering with an HTML error page would otherwise be embedded under `image/jpeg` and produce a file whose cover silently fails to render.

It also gives `DownloadCoverArtAsync` its first production caller. It has been dead since it was written.

## Conflicts to expect

This edits the pinned migration list in `SqliteMigrationSchemaTests` and the model snapshot, so it collides with any other PR adding a migration, including your #841 against our #763. It also collides with the release blocklist branch for the same reason. Whichever lands second wants a rebase; the resolution is keeping both ids in migration-timestamp order.

## Tests

Backend 3124 passed, frontend 607 passed. The gate has a control: the test fails with the settings check removed, which I checked rather than assumed.

Happy to change the default, split the frontend copy fix out on its own, or close this if you would rather the setting were removed instead.

Worked through with Claude Code at my direction. The suite numbers are runs on this machine against this branch, and the family citations are source-reading against Lidarr and Readarr. I reviewed this before posting.
