### PR TITLE
fix(quality): let a real encoder bitrate reach the rung it was encoded for

### DIFF
--- a/listenarr.domain/Common/QualityMatcher.cs
+++ b/listenarr.domain/Common/QualityMatcher.cs
@@ -135,7 +135,7 @@ namespace Listenarr.Domain.Common
 
             if (fileKbps is int kbps)
             {
-                var eligible = withBitrate.Where(r => r.BitrateKbps <= kbps).ToList();
+                var eligible = withBitrate.Where(r => MeetsRung(kbps, r.BitrateKbps!.Value)).ToList();
                 if (eligible.Count > 0)
                 {
                     return ToAllowedMatch(Best(eligible).Source);
@@ -387,6 +387,38 @@ namespace Listenarr.Domain.Common
         }
 
         /// <summary>Convert a bitrate to kbps, guarding values already expressed in kbps.</summary>
+        /// <summary>
+        /// How far below a rung a file may report and still count as that rung, as a fraction.
+        ///
+        /// A file encoded at a nominal bitrate almost never reports exactly that figure. A "128kbps"
+        /// AAC file commonly reports something like 127241 bps, which rounds to 127 kbps, and a
+        /// strict `rung &lt;= file` comparison then excludes the 128 rung and drops the file a whole
+        /// tier. Applied to a real library that misclassifies most lossy files, because the failure
+        /// is systematic rather than occasional.
+        ///
+        /// Five percent is far smaller than the gap between adjacent rungs in any ordinary profile,
+        /// where 64, 96, 128, 192, 256 and 320 sit at least a third apart, so this cannot promote a
+        /// file across a real tier boundary. It only absorbs encoder variance.
+        /// </summary>
+        private const double RungBitrateTolerance = 0.05;
+
+        /// <summary>
+        /// Whether a file's bitrate reaches a rung, allowing for the difference between a nominal
+        /// bitrate and what an encoder actually reports.
+        /// </summary>
+        private static bool MeetsRung(int fileKbps, int rungKbps)
+        {
+            if (fileKbps >= rungKbps)
+            {
+                return true;
+            }
+
+            // At least one whole kbps of slack, so the smallest rungs are not left with a tolerance
+            // that rounds away to nothing.
+            var slack = Math.Max(1d, rungKbps * RungBitrateTolerance);
+            return rungKbps - fileKbps <= slack;
+        }
+
         private static int? NormalizeKbps(int? bitsPerSecond)
         {
             if (bitsPerSecond is not int bps || bps <= 0)

--- a/listenarr.domain/Common/QualityMatcher.cs
+++ b/listenarr.domain/Common/QualityMatcher.cs
@@ -386,7 +386,6 @@ namespace Listenarr.Domain.Common
             return MapCodec(file).Overlaps(LosslessGroups);
         }
 
-        /// <summary>Convert a bitrate to kbps, guarding values already expressed in kbps.</summary>
         /// <summary>
         /// How far below a rung a file may report and still count as that rung, as a fraction.
         ///
@@ -396,9 +395,10 @@ namespace Listenarr.Domain.Common
         /// tier. Applied to a real library that misclassifies most lossy files, because the failure
         /// is systematic rather than occasional.
         ///
-        /// Five percent is far smaller than the gap between adjacent rungs in any ordinary profile,
-        /// where 64, 96, 128, 192, 256 and 320 sit at least a third apart, so this cannot promote a
-        /// file across a real tier boundary. It only absorbs encoder variance.
+        /// Five percent is far smaller than the gap between adjacent rungs in any ordinary profile.
+        /// Across 64, 96, 128, 192, 256 and 320 the narrowest gap is 256 to 320, a fifth of the
+        /// higher rung and four times this tolerance, so a constant-bitrate file cannot be promoted
+        /// across a real tier boundary. It only absorbs encoder variance.
         /// </summary>
         private const double RungBitrateTolerance = 0.05;
 
@@ -419,6 +419,7 @@ namespace Listenarr.Domain.Common
             return rungKbps - fileKbps <= slack;
         }
 
+        /// <summary>Convert a bitrate to kbps, guarding values already expressed in kbps.</summary>
         private static int? NormalizeKbps(int? bitsPerSecond)
         {
             if (bitsPerSecond is not int bps || bps <= 0)

--- a/tests/Features/Application/Audiobooks/Matching/AudiobookStatusEvaluatorTests.cs
+++ b/tests/Features/Application/Audiobooks/Matching/AudiobookStatusEvaluatorTests.cs
@@ -164,6 +164,23 @@ namespace Listenarr.Tests.Features.Application.Audiobooks.Matching
             Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
         }
 
+        [Fact]
+        public void ComputeStatus_ReturnsQualityMatch_ForARealEncoderBitrateJustUnderTheCutoff()
+        {
+            // Every other test here uses an exactly round bitrate, which is why this class passes
+            // while a real library does not. An encoder asked for 256kbps reports something a little
+            // under it, and that used to drop the file a whole tier and report a mismatch.
+            var profile = CreateProfile(cutoffQuality: "256kbps", preferredFormats: new List<string> { "m4b" });
+            var files = new List<AudiobookFormatSummary>
+            {
+                new() { Format = "m4b", Bitrate = 255_000 }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
         private static QualityProfile CreateProfile(string cutoffQuality, List<string> preferredFormats)
         {
             return new QualityProfile

--- a/tests/Features/Application/Audiobooks/Matching/AudiobookStatusEvaluatorTests.cs
+++ b/tests/Features/Application/Audiobooks/Matching/AudiobookStatusEvaluatorTests.cs
@@ -181,6 +181,23 @@ namespace Listenarr.Tests.Features.Application.Audiobooks.Matching
             Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
         }
 
+        [Fact]
+        public void ComputeStatus_ReturnsQualityMatch_ForABitrateAcrossMostOfTheTolerance()
+        {
+            // 255000 above is one kbps short of the cutoff rung, which the one-kbps floor alone
+            // would carry. This one is twelve short, so it reaches 256 only if the percentage
+            // tolerance is really applied on the status path as well.
+            var profile = CreateProfile(cutoffQuality: "256kbps", preferredFormats: new List<string> { "m4b" });
+            var files = new List<AudiobookFormatSummary>
+            {
+                new() { Format = "m4b", Bitrate = 244_000 }
+            };
+
+            var status = AudiobookStatusEvaluator.ComputeStatus(false, true, null, profile, files);
+
+            Assert.Equal(AudiobookStatusEvaluator.QualityMatch, status);
+        }
+
         private static QualityProfile CreateProfile(string cutoffQuality, List<string> preferredFormats)
         {
             return new QualityProfile

--- a/tests/Features/Domain/Utils/QualityMatcherTests.cs
+++ b/tests/Features/Domain/Utils/QualityMatcherTests.cs
@@ -402,5 +402,44 @@ namespace Listenarr.Tests.Features.Domain.Utils
 
             Assert.True(QualityMatcher.IsLabelBetter("AAC 320kbps", "AAC 256kbps", profile));
         }
-    }
+    
+        // ---- real encoder bitrates, which are never exactly the nominal tier ----------------
+
+        [Fact]
+        public void Match_FileJustUnderItsNominalTier_StillMatchesThatTier()
+        {
+            // A file encoded at "128kbps" AAC reports something like 127241 bps. NormalizeKbps
+            // rounds that to 127, and rung eligibility is `rung.BitrateKbps <= fileKbps`, so the
+            // 128 rung is excluded and the file drops to the tier below. Real encoders essentially
+            // never hit the nominal value exactly, so this affects almost every lossy file.
+            var profile = new QualityProfileBuilder()
+                .WithName("Standard")
+                .WithQuality("AAC 128kbps", 0, codec: "AAC", bitrate: 128)
+                .WithQuality("AAC 64kbps", 1, codec: "AAC", bitrate: 64)
+                .Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 127_241 };
+
+            var result = QualityMatcher.Match(file, profile);
+
+            Assert.True(result.IsMatch);
+            Assert.Equal("AAC 128kbps", result.Rung!.Quality);
+        }
+
+        [Fact]
+        public void Match_FileWellBelowATier_DoesNotGetPromotedToIt()
+        {
+            // The tolerance must not swallow a genuine tier gap: a 96kbps file is not 128kbps.
+            var profile = new QualityProfileBuilder()
+                .WithName("Standard")
+                .WithQuality("AAC 128kbps", 0, codec: "AAC", bitrate: 128)
+                .WithQuality("AAC 64kbps", 1, codec: "AAC", bitrate: 64)
+                .Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = 96_000 };
+
+            var result = QualityMatcher.Match(file, profile);
+
+            Assert.True(result.IsMatch);
+            Assert.Equal("AAC 64kbps", result.Rung!.Quality);
+        }
+}
 }

--- a/tests/Features/Domain/Utils/QualityMatcherTests.cs
+++ b/tests/Features/Domain/Utils/QualityMatcherTests.cs
@@ -402,7 +402,7 @@ namespace Listenarr.Tests.Features.Domain.Utils
 
             Assert.True(QualityMatcher.IsLabelBetter("AAC 320kbps", "AAC 256kbps", profile));
         }
-    
+
         // ---- real encoder bitrates, which are never exactly the nominal tier ----------------
 
         [Fact]
@@ -441,5 +441,46 @@ namespace Listenarr.Tests.Features.Domain.Utils
             Assert.True(result.IsMatch);
             Assert.Equal("AAC 64kbps", result.Rung!.Quality);
         }
-}
+
+        // The two tests above are both satisfied by the one-kbps floor alone, so neither of them
+        // says anything about the size of the tolerance. These three pin it. Without them the
+        // percentage can be set to zero and the whole suite still passes, which is the same shape
+        // of gap that let the original mismatch through.
+
+        [Theory]
+        [InlineData(122_000, "AAC 128kbps")]  // six kbps short of 128, inside the tolerance
+        [InlineData(121_000, "AAC 64kbps")]   // seven kbps short, outside it
+        public void Match_ReachesARungOnlyWithinTheTolerance(int bitsPerSecond, string expectedRung)
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("Standard")
+                .WithQuality("AAC 128kbps", 0, codec: "AAC", bitrate: 128)
+                .WithQuality("AAC 64kbps", 1, codec: "AAC", bitrate: 64)
+                .Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = bitsPerSecond };
+
+            var result = QualityMatcher.Match(file, profile);
+
+            Assert.True(result.IsMatch);
+            Assert.Equal(expectedRung, result.Rung!.Quality);
+        }
+
+        [Theory]
+        [InlineData(15_000, "16kbps")]  // five percent of 16 rounds away, so the floor carries this
+        [InlineData(14_000, "8kbps")]   // two kbps short is outside the floor
+        public void Match_KeepsAWholeKbpsOfSlackOnASmallRung(int bitsPerSecond, string expectedRung)
+        {
+            var profile = new QualityProfileBuilder()
+                .WithName("Tiny")
+                .WithQuality("16kbps", 0, codec: "AAC", bitrate: 16)
+                .WithQuality("8kbps", 1, codec: "AAC", bitrate: 8)
+                .Build();
+            var file = new AudioQualityInput { Codec = "aac", BitrateBitsPerSecond = bitsPerSecond };
+
+            var result = QualityMatcher.Match(file, profile);
+
+            Assert.True(result.IsMatch);
+            Assert.Equal(expectedRung, result.Rung!.Quality);
+        }
+    }
 }


### PR DESCRIPTION
Fixes one of the causes behind #549, where books report `quality-mismatch` against a profile they
should satisfy.

## What happens

`QualityMatcher.NormalizeKbps` rounds a reported bitrate to whole kbps, and rung eligibility was

```csharp
withBitrate.Where(r => r.BitrateKbps <= kbps)
```

A file encoded at a nominal 128kbps does not report 128000 bps. It reports something like 127241,
which rounds to 127, so the 128 rung is excluded and the file falls to the tier below. Where that
lower tier sits under the profile cutoff, the book reports a mismatch.

Most lossy files land at least a little under their nominal tier, so this is not an occasional
rounding artifact. It is closer to the normal case.

## The change

Eligibility goes through `MeetsRung`, which lets a file reach a rung it falls just short of. The
tolerance is five percent, with a floor of one kbps.

Adjacent rungs in an ordinary profile sit much further apart than that. 64, 96, 128, 192, 256 and 320
are at least a third apart, so the tolerance cannot carry a file across a real tier boundary. There
is a test for exactly that: a 96kbps file against a profile of 128 and 64 still matches 64.

## Tests

Two, both failing before the change. One at `QualityMatcher`, one at `AudiobookStatusEvaluator` so
the user-visible status is covered and not just the internals.

It is worth saying why the existing tests did not catch this. Every bitrate in `QualityMatcherTests`
and `AudiobookStatusEvaluatorTests` is an exactly round tier value: 256000, 320000, 128. The suite
only ever asks the question in the one form where the answer was already right.

## Scope, and what this does not fix

This is one cause. It is not the whole of #549.

Measured on a real library before and after, the share of books with a file reporting
`quality-mismatch` went from roughly nine in ten to roughly two in three. Better, and obviously not
finished.

The rest looks like a different mechanism, which I have left alone here.
`AudiobookStatusEvaluator.ComputeStatus` filters the file list by the profile's `PreferredFormats`
before the matcher is consulted, and a book left with no candidate files returns `QualityMismatch`.
So a book whose only files are in a format the profile does not prefer reports a quality mismatch
whatever its bitrate:

```
mp3 at 320000 bps, PreferredFormats ["m4b"]  ->  quality-mismatch
mp3 at 320000 bps, PreferredFormats []       ->  quality-match
```

On that library, every book that matched was AAC and every MP3-only book was mismatched regardless
of bitrate, against an m4b-only `PreferredFormats`.

I do not think that is mine to decide. There is a reading where a book in a format you did not ask
for is legitimately not what you wanted. But `quality-mismatch` is the status the UI reads, so
treating a format preference as a quality shortfall reaches further than the label does, and
redefining that status does not belong in a pull request about rounding. I can open a separate issue
for it if that is useful.

---

Worked through with Claude Code at my direction. The mechanism and both tests were checked by
running them, including confirming they fail without the change. The before and after rates come
from a real library rather than from the test suite. I reviewed this before posting.
