### PR TITLE
fix(library): a destination equal to a configured root plans the book folder instead of claiming the root

### DIFF
--- a/listenarr.application/Audiobooks/Catalog/LibraryAddService.Destination.cs
+++ b/listenarr.application/Audiobooks/Catalog/LibraryAddService.Destination.cs
@@ -60,6 +60,37 @@ public partial class LibraryAddService
                     normalizedRequestedBaseDirectory);
             }
 
+            if (IsExactlyAllowedDestinationRoot(
+                    normalizedRequestedBaseDirectory,
+                    allowedDestinationRoots))
+            {
+                // A destination that IS a root folder is a root selection, not
+                // the audiobook's folder. No audiobook may claim a root as its
+                // own BasePath: the destination guard rejects every later add
+                // aimed at that root, and imports would land files loose at the
+                // library root. Plan the book's folder under the chosen root
+                // exactly as an omitted destination plans it under the default.
+                settings ??= await _configurationService.GetApplicationSettingsAsync();
+                var plannedBasePath = Path.Join(
+                    normalizedRequestedBaseDirectory,
+                    _fileNamingService.ApplyNamingPattern(
+                        settings.FolderNamingPattern,
+                        metadata));
+                if (!FileUtils.TryNormalizeUserProvidedDirectoryPathForCurrentOs(
+                    plannedBasePath,
+                    out var normalizedPlannedBasePath,
+                    out var plannedValidationReason,
+                    rejectParentTraversal: true))
+                {
+                    return ValidationFailure(
+                        "destination_path_invalid",
+                        $"Generated library destination is invalid: {plannedValidationReason}",
+                        plannedBasePath);
+                }
+
+                normalizedRequestedBaseDirectory = normalizedPlannedBasePath;
+            }
+
             audiobook.BasePath = normalizedRequestedBaseDirectory;
         }
         else
@@ -131,4 +162,11 @@ public partial class LibraryAddService
                 destinationBlockingReason,
                 audiobook.BasePath);
     }
+
+    private static bool IsExactlyAllowedDestinationRoot(
+        string normalizedDestination,
+        IReadOnlyCollection<string> allowedDestinationRoots) =>
+        allowedDestinationRoots.Any(root =>
+            FileUtils.IsPathSameOrInside(normalizedDestination, root)
+            && !FileUtils.IsPathInsideOf(normalizedDestination, root));
 }

--- a/listenarr.application/Audiobooks/Catalog/LibraryAddService.Destination.cs
+++ b/listenarr.application/Audiobooks/Catalog/LibraryAddService.Destination.cs
@@ -165,8 +165,27 @@ public partial class LibraryAddService
 
     private static bool IsExactlyAllowedDestinationRoot(
         string normalizedDestination,
-        IReadOnlyCollection<string> allowedDestinationRoots) =>
-        allowedDestinationRoots.Any(root =>
-            FileUtils.IsPathSameOrInside(normalizedDestination, root)
-            && !FileUtils.IsPathInsideOf(normalizedDestination, root));
+        IReadOnlyCollection<string> allowedDestinationRoots)
+    {
+        // Exact canonical spelling is the conservative test here: the root
+        // selection this rewrites always arrives as the root's stored path. A
+        // case-alias spelling of a root simply skips subfolder planning and
+        // falls through to the destination guard, exactly as before.
+        var canonicalDestination = FileSystemPathIdentity
+            .TryCanonicalizeUnambiguousStoredAbsolutePathForHost(
+                normalizedDestination,
+                out var normalized,
+                out _)
+            ? normalized
+            : normalizedDestination;
+        return allowedDestinationRoots.Any(root => string.Equals(
+            FileSystemPathIdentity.TryCanonicalizeUnambiguousStoredAbsolutePathForHost(
+                root,
+                out var canonicalRoot,
+                out _)
+                ? canonicalRoot
+                : root,
+            canonicalDestination,
+            StringComparison.Ordinal));
+    }
 }

--- a/tests/Features/Api/Features/Library/LibraryController_AddToLibraryTests.cs
+++ b/tests/Features/Api/Features/Library/LibraryController_AddToLibraryTests.cs
@@ -121,6 +121,36 @@ namespace Listenarr.Tests.Features.Api.Features.Library
         }
 
         [Fact]
+        public async Task AddToLibrary_DestinationIsConfiguredRoot_PlansFolderUnderRootInsteadOfClaimingIt()
+        {
+            // A destination equal to a configured root folder is a root
+            // selection. Persisting the root itself as BasePath makes the
+            // destination guard reject every later add aimed at that root and
+            // sends the book's eventual import loose into the library root.
+            var controller = _provider.GetRequiredService<LibraryController>();
+
+            var result = await controller.AddToLibrary(new LibraryController.AddToLibraryRequest
+            {
+                Metadata = new AudibleBookMetadata
+                {
+                    Title = "Root Selection Probe",
+                    Authors = ["Rooted Author"]
+                },
+                DestinationPath = tempRoot,
+                Monitored = true
+            });
+
+            Assert.IsType<OkObjectResult>(result);
+            var audiobook = Assert.Single(await _audiobookRepository.GetAllAsync());
+            Assert.NotEqual(
+                Path.GetFullPath(tempRoot),
+                Path.GetFullPath(audiobook.BasePath!));
+            Assert.Equal(
+                Path.GetFullPath(Path.Join(tempRoot, "Rooted Author")),
+                Path.GetFullPath(audiobook.BasePath!));
+        }
+
+        [Fact]
         public async Task AddToLibrary_ConcurrentIdentifierlessSameDestination_CommitsExactlyOnce()
         {
             var destination = Path.Join(tempRoot, "Identifierless", "Book");


### PR DESCRIPTION
## The bug

`LibraryAddService` persists a provided `DestinationPath` verbatim as the audiobook's `BasePath`. When a client passes the **root folder path itself** ("put it under this root" — my series bulk-add UI does, and any API caller can), the record ends up with `BasePath = <root>`. Two failure modes:

1. **One such record poisons all future adds to that root.** The post-#717 destination mutation guard rejects any destination "already assigned to another audiobook" — with a record claiming the root, every subsequent root-destined add fails `destination_path_blocked`. On my instance 102 wishlist records had accumulated `BasePath = /audiobooks`, at which point bulk-adding an entire series failed 100% (that's how I found it).
2. **Imports land loose in the library root.** When such a record's download completes, files import into `BasePath` = the root — 10 of my records had scattered ~330 loose files at the top of the library before the guard started blocking.

## The fix

Treat a destination that *is* a configured root as a root selection: plan the book folder under the chosen root with `FolderNamingPattern`, exactly as an omitted destination plans one under the default root. Destinations already inside a root are unchanged.

Regression test: add with `DestinationPath = <configured root>` asserts the persisted `BasePath` is the planned `{Author}` folder under the root, not the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)