### PR TITLE
feat(library): render the list view when grouping by author or series

### DIFF
--- a/fe/src/__tests__/AudiobooksView.spec.ts
+++ b/fe/src/__tests__/AudiobooksView.spec.ts
@@ -318,6 +318,90 @@ describe('AudiobooksView Grouping', () => {
     expect((vm as unknown).sortOrder).toBe('asc')
   })
 
+  const mountGroupedView = async () => {
+    if (
+      typeof (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver === 'undefined'
+    ) {
+      ;(globalThis as unknown as Record<string, unknown>).ResizeObserver = class {
+        observe() {}
+        disconnect() {}
+      }
+    }
+
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'home', component: { template: '<div />' } },
+        { path: '/audiobooks', name: 'audiobooks', component: AudiobooksView },
+      ],
+    })
+    await router.push('/audiobooks')
+    await router.isReady().catch(() => {})
+
+    const store = useLibraryStore()
+    store.audiobooks = [
+      { id: 1, title: 'Book 1', authors: ['Author A'], imageUrl: 'c1.jpg', files: [] },
+      { id: 2, title: 'Book 2', authors: ['Author A'], imageUrl: 'c2.jpg', files: [] },
+      { id: 3, title: 'Book 3', authors: ['Author B'], imageUrl: 'c3.jpg', files: [] },
+    ] as unknown as import('@/types').Audiobook[]
+    store.fetchLibrary = vi.fn(async () => undefined)
+
+    const wrapper = mount(AudiobooksView, {
+      global: {
+        plugins: [pinia, router],
+        stubs: [
+          'BulkEditModal',
+          'EditAudiobookModal',
+          'CustomFilterModal',
+          'FiltersDropdown',
+          'CustomSelect',
+        ],
+      },
+    })
+    await new Promise((r) => setTimeout(r, 0))
+    await getVm(wrapper).setGroupBy?.('authors')
+    await wrapper.vm.$nextTick()
+    return wrapper
+  }
+
+  it('renders authors as list rows when the view mode is list', async () => {
+    const wrapper = await mountGroupedView()
+
+    ;(wrapper.vm as unknown as { viewMode: string }).viewMode = 'list'
+    await wrapper.vm.$nextTick()
+
+    const rows = wrapper.findAll('.collection-list-item')
+    expect(rows).toHaveLength(2)
+    expect(rows.map((row) => row.text())).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Author A'),
+        expect.stringContaining('Author B'),
+      ]),
+    )
+    expect(wrapper.find('.collection-list-item').text()).toContain('book')
+
+    // The grid must be gone, or the toggle has added a second layout rather than switching.
+    expect(wrapper.findAll('.collection-card')).toHaveLength(0)
+
+    wrapper.unmount()
+  })
+
+  it('renders authors as cards when the view mode is grid', async () => {
+    // The control. Without it, a test asserting the list rows would also pass against a
+    // component that ignored viewMode and always rendered the list.
+    const wrapper = await mountGroupedView()
+
+    ;(wrapper.vm as unknown as { viewMode: string }).viewMode = 'grid'
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.findAll('.collection-card')).toHaveLength(2)
+    expect(wrapper.findAll('.collection-list-item')).toHaveLength(0)
+
+    wrapper.unmount()
+  })
+
   it('groups audiobooks by series when groupBy is series', async () => {
     if (
       typeof (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver === 'undefined'

--- a/fe/src/__tests__/AudiobooksView.spec.ts
+++ b/fe/src/__tests__/AudiobooksView.spec.ts
@@ -23,7 +23,7 @@ import AudiobooksView from '@/views/library/AudiobooksView.vue'
 import { useLibraryStore } from '@/stores/library'
 // apiService stubbed in vi.mock below if needed
 
-const { mockGetAudiobookDeleteCapabilities } = vi.hoisted(() => ({
+const { mockGetAudiobookDeleteCapabilities, mockGetAuthorLookup } = vi.hoisted(() => ({
   mockGetAudiobookDeleteCapabilities: vi.fn(async () => ({
     canRemoveFromLibrary: true,
     canDeleteTrackedFiles: true,
@@ -31,6 +31,7 @@ const { mockGetAudiobookDeleteCapabilities } = vi.hoisted(() => ({
     reason: null,
     fallbackAction: 'RemoveFromLibraryOnly' as const,
   })),
+  mockGetAuthorLookup: vi.fn(async () => null),
 }))
 
 vi.mock('@/services/api', () => ({
@@ -41,6 +42,7 @@ vi.mock('@/services/api', () => ({
     getStartupConfig: vi.fn(async () => ({})),
     getApplicationSettings: vi.fn(async () => ({})),
     getAudiobookDeleteCapabilities: mockGetAudiobookDeleteCapabilities,
+    getAuthorLookup: mockGetAuthorLookup,
   },
 }))
 
@@ -318,7 +320,18 @@ describe('AudiobooksView Grouping', () => {
     expect((vm as unknown).sortOrder).toBe('asc')
   })
 
-  const mountGroupedView = async () => {
+  const mountGroupedView = async (
+    initialViewMode: 'grid' | 'list' = 'grid',
+    attachToBody = false,
+  ) => {
+    try {
+      // Both are persisted by the component and survive between tests in this file. Left
+      // alone, an earlier test's grouping makes the grouped GRID render on mount and do the
+      // author-cover work before the mode under test is applied.
+      localStorage.setItem('listenarr.viewMode', initialViewMode)
+      localStorage.setItem('listenarr.groupBy', 'books')
+    } catch {}
+
     if (
       typeof (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver === 'undefined'
     ) {
@@ -349,6 +362,9 @@ describe('AudiobooksView Grouping', () => {
     store.fetchLibrary = vi.fn(async () => undefined)
 
     const wrapper = mount(AudiobooksView, {
+      // observeAuthorCards reaches for the grouped nodes through `document`, so the component
+      // has to actually be in the document for those tests to say anything.
+      ...(attachToBody ? { attachTo: document.body } : {}),
       global: {
         plugins: [pinia, router],
         stubs: [
@@ -361,6 +377,14 @@ describe('AudiobooksView Grouping', () => {
       },
     })
     await new Promise((r) => setTimeout(r, 0))
+
+    // onMounted reads the stored mode behind an await, so pin it here too: otherwise the
+    // grouped GRID can render first and do the author-cover work the list is meant to do,
+    // and a test about the list would pass against a list that never asked for anything.
+    ;(wrapper.vm as unknown as { viewMode: 'grid' | 'list' }).viewMode = initialViewMode
+    await wrapper.vm.$nextTick()
+
+    mockGetAuthorLookup.mockClear()
     await getVm(wrapper).setGroupBy?.('authors')
     await wrapper.vm.$nextTick()
     return wrapper
@@ -400,6 +424,140 @@ describe('AudiobooksView Grouping', () => {
     expect(wrapper.findAll('.collection-list-item')).toHaveLength(0)
 
     wrapper.unmount()
+  })
+
+  it('fetches author covers in the grouped list view, not only in the grid', async () => {
+    // The grouped grid and the grouped list are v-if siblings, so the list is the only markup
+    // in the DOM when the list is showing. observeAuthorCards has to reach it, or grouping by
+    // author in list view shows a placeholder for every author and never asks for the real
+    // cover. jsdom has no IntersectionObserver, so the function takes its direct fallback.
+    const wrapper = await mountGroupedView('list', true)
+
+    expect(wrapper.findAll('.collection-list-item').length).toBe(2)
+    expect(mockGetAuthorLookup.mock.calls.map((call) => call[0]).sort()).toEqual([
+      'Author A',
+      'Author B',
+    ])
+
+    wrapper.unmount()
+    try {
+      localStorage.removeItem('listenarr.viewMode')
+    } catch {}
+  })
+
+  it('re-observes the grouped cards after the view mode switches back to grid', async () => {
+    // Switching layout destroys the observed nodes and mounts fresh ones. groupedCollections
+    // has not changed, so its watcher stays quiet and nothing else re-observes them.
+    const observed: HTMLElement[] = []
+    const previous = (globalThis as unknown as { IntersectionObserver?: unknown })
+      .IntersectionObserver
+    ;(globalThis as unknown as Record<string, unknown>).IntersectionObserver = class {
+      observe(element: HTMLElement) {
+        observed.push(element)
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+
+    try {
+      const wrapper = await mountGroupedView('grid', true)
+      const vm = wrapper.vm as unknown as { viewMode: string }
+
+      vm.viewMode = 'list'
+      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick()
+
+      observed.length = 0
+
+      vm.viewMode = 'grid'
+      await wrapper.vm.$nextTick()
+      await wrapper.vm.$nextTick()
+
+      // Scope to this wrapper: an attached mount left behind by a failing earlier test would
+      // otherwise show up here and turn a cascade into a second, misleading failure.
+      const mine = observed.filter((element) => wrapper.element.contains(element))
+      expect(mine.map((element) => element.dataset.authorName).sort()).toEqual([
+        'Author A',
+        'Author B',
+      ])
+      expect(
+        mine.every((element) => element.classList.contains('audiobook-poster-container')),
+      ).toBe(true)
+
+      wrapper.unmount()
+    } finally {
+      if (previous === undefined) {
+        delete (globalThis as unknown as Record<string, unknown>).IntersectionObserver
+      } else {
+        ;(globalThis as unknown as Record<string, unknown>).IntersectionObserver = previous
+      }
+      try {
+        localStorage.removeItem('listenarr.viewMode')
+      } catch {}
+    }
+  })
+
+  it('remembers a view mode chosen while the library is already grouped', async () => {
+    // The watcher that persists viewMode was registered only by the virtual scroller, which
+    // bails out when there is no scroll container. A library that loads already grouped never
+    // has one, so the toggle worked for the session and was forgotten on the next load.
+    // This mounts straight into the grouped state rather than switching into it, because
+    // passing through Books registers the watcher and hides the problem.
+    if (
+      typeof (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver === 'undefined'
+    ) {
+      ;(globalThis as unknown as Record<string, unknown>).ResizeObserver = class {
+        observe() {}
+        disconnect() {}
+      }
+    }
+
+    localStorage.setItem('listenarr.groupBy', 'authors')
+    localStorage.setItem('listenarr.viewMode', 'grid')
+
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', name: 'home', component: { template: '<div />' } },
+        { path: '/audiobooks', name: 'audiobooks', component: AudiobooksView },
+      ],
+    })
+    await router.push('/audiobooks')
+    await router.isReady().catch(() => {})
+
+    const store = useLibraryStore()
+    store.audiobooks = [
+      { id: 1, title: 'Book 1', authors: ['Author A'], imageUrl: 'c1.jpg', files: [] },
+    ] as unknown as import('@/types').Audiobook[]
+    store.fetchLibrary = vi.fn(async () => undefined)
+
+    const wrapper = mount(AudiobooksView, {
+      global: {
+        plugins: [pinia, router],
+        stubs: [
+          'BulkEditModal',
+          'EditAudiobookModal',
+          'CustomFilterModal',
+          'FiltersDropdown',
+          'CustomSelect',
+        ],
+      },
+    })
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(getVm(wrapper).groupBy).toBe('authors')
+    ;(wrapper.vm as unknown as { toggleViewMode: () => void }).toggleViewMode()
+    await wrapper.vm.$nextTick()
+
+    expect(localStorage.getItem('listenarr.viewMode')).toBe('list')
+
+    wrapper.unmount()
+    try {
+      localStorage.removeItem('listenarr.viewMode')
+      localStorage.removeItem('listenarr.groupBy')
+    } catch {}
   })
 
   it('groups audiobooks by series when groupBy is series', async () => {

--- a/fe/src/views/library/AudiobooksView.vue
+++ b/fe/src/views/library/AudiobooksView.vue
@@ -211,7 +211,7 @@
 
     <!-- Grouped View -->
     <div v-else-if="groupBy !== 'books'" class="grouped-view">
-      <div class="grouped-grid">
+      <div v-if="viewMode === 'grid'" class="grouped-grid">
         <div
           v-for="collection in groupedCollections || []"
           :key="collection.name"
@@ -395,6 +395,45 @@
                 {{ collection.count }} book{{ collection.count !== 1 ? 's' : '' }}
               </p>
             </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-else class="audiobooks-list grouped-list">
+        <div v-if="(groupedCollections || []).length > 0" class="list-header">
+          <div class="col-cover">Cover</div>
+          <div class="col-title">{{ groupBy === 'authors' ? 'Author' : 'Series' }}</div>
+          <div class="col-count">Books</div>
+        </div>
+        <div
+          v-for="collection in groupedCollections || []"
+          :key="`collection-list-${collection.name}`"
+          tabindex="0"
+          class="audiobook-list-item collection-list-item"
+          @keydown.enter="navigateToCollection(collection)"
+          @click="navigateToCollection(collection)"
+        >
+          <div class="list-thumb-container">
+            <img
+              class="list-thumb"
+              :src="
+                getProtectedImageSrc(
+                  groupBy === 'authors'
+                    ? getAuthorImageUrl(collection)
+                    : collection.coverUrls?.[0] || '',
+                  getPlaceholderUrl(),
+                )
+              "
+              :alt="collection.name"
+              loading="lazy"
+              decoding="async"
+            />
+          </div>
+          <div class="list-details">
+            <div class="audiobook-title">{{ safeText(collection.name) }}</div>
+          </div>
+          <div class="collection-list-count">
+            {{ collection.count }} book{{ collection.count !== 1 ? 's' : '' }}
           </div>
         </div>
       </div>
@@ -2804,6 +2843,24 @@ defineExpose({
 
 .menu-item:last-child {
   border-radius: 6px;
+}
+
+/* A collection row carries a cover, a name and a count. The book row's five-column
+   template leaves two of its columns empty here, so the grouped list sets its own.
+
+   Both selectors have to out-rank the book row's own rules, which appear later in this
+   stylesheet. A bare `.collection-list-item` ties with `.audiobook-list-item` on
+   specificity and loses on source order, which left the header at three columns and the
+   rows it labels at five. */
+.grouped-list .list-header,
+.audiobook-list-item.collection-list-item {
+  grid-template-columns: 64px 1fr auto;
+}
+
+.collection-list-count {
+  color: #aaa;
+  font-size: 13px;
+  white-space: nowrap;
 }
 
 .grouped-view {

--- a/fe/src/views/library/AudiobooksView.vue
+++ b/fe/src/views/library/AudiobooksView.vue
@@ -413,7 +413,11 @@
           @keydown.enter="navigateToCollection(collection)"
           @click="navigateToCollection(collection)"
         >
-          <div class="list-thumb-container">
+          <div
+            class="list-thumb-container"
+            :data-author-name="groupBy === 'authors' ? collection.name : undefined"
+            :data-author-has-cover="authorHasSpecificCoverMap[collection.name] ? '1' : ''"
+          >
             <img
               class="list-thumb"
               :src="
@@ -1549,10 +1553,9 @@ let authorCardObserver: IntersectionObserver | null = null
 
 function observeAuthorCards() {
   if (groupBy.value !== 'authors') return
+  // Both grouped layouts carry the hook, so a cover is fetched whichever one is showing.
   const cards = Array.from(
-    document.querySelectorAll<HTMLElement>(
-      '.author-collection .audiobook-poster-container[data-author-name]',
-    ),
+    document.querySelectorAll<HTMLElement>('.grouped-view [data-author-name]'),
   )
   if (cards.length === 0) return
 
@@ -1943,6 +1946,13 @@ async function initializeVirtualScroller() {
     )
   }
 
+  registerViewModeWatchers()
+}
+
+// Registered independently of the virtual scroller. The scroller bails out when there is no
+// scroll container, and there is none while the library is grouped, so leaving these in it
+// meant a view-mode switch made under a grouping was neither reacted to nor remembered.
+function registerViewModeWatchers() {
   if (!stopViewModeWatch) {
     stopViewModeWatch = watch(viewMode, async () => {
       measuredRowHeight.value = null
@@ -1950,6 +1960,10 @@ async function initializeVirtualScroller() {
       await nextTick()
       syncMeasuredRowHeight()
       updateVisibleRange()
+      // The grouped branches are v-if siblings, so a layout switch destroys the observed
+      // nodes and mounts fresh ones. Nothing else re-observes them: groupedCollections has
+      // not changed, so its watcher stays quiet.
+      observeAuthorCards()
     })
   }
 
@@ -1981,6 +1995,8 @@ onMounted(async () => {
   } catch {
     // ignore localStorage errors (e.g., privacy mode)
   }
+
+  registerViewModeWatchers()
 
   await initializeVirtualScroller()
 
@@ -2157,7 +2173,7 @@ async function waitForImagesToLoad(timeoutMs = 5000) {
       )
     }
   } else {
-    const grouped = document.querySelector('.grouped-grid')
+    const grouped = document.querySelector('.grouped-view')
     if (grouped) imgs.push(...Array.from(grouped.querySelectorAll<HTMLImageElement>('img')))
   }
 


### PR DESCRIPTION
Closes #595.

The grid and list toggle does nothing under Authors or Series.

The grouped branch at `AudiobooksView.vue:213` renders only `.grouped-grid` and never reads `viewMode`. The `viewMode` gate lives inside the ungrouped books branch. The toggle button still renders, so it looks operable and silently is not, and a `viewMode` of `list` kept in localStorage is ignored the moment you switch grouping.

This adds the list layout to the grouped branch. A collection row carries a cover, a name and a book count, so it reuses the book row's classes and overrides the grid template rather than inventing a second visual language for the same thing.

Both branches are gated now, so the two layouts cannot render at once.

## Tests

Two, one per mode. The grid one is there so the pair cannot both pass against a component that ignored `viewMode` and always rendered the list.

Confirmed by pinning the grid branch to `v-if="true"`, which fails the list test and leaves the grid one green.

---

Worked through with Claude Code at my direction. The claims above were checked by running them rather than by reading, and I reviewed this before posting.
