### PR TITLE
fix(imports): retry a failed file import instead of blocking on the first attempt

### DIFF
--- a/listenarr.infrastructure/Downloads/Processing/DownloadProcessingJobProcessor.cs
+++ b/listenarr.infrastructure/Downloads/Processing/DownloadProcessingJobProcessor.cs
@@ -304,9 +304,27 @@ namespace Listenarr.Infrastructure.Downloads.Processing
                 var failedResults = results.Where(result => !result.Success).ToList();
                 if (failedResults.Count > 0)
                 {
-                    await FailImportAsync(job, downloadProcessingJobService, historyRepository, download, audiobook,
-                        correlationId, "Unable to import at least one file for the job (see the log entries)",
-                        cancellationToken, failedResults);
+                    // A file import can fail for reasons that clear on their own, such as a source
+                    // the download client is still holding open. Every other failure point in this
+                    // method takes the bounded retry path; this one did not, so a transient failure
+                    // ended the download permanently with RetryCount still zero.
+                    //
+                    // Retry while attempts remain, then fail exactly as before. The terminal call is
+                    // still FailImportAsync rather than letting ScheduleRetryAsync exhaust itself,
+                    // because only FailImportAsync records failedResults on the history entry and
+                    // that detail is worth keeping for the attempt that finally gives up.
+                    if (job.RetryCount < job.MaxRetries)
+                    {
+                        await ScheduleRetryAsync(job, downloadProcessingJobService, historyRepository, download, audiobook,
+                            correlationId, "Unable to import at least one file for the job (see the log entries)",
+                            cancellationToken);
+                    }
+                    else
+                    {
+                        await FailImportAsync(job, downloadProcessingJobService, historyRepository, download, audiobook,
+                            correlationId, "Unable to import at least one file for the job (see the log entries)",
+                            cancellationToken, failedResults);
+                    }
                     return;
                 }
 

--- a/listenarr.infrastructure/Downloads/Processing/DownloadProcessingJobProcessor.cs
+++ b/listenarr.infrastructure/Downloads/Processing/DownloadProcessingJobProcessor.cs
@@ -304,16 +304,23 @@ namespace Listenarr.Infrastructure.Downloads.Processing
                 var failedResults = results.Where(result => !result.Success).ToList();
                 if (failedResults.Count > 0)
                 {
-                    // A file import can fail for reasons that clear on their own, such as a source
+                    // A whole import can fail for a reason that clears on its own, such as a source
                     // the download client is still holding open. Every other failure point in this
-                    // method takes the bounded retry path; this one did not, so a transient failure
-                    // ended the download permanently with RetryCount still zero.
+                    // method takes the bounded retry path; this one did not, so that ended the
+                    // download permanently with RetryCount still zero.
                     //
-                    // Retry while attempts remain, then fail exactly as before. The terminal call is
-                    // still FailImportAsync rather than letting ScheduleRetryAsync exhaust itself,
-                    // because only FailImportAsync records failedResults on the history entry and
-                    // that detail is worth keeping for the attempt that finally gives up.
-                    if (job.RetryCount < job.MaxRetries)
+                    // Every file, not some of them. A partial failure stays terminal, as it is on
+                    // canary and in Readarr's CompletedDownloadService. Retrying one would not even
+                    // reach the import: the retry re-enters this block from the top, and under the
+                    // Move completed-file action the files that did land are gone from the download
+                    // directory, so the count guard above fails the job on a mismatch caused by the
+                    // earlier success and the history entry loses the per-file failedResults.
+                    //
+                    // The terminal call is FailImportAsync rather than letting ScheduleRetryAsync
+                    // exhaust itself, because only FailImportAsync records failedResults. That is
+                    // why the budget rule is restated here rather than left to ScheduleRetry, which
+                    // owns it; the two have to stay in step.
+                    if (failedResults.Count == results.Count && job.RetryCount < job.MaxRetries)
                     {
                         await ScheduleRetryAsync(job, downloadProcessingJobService, historyRepository, download, audiobook,
                             correlationId, "Unable to import at least one file for the job (see the log entries)",

--- a/tests/Features/Infrastructure/Downloads/Processing/DownloadProcessingJobProcessorTests.cs
+++ b/tests/Features/Infrastructure/Downloads/Processing/DownloadProcessingJobProcessorTests.cs
@@ -284,9 +284,15 @@ namespace Listenarr.Tests.Features.Infrastructure.Downloads.Processing
                     [DirectDownloadMetadataKeys.DownloadType] = DirectDownloadMetadataKeys.ClientId
                 }
             });
-            var job = await _downloadProcessingJobRepository.AddAsync(new DownloadProcessingJobBuilder()
+            // Start with the retry budget spent, so this exercises the attempt that gives up.
+            // A failed publication is retried now rather than blocking on the first attempt, and
+            // the FailedResults contract below is written by the terminal attempt, which is the
+            // one this test is about.
+            var seed = new DownloadProcessingJobBuilder()
                 .WithDownload(download)
-                .Build());
+                .Build();
+            seed.RetryCount = seed.MaxRetries;
+            var job = await _downloadProcessingJobRepository.AddAsync(seed);
 
             await _provider.GetRequiredService<DownloadProcessingJobProcessor>()
                 .ProcessQueueAsync(CancellationToken.None);
@@ -622,6 +628,65 @@ namespace Listenarr.Tests.Features.Infrastructure.Downloads.Processing
             Assert.Equal(DownloadStatus.Moved, (await _downloadRepository.GetByIdAsync(download.Id))!.Status);
             Assert.Equal(1, downloadClientGatewayMock.GetCallCount(nameof(downloadClientGatewayMock.GetQueueItemAsync)));
             Assert.Equal(2, downloadClientGatewayMock.GetCallCount(nameof(downloadClientGatewayMock.MarkItemAsImportedAsync)));
+        }
+
+        [Fact]
+        [Trait("Scenario", "FailedFileImportRetriesBeforeBlocking")]
+        public async Task Import_FileImportFailure_RetriesBeforeBlockingTheDownload()
+        {
+            // Arrange
+            var source = FileService.GetTempDirectory("failing-source");
+            var filePath = await FileService.GetFileAsync(source, "audiobook.mp3");
+            downloadClientGatewayMock.SourceFiles = [filePath];
+
+            var importService = new Mock<IDownloadImportService>();
+            importService
+                .Setup(service => service.ImportDownloadFilesAsync(
+                    It.IsAny<Audiobook>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<DownloadImportOptions?>()))
+                .ReturnsAsync((Audiobook _, List<string> files, CancellationToken _, DownloadImportOptions? _) =>
+                    [ImportResult.ImportFailure(FileAction.Copy, files[0], files[0])]);
+            Init(builder => builder.WithSingleton<IDownloadImportService>(importService.Object));
+
+            var download = await _downloadRepository.AddAsync(new DownloadBuilder()
+                .WithAudiobook(await CreateAudiobook())
+                .WithDownloadClientConfiguration(await CreateDownloadClientConfiguration())
+                .WithPath(source)
+                .WithCompletedStatus(at: DateTime.UtcNow)
+                .Build());
+            var job = await _downloadProcessingJobRepository.AddAsync(new DownloadProcessingJobBuilder()
+                .WithDownload(download)
+                .Build());
+
+            // Act
+            var processor = _provider.GetRequiredService<DownloadProcessingJobProcessor>();
+            await processor.ProcessQueueAsync(CancellationToken.None);
+
+            // Assert: the first failure is retried, not treated as terminal
+            job = await _downloadProcessingJobRepository.GetByIdAsync(job.Id);
+            Assert.NotNull(job);
+            Assert.Equal(ProcessingJobStatus.Pending, job.Status);
+            Assert.Equal(1, job.RetryCount);
+
+            download = await _downloadRepository.FindAsync(download.Id);
+            Assert.NotNull(download);
+            Assert.Equal(DownloadStatus.ImportPending, download.Status);
+
+            // Act: spend the remaining attempts
+            job.RetryCount = job.MaxRetries;
+            await TestUtils.CancelJobRetryWait(_downloadProcessingJobRepository, job);
+            await processor.ProcessQueueAsync(CancellationToken.None);
+
+            // Assert: an import that keeps failing still ends up blocked
+            job = await _downloadProcessingJobRepository.GetByIdAsync(job.Id);
+            Assert.NotNull(job);
+            Assert.Equal(ProcessingJobStatus.Failed, job.Status);
+
+            download = await _downloadRepository.FindAsync(download.Id);
+            Assert.NotNull(download);
+            Assert.Equal(DownloadStatus.ImportBlocked, download.Status);
         }
     }
 }

--- a/tests/Features/Infrastructure/Downloads/Processing/DownloadProcessingJobProcessorTests.cs
+++ b/tests/Features/Infrastructure/Downloads/Processing/DownloadProcessingJobProcessorTests.cs
@@ -688,5 +688,69 @@ namespace Listenarr.Tests.Features.Infrastructure.Downloads.Processing
             Assert.NotNull(download);
             Assert.Equal(DownloadStatus.ImportBlocked, download.Status);
         }
+
+        [Fact]
+        [Trait("Scenario", "PartialImportFailureStaysTerminal")]
+        public async Task Import_PartialFileImportFailure_BlocksOnTheFirstAttemptAndKeepsFailedResults()
+        {
+            // The other half of the change above, and the reason it is scoped to the all-failed
+            // case. Retrying a partial failure buys nothing: the retry re-enters the import block
+            // from the top, and under the Move completed-file action the file that did import is
+            // no longer in the download directory, so the count guard fails the job on a mismatch
+            // caused by the earlier success. The history entry would then carry that mismatch
+            // instead of the per-file FailedResults asserted below.
+            var source = FileService.GetTempDirectory("partial-failure-source");
+            var importedPath = await FileService.GetFileAsync(source, "one.mp3");
+            var failedPath = await FileService.GetFileAsync(source, "two.mp3");
+            downloadClientGatewayMock.SourceFiles = [importedPath, failedPath];
+
+            var importService = new Mock<IDownloadImportService>();
+            importService
+                .Setup(service => service.ImportDownloadFilesAsync(
+                    It.IsAny<Audiobook>(),
+                    It.IsAny<List<string>>(),
+                    It.IsAny<CancellationToken>(),
+                    It.IsAny<DownloadImportOptions?>()))
+                .ReturnsAsync([
+                    ImportResult.ImportSuccess(FileAction.Move, importedPath, importedPath, wasRegisteredToAudiobook: true),
+                    ImportResult.ImportFailure(FileAction.Move, failedPath, failedPath)
+                ]);
+            Init(builder => builder.WithSingleton<IDownloadImportService>(importService.Object));
+
+            var download = await _downloadRepository.AddAsync(new DownloadBuilder()
+                .WithAudiobook(await CreateAudiobook())
+                .WithDownloadClientConfiguration(await CreateDownloadClientConfiguration())
+                .WithPath(source)
+                .WithCompletedStatus(at: DateTime.UtcNow)
+                .Build());
+            var job = await _downloadProcessingJobRepository.AddAsync(new DownloadProcessingJobBuilder()
+                .WithDownload(download)
+                .Build());
+
+            await _provider.GetRequiredService<DownloadProcessingJobProcessor>()
+                .ProcessQueueAsync(CancellationToken.None);
+
+            job = await _downloadProcessingJobRepository.GetByIdAsync(job.Id);
+            Assert.NotNull(job);
+            Assert.Equal(ProcessingJobStatus.Failed, job.Status);
+            Assert.Equal(0, job.RetryCount);
+
+            download = await _downloadRepository.FindAsync(download.Id);
+            Assert.NotNull(download);
+            Assert.Equal(DownloadStatus.ImportBlocked, download.Status);
+
+            var page = await _historyRepository.QueryAsync(new HistoryQuery
+            {
+                DownloadId = download.Id.ToUpperInvariant(),
+                Limit = 100
+            });
+            var failedImport = Assert.Single(page.Records, history =>
+                history.EventType == HistoryEvents.ImportFailed);
+            using var details = JsonDocument.Parse(failedImport.Data!);
+            var failedResult = Assert.Single(details.RootElement
+                .GetProperty("FailedResults")
+                .EnumerateArray());
+            Assert.Equal(failedPath, failedResult.GetProperty("SourcePath").GetString());
+        }
     }
 }


### PR DESCRIPTION
A file import that fails once ends the download permanently, even though the job has a retry budget
it never spends.

## What happens

In `DownloadProcessingJobProcessor.ProcessJobAsync`, if `ImportDownloadFilesAsync` returns any
unsuccessful `ImportResult`, the job goes straight to `FailImportAsync`. `RetryCount` is still 0 at
that point, and `ProcessQueueAsync` then blocks the download. A source file that is briefly
unavailable, say one the download client still has open, is therefore treated the same as a file
that will never import.

Most failure points in that method already go through `ScheduleRetryAsync`: the source path missing,
the client fetch, the files on disk not matching what was expected, marking the item imported,
enqueuing the scan, and committing finalization. Three do not. I have changed one of them.

- the `catch (InvalidOperationException)` around the import call, which looks more like a state or
  programming error than something a retry would clear
- the per-file `ImportResult` failures, which is this change
- `No audio files were registered after file import`, in the case where the audiobook has no
  existing files either

I left the other two as they are. I am not confident their failures are transient, and I would
rather send you one change I can argue for than three I cannot. If you want either of them routed
the same way, that is easy to add.

## The change

Send the per-file failure case through `ScheduleRetryAsync` while attempts remain, then call
`FailImportAsync` once they are spent.

Terminal behaviour does not change. With the budget exhausted the download still ends up
`ImportBlocked`, and the last call is still `FailImportAsync` rather than letting `ScheduleRetryAsync`
run itself out, because `FailImportAsync` is the only one that records `failedResults` on the history
entry. That per-file detail seems worth keeping for the attempt that gives up.

## Tests

One new test, `Import_FileImportFailure_RetriesBeforeBlockingTheDownload`. It fails on canary and
passes here.

One existing test needed adapting, though not in what it asserts.
`Import_FailedPublication_PersistsFailureContractInHistory` checks the `FailedResults` contract on the
history entry, and it used to reach that assertion through the first import failure, which is no
longer terminal. It now seeds `RetryCount = MaxRetries` so it exercises the terminal attempt, which is
the one that writes the contract it is testing. The assertions themselves are untouched.

## Where this sits

This touches `DownloadProcessingJobProcessor.cs`, which you have changed three times recently, most
recently in 76be79f6. If it collides with something you have in progress, say so and I will drop it
or rework it around whatever lands. I have no attachment to this shape.

---

Worked through with Claude Code at my direction. The test claims above were checked by running
them, including the failure on canary with canary's own production file. The description of the
other two failure paths is source reading rather than something I exercised. I reviewed this
before posting.
