### PR TITLE
feat(metadata): automatic blank-only "fill missing from online" for books with files

### DIFF
--- a/fe/src/__tests__/FeaturesSection.spec.ts
+++ b/fe/src/__tests__/FeaturesSection.spec.ts
@@ -33,6 +33,7 @@ describe('FeaturesSection', () => {
           enableCoverArtDownload: false,
           enableNotifications: false,
           showCompletedExternalDownloads: false,
+          metadataAutoBackfillEnabled: false,
         },
       },
       global: { components: { Checkbox } },
@@ -48,5 +49,13 @@ describe('FeaturesSection', () => {
     last =
       wrapper.emitted()['update:settings']![wrapper.emitted()['update:settings']!.length - 1][0]
     expect(last.enableCoverArtDownload).toBe(true)
+
+    // Automatic metadata backfill is the last card; it is off by default and
+    // toggles independently of the other feature flags.
+    await checks[4].setValue(true)
+    last =
+      wrapper.emitted()['update:settings']![wrapper.emitted()['update:settings']!.length - 1][0]
+    expect(last.metadataAutoBackfillEnabled).toBe(true)
+    expect(last.enableNotifications).toBe(false)
   })
 })

--- a/fe/src/components/settings/FeaturesSection.vue
+++ b/fe/src/components/settings/FeaturesSection.vue
@@ -46,6 +46,13 @@
         title="Show completed external downloads in Activity"
         description="When enabled, completed torrents/NZBs from external clients will remain visible in the Activity view. When disabled, completed external items will be hidden to reduce clutter."
       />
+
+      <CheckboxCard
+        :modelValue="settings.metadataAutoBackfillEnabled ?? false"
+        @update:modelValue="updateMetadataAutoBackfillEnabled"
+        title="Fill missing metadata from online sources automatically"
+        description="Books that have files but lack a description, cover, narrators, publisher, language or release date are looked up by their own ASIN/ISBN in the background and only the blank fields are filled in. Existing values are never overwritten. Runs a small batch every 15 minutes."
+      />
     </div>
   </div>
 </template>
@@ -80,6 +87,10 @@ function updateEnableNotifications(value: boolean) {
 
 function updateShowCompletedExternalDownloads(value: boolean) {
   updateField('showCompletedExternalDownloads', value)
+}
+
+function updateMetadataAutoBackfillEnabled(value: boolean) {
+  updateField('metadataAutoBackfillEnabled', value)
 }
 </script>
 

--- a/fe/src/types/index.ts
+++ b/fe/src/types/index.ts
@@ -443,6 +443,9 @@ export interface ApplicationSettings {
   completedFileAction?: 'none' | 'move' | 'copy' | 'hardlink/copy'
   // Show completed external downloads (torrents/NZBs) in the Activity view
   showCompletedExternalDownloads?: boolean
+  // Background "fill missing from online": look up books that hold files but lack
+  // core metadata by their own ASIN/ISBN and fill only the blank fields.
+  metadataAutoBackfillEnabled?: boolean
   // Failed download handling
   failedDownloadHandlingEnabled?: boolean
   failedDownloadAutoSearch?: boolean

--- a/listenarr.application/Audiobooks/Contracts/Repositories/IAudiobookRepository.cs
+++ b/listenarr.application/Audiobooks/Contracts/Repositories/IAudiobookRepository.cs
@@ -65,6 +65,23 @@ namespace Listenarr.Application.Audiobooks.Contracts.Repositories
         Task<SeriesCacheEntry> UpsertCachedSeriesAsync(SeriesCacheEntry seriesCacheEntry);
         Task<Audiobook> AddAsync(Audiobook audiobook);
         Task<bool> UpdateAsync(Audiobook audiobook);
+
+        /// <summary>
+        /// Books the automatic metadata backfill should look up next: they hold
+        /// files, carry an ASIN or ISBN to look up by, have at least one core text
+        /// field blank, and were not attempted since <paramref name="retryBeforeUtc"/>.
+        /// Never-attempted books come first, then the longest-ago attempts.
+        /// </summary>
+        Task<List<Audiobook>> GetMetadataBackfillCandidatesAsync(
+            int max,
+            DateTime retryBeforeUtc,
+            CancellationToken ct = default);
+
+        /// <summary>
+        /// Targeted single-column write of <see cref="Audiobook.MetadataBackfillAttemptedAt"/>
+        /// so a lookup that found nothing is still recorded without re-saving the row.
+        /// </summary>
+        Task SetMetadataBackfillAttemptedAtAsync(int audiobookId, DateTime attemptedAtUtc, CancellationToken ct = default);
         Task<bool> RewritePathReferencesAsync(
             int audiobookId,
             string? sourceBasePath,

--- a/listenarr.application/Audiobooks/Metadata/AudiobookBlankFieldBackfill.cs
+++ b/listenarr.application/Audiobooks/Metadata/AudiobookBlankFieldBackfill.cs
@@ -1,0 +1,145 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+namespace Listenarr.Application.Audiobooks.Metadata
+{
+    /// <summary>
+    /// Fills the fields an audiobook record LACKS from provider metadata and
+    /// leaves every populated field alone. This is the "fill missing" half of the
+    /// metadata rescan: the rescan overwrites with the provider's answer, which is
+    /// right for an explicit user refresh but wrong for an unattended worker that
+    /// must never clobber manual edits or a verified title. Identifiers (ASIN,
+    /// ISBN, OpenLibrary) and the cover are deliberately out of scope here — the
+    /// cover needs the image cache and identifiers need the identifier mapper, so
+    /// callers handle both around this call.
+    /// </summary>
+    public static class AudiobookBlankFieldBackfill
+    {
+        /// <summary>
+        /// Copies each blank scalar/list field from <paramref name="metadata"/> onto
+        /// <paramref name="audiobook"/>. Returns the names of the fields that were
+        /// filled (empty when the record already had everything the provider knows).
+        /// </summary>
+        public static IReadOnlyList<string> Apply(Audiobook audiobook, AudibleBookMetadata metadata)
+        {
+            ArgumentNullException.ThrowIfNull(audiobook);
+            ArgumentNullException.ThrowIfNull(metadata);
+
+            var filled = new List<string>();
+
+            FillText(filled, nameof(Audiobook.Title), audiobook.Title, metadata.Title, v => audiobook.Title = v);
+            FillText(filled, nameof(Audiobook.Subtitle), audiobook.Subtitle, metadata.Subtitle, v => audiobook.Subtitle = v);
+            FillText(filled, nameof(Audiobook.Description), audiobook.Description, metadata.Description, v => audiobook.Description = v);
+            FillText(filled, nameof(Audiobook.Publisher), audiobook.Publisher, metadata.Publisher, v => audiobook.Publisher = v);
+            FillText(filled, nameof(Audiobook.Language), audiobook.Language, metadata.Language, v => audiobook.Language = v);
+            FillText(filled, nameof(Audiobook.PublishYear), audiobook.PublishYear, metadata.PublishYear, v => audiobook.PublishYear = v);
+            FillText(filled, nameof(Audiobook.PublishedDate), audiobook.PublishedDate, metadata.PublishedDate, v => audiobook.PublishedDate = v);
+            FillText(filled, nameof(Audiobook.Version), audiobook.Version, metadata.Version, v => audiobook.Version = v);
+
+            if ((audiobook.Runtime is null || audiobook.Runtime <= 0) && metadata.Runtime is > 0)
+            {
+                audiobook.Runtime = metadata.Runtime;
+                filled.Add(nameof(Audiobook.Runtime));
+            }
+
+            FillList(
+                filled,
+                nameof(Audiobook.Authors),
+                audiobook.Authors,
+                FirstNonEmptyList(metadata.Authors, metadata.Author),
+                v => audiobook.Authors = v);
+            FillList(
+                filled,
+                nameof(Audiobook.Narrators),
+                audiobook.Narrators,
+                FirstNonEmptyList(metadata.Narrators, metadata.Narrator),
+                v => audiobook.Narrators = v);
+            FillList(filled, nameof(Audiobook.Genres), audiobook.Genres, Normalize(metadata.Genres), v => audiobook.Genres = v);
+            FillList(filled, nameof(Audiobook.Tags), audiobook.Tags, Normalize(metadata.Tags), v => audiobook.Tags = v);
+
+            // Series: only when the record has no series at all. A book already
+            // placed in a series (possibly by hand) keeps its placement untouched.
+            var hasSeries = (audiobook.SeriesMemberships?.Any(m => !string.IsNullOrWhiteSpace(m.SeriesName)) ?? false)
+                || !string.IsNullOrWhiteSpace(audiobook.Series);
+            var providerHasSeries = (metadata.SeriesMemberships?.Any(m => !string.IsNullOrWhiteSpace(m.SeriesName)) ?? false)
+                || !string.IsNullOrWhiteSpace(metadata.Series);
+            if (!hasSeries && providerHasSeries)
+            {
+                AudiobookSeriesMembershipHelper.ApplyToAudiobook(
+                    audiobook,
+                    metadata.SeriesMemberships,
+                    metadata.Series,
+                    metadata.SeriesNumber);
+                filled.Add(nameof(Audiobook.Series));
+            }
+
+            return filled;
+        }
+
+        private static void FillText(
+            List<string> filled,
+            string name,
+            string? current,
+            string? incoming,
+            Action<string> assign)
+        {
+            if (!string.IsNullOrWhiteSpace(current) || string.IsNullOrWhiteSpace(incoming))
+            {
+                return;
+            }
+
+            assign(incoming.Trim());
+            filled.Add(name);
+        }
+
+        private static void FillList(
+            List<string> filled,
+            string name,
+            List<string>? current,
+            List<string> incoming,
+            Action<List<string>> assign)
+        {
+            if ((current?.Any(v => !string.IsNullOrWhiteSpace(v)) ?? false) || incoming.Count == 0)
+            {
+                return;
+            }
+
+            assign(incoming);
+            filled.Add(name);
+        }
+
+        private static List<string> FirstNonEmptyList(IEnumerable<string>? list, string? single)
+        {
+            var normalized = Normalize(list);
+            if (normalized.Count > 0)
+            {
+                return normalized;
+            }
+
+            return string.IsNullOrWhiteSpace(single)
+                ? new List<string>()
+                : new List<string> { single.Trim() };
+        }
+
+        private static List<string> Normalize(IEnumerable<string>? values) =>
+            (values ?? Enumerable.Empty<string>())
+                .Where(v => !string.IsNullOrWhiteSpace(v))
+                .Select(v => v.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+    }
+}

--- a/listenarr.domain/Audiobooks/Audiobook.cs
+++ b/listenarr.domain/Audiobooks/Audiobook.cs
@@ -76,6 +76,14 @@ namespace Listenarr.Domain.Audiobooks
         public DateTime? LastSearchTime { get; set; }
 
         /// <summary>
+        /// UTC time the automatic metadata backfill last looked this book up
+        /// online (whether or not anything was filled). Lets the worker rotate
+        /// through candidates and retry misses on a slow cadence instead of
+        /// hammering the same unresolvable ASIN every cycle.
+        /// </summary>
+        public DateTime? MetadataBackfillAttemptedAt { get; set; }
+
+        /// <summary>
         /// Create AudioMetadata from the Audiobook as a basic metadata for imported files
         /// </summary>
         /// <returns>AudioMetada based on the audiobook retrieved metadata</returns>

--- a/listenarr.domain/Configuration/ApplicationSettings.cs
+++ b/listenarr.domain/Configuration/ApplicationSettings.cs
@@ -104,6 +104,14 @@ namespace Listenarr.Domain.Configuration
         // Failed download handling settings
         public bool FailedDownloadHandlingEnabled { get; set; } = true;
         public bool FailedDownloadAutoSearch { get; set; } = false;
+
+        // Background "fill missing from online": for books that hold files,
+        // periodically look up the catalog by the book's own ASIN/ISBN and fill
+        // ONLY the fields the record lacks (description, cover, narrators,
+        // genres, publisher, dates, language). Never overwrites an existing
+        // value, so manual edits stay intact. Off by default: it spends
+        // provider requests unattended.
+        public bool MetadataAutoBackfillEnabled { get; set; } = false;
         public List<string> ImportBlacklistExtensions
         {
             get

--- a/listenarr.infrastructure/DependencyInjection/Workers/WorkerRegistrationExtensions.cs
+++ b/listenarr.infrastructure/DependencyInjection/Workers/WorkerRegistrationExtensions.cs
@@ -43,6 +43,10 @@ internal static class WorkerRegistrationExtensions
         AddHostedProcessor<SeriesMonitoringProcessor, ISeriesMonitoringProcessor, SeriesMonitoringBackgroundService>(services);
         AddHostedProcessor<FfmpegInstallProcessor, IFfmpegInstallProcessor, FfmpegInstallBackgroundService>(services);
         AddHostedProcessor<MetadataRescanProcessor, IMetadataRescanProcessor, MetadataRescanService>(services);
+        AddHostedProcessor<
+            Listenarr.Infrastructure.HostedServices.Metadata.MetadataAutoBackfillProcessor,
+            Listenarr.Infrastructure.HostedServices.Metadata.IMetadataAutoBackfillProcessor,
+            Listenarr.Infrastructure.HostedServices.Metadata.MetadataAutoBackfillService>(services);
         services.AddSingleton<DownloadProcessingJobProcessor>();
         services.AddSingleton<IDownloadImportProcessor>(provider =>
             provider.GetRequiredService<DownloadProcessingJobProcessor>());

--- a/listenarr.infrastructure/HostedServices/Metadata/MetadataAutoBackfillService.cs
+++ b/listenarr.infrastructure/HostedServices/Metadata/MetadataAutoBackfillService.cs
@@ -1,0 +1,460 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Application.Audiobooks.Identifiers;
+using Listenarr.Application.Audiobooks.Metadata;
+using Listenarr.Application.Common.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Infrastructure.HostedServices.Metadata
+{
+    /// <summary>
+    /// Unattended "fill missing from online". Books that hold files but lack
+    /// core metadata (no description, cover, publisher, language or date) are
+    /// looked up by their own ASIN/ISBN on a slow cadence and the blanks filled.
+    /// Blank-only by design: unlike the per-book rescan endpoint, this never
+    /// overwrites a populated field, so manual edits survive. Gated by the
+    /// MetadataAutoBackfillEnabled setting (off by default).
+    /// </summary>
+    public class MetadataAutoBackfillService(
+        ILogger<MetadataAutoBackfillService> logger,
+        IMetadataAutoBackfillProcessor processor,
+        IWorkerCycleRunner cycleRunner) : BackgroundService
+    {
+        private static readonly TimeSpan StartupDelay = TimeSpan.FromMinutes(3);
+        private static readonly TimeSpan CycleInterval = TimeSpan.FromMinutes(15);
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            logger.LogInformation(
+                "MetadataAutoBackfillService started; checking for books missing metadata every {Minutes} minutes",
+                CycleInterval.TotalMinutes);
+
+            await cycleRunner.RunPeriodicAsync(
+                nameof(MetadataAutoBackfillService),
+                initialDelay: StartupDelay,
+                intervalProvider: () => CycleInterval,
+                runCycle: processor.RunCycleAsync,
+                stoppingToken);
+
+            logger.LogInformation("MetadataAutoBackfillService stopped");
+        }
+    }
+
+    public interface IMetadataAutoBackfillProcessor
+    {
+        Task RunCycleAsync(CancellationToken cancellationToken);
+    }
+
+    public enum MetadataAutoBackfillOutcome
+    {
+        /// <summary>
+        /// Left alone and NOT marked attempted: the book has an unresolved move,
+        /// or the record disappeared between candidate selection and apply.
+        /// </summary>
+        Skipped,
+        /// <summary>No ASIN/ISBN could be resolved to provider metadata; marked attempted.</summary>
+        NoMetadata,
+        /// <summary>Provider answered but every field it knows was already populated.</summary>
+        NothingToFill,
+        /// <summary>One or more blank fields were filled.</summary>
+        Filled
+    }
+
+    public class MetadataAutoBackfillProcessor(
+        IServiceScopeFactory scopeFactory,
+        IAudiobookOperationCoordinator audiobookOperationCoordinator,
+        IMoveQueueService moveQueueService,
+        ILogger<MetadataAutoBackfillProcessor> logger) : IMetadataAutoBackfillProcessor
+    {
+        // Provider etiquette: a small batch per cycle with a pause between lookups.
+        // 25 every 15 minutes is ~100 books/hour — a few-hundred-book backlog
+        // clears in an afternoon without ever bursting at Audible/Audnexus.
+        internal const int MaxLookupsPerCycle = 25;
+        internal static readonly TimeSpan DelayBetweenLookups = TimeSpan.FromSeconds(3);
+
+        // A book whose lookup found nothing (or still has blanks the provider
+        // can't fill) is retried on this cadence rather than every cycle.
+        internal static readonly TimeSpan RetryInterval = TimeSpan.FromDays(7);
+
+        private const int MaxAsinLookupAttemptsPerBook = 3;
+
+        public async Task RunCycleAsync(CancellationToken cancellationToken)
+        {
+            using var scope = scopeFactory.CreateScope();
+            var configurationService = scope.ServiceProvider.GetRequiredService<IConfigurationService>();
+            var settings = await configurationService.GetApplicationSettingsAsync();
+            if (!settings.MetadataAutoBackfillEnabled)
+            {
+                logger.LogDebug("Automatic metadata backfill is disabled in settings; skipping cycle");
+                return;
+            }
+
+            var defaultRegion = string.IsNullOrWhiteSpace(settings.DefaultSearchRegion)
+                ? "us"
+                : settings.DefaultSearchRegion;
+
+            var repository = scope.ServiceProvider.GetRequiredService<IAudiobookRepository>();
+            var candidates = await repository.GetMetadataBackfillCandidatesAsync(
+                MaxLookupsPerCycle,
+                DateTime.UtcNow - RetryInterval,
+                cancellationToken);
+
+            if (candidates.Count == 0)
+            {
+                logger.LogDebug("Automatic metadata backfill found no books missing metadata");
+                return;
+            }
+
+            logger.LogInformation(
+                "Automatic metadata backfill: {Count} book(s) missing metadata this cycle",
+                candidates.Count);
+
+            var filled = 0;
+            var nothingToFill = 0;
+            var noMetadata = 0;
+            var skipped = 0;
+            var failed = 0;
+
+            for (var index = 0; index < candidates.Count; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var candidate = candidates[index];
+
+                try
+                {
+                    var outcome = await ProcessAsync(candidate, defaultRegion, cancellationToken);
+                    switch (outcome)
+                    {
+                        case MetadataAutoBackfillOutcome.Filled: filled++; break;
+                        case MetadataAutoBackfillOutcome.NothingToFill: nothingToFill++; break;
+                        case MetadataAutoBackfillOutcome.NoMetadata: noMetadata++; break;
+                        default: skipped++; break;
+                    }
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException)
+                {
+                    failed++;
+                    logger.LogWarning(
+                        ex,
+                        "Automatic metadata backfill failed for audiobook {AudiobookId} ({Title})",
+                        candidate.Id,
+                        LogRedaction.SanitizeText(candidate.Title));
+                }
+
+                if (index < candidates.Count - 1)
+                {
+                    await Task.Delay(DelayBetweenLookups, cancellationToken);
+                }
+            }
+
+            logger.LogInformation(
+                "Automatic metadata backfill cycle complete: {Filled} filled, {NothingToFill} already complete, {NoMetadata} without provider metadata, {Skipped} skipped, {Failed} failed",
+                filled,
+                nothingToFill,
+                noMetadata,
+                skipped,
+                failed);
+        }
+
+        /// <summary>
+        /// One book: resolve provider metadata by its identifiers, then fill blanks
+        /// under the per-audiobook exclusive lock so a concurrent edit or move can't
+        /// be clobbered.
+        /// </summary>
+        internal async Task<MetadataAutoBackfillOutcome> ProcessAsync(
+            Audiobook candidate,
+            string defaultRegion,
+            CancellationToken cancellationToken)
+        {
+            var recovery = await moveQueueService.GetRecoveryStateForAudiobookAsync(candidate.Id, cancellationToken);
+            if (recovery.BlocksFilesystemMutation)
+            {
+                logger.LogDebug(
+                    "Skipping automatic metadata backfill for audiobook {AudiobookId}; unresolved move state {Disposition}",
+                    candidate.Id,
+                    recovery.Disposition);
+                return MetadataAutoBackfillOutcome.Skipped;
+            }
+
+            using var scope = scopeFactory.CreateScope();
+            var metadataService = scope.ServiceProvider.GetRequiredService<IAudiobookMetadataService>();
+            var asinLookupService = scope.ServiceProvider.GetService<IAsinLookupService>();
+            var imageCacheService = scope.ServiceProvider.GetService<IImageCacheService>();
+            var converters = scope.ServiceProvider.GetService<MetadataConverters>()
+                ?? new MetadataConverters(
+                    imageCacheService,
+                    scope.ServiceProvider.GetRequiredService<ILogger<MetadataConverters>>());
+
+            var lookup = await ResolveProviderMetadataAsync(
+                candidate,
+                defaultRegion,
+                metadataService,
+                asinLookupService,
+                cancellationToken);
+
+            if (lookup == null)
+            {
+                var repository = scope.ServiceProvider.GetRequiredService<IAudiobookRepository>();
+                await repository.SetMetadataBackfillAttemptedAtAsync(candidate.Id, DateTime.UtcNow, cancellationToken);
+                logger.LogInformation(
+                    "Automatic metadata backfill found no provider metadata for audiobook {AudiobookId} ({Title}); will retry in {Days} days",
+                    candidate.Id,
+                    LogRedaction.SanitizeText(candidate.Title),
+                    RetryInterval.TotalDays);
+                return MetadataAutoBackfillOutcome.NoMetadata;
+            }
+
+            var (envelope, resolvedAsin) = lookup.Value;
+            var metadata = converters.ConvertAudibleToMetadata(
+                envelope.Metadata,
+                resolvedAsin,
+                string.IsNullOrWhiteSpace(envelope.Source) ? "Audible" : envelope.Source);
+
+            try
+            {
+                return await audiobookOperationCoordinator.ExecuteExclusiveAsync(
+                    candidate.Id,
+                    async token =>
+                    {
+                        await moveQueueService.EnsureFilesystemMutationAllowedAsync(candidate.Id, token);
+                        return await ApplyAsync(candidate.Id, resolvedAsin, metadata, imageCacheService, token);
+                    },
+                    cancellationToken);
+            }
+            catch (ApplicationConflictException ex)
+            {
+                // A move started between the pre-check and the lock; leave the
+                // book for a later cycle rather than marking it attempted.
+                logger.LogDebug(
+                    ex,
+                    "Automatic metadata backfill deferred for audiobook {AudiobookId}; filesystem mutation currently blocked",
+                    candidate.Id);
+                return MetadataAutoBackfillOutcome.Skipped;
+            }
+        }
+
+        private async Task<(AudiobookMetadataEnvelope Envelope, string Asin)?> ResolveProviderMetadataAsync(
+            Audiobook candidate,
+            string defaultRegion,
+            IAudiobookMetadataService metadataService,
+            IAsinLookupService? asinLookupService,
+            CancellationToken cancellationToken)
+        {
+            var identifiers = AudiobookIdentifierMapper.GetEffectiveIdentifiers(candidate);
+            var attempts = 0;
+            var tried = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            async Task<(AudiobookMetadataEnvelope, string)?> TryAsinAsync(string? rawAsin, string? preferredRegion)
+            {
+                if (!AudiobookIdentifierNormalizer.TryNormalize(
+                        AudiobookExternalIdentifierType.Asin,
+                        rawAsin ?? string.Empty,
+                        out var asin,
+                        out _)
+                    || string.IsNullOrWhiteSpace(asin))
+                {
+                    return null;
+                }
+
+                var region = string.IsNullOrWhiteSpace(preferredRegion) ? defaultRegion : preferredRegion!;
+                if (!tried.Add($"{asin}|{region}") || attempts >= MaxAsinLookupAttemptsPerBook)
+                {
+                    return null;
+                }
+
+                attempts++;
+                try
+                {
+                    var envelope = await metadataService.GetMetadataAsync(asin, region, cache: true);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (envelope?.Metadata == null)
+                    {
+                        return null;
+                    }
+
+                    var resolvedAsin = string.IsNullOrWhiteSpace(envelope.Metadata.Asin) ? asin : envelope.Metadata.Asin!;
+                    return (envelope, resolvedAsin);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException)
+                {
+                    logger.LogWarning(
+                        ex,
+                        "Automatic metadata backfill lookup failed for audiobook {AudiobookId} ASIN {Asin} region {Region}",
+                        candidate.Id,
+                        asin,
+                        region);
+                    return null;
+                }
+            }
+
+            foreach (var identifier in identifiers
+                .Where(i => i.Type == AudiobookExternalIdentifierType.Asin)
+                .OrderByDescending(i => i.IsPrimary)
+                .ThenBy(i => i.Id))
+            {
+                var result = await TryAsinAsync(
+                    string.IsNullOrWhiteSpace(identifier.ValueNormalized) ? identifier.ValueRaw : identifier.ValueNormalized,
+                    identifier.Region);
+                if (result != null)
+                {
+                    return result;
+                }
+            }
+
+            if (asinLookupService == null)
+            {
+                return null;
+            }
+
+            foreach (var identifier in identifiers
+                .Where(i => i.Type == AudiobookExternalIdentifierType.Isbn)
+                .OrderByDescending(i => i.IsPrimary)
+                .ThenBy(i => i.Id))
+            {
+                var isbn = string.IsNullOrWhiteSpace(identifier.ValueNormalized) ? identifier.ValueRaw : identifier.ValueNormalized;
+                if (string.IsNullOrWhiteSpace(isbn))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    var (success, asinFromIsbn, _) = await asinLookupService.GetAsinFromIsbnAsync(isbn, cancellationToken);
+                    if (!success || string.IsNullOrWhiteSpace(asinFromIsbn))
+                    {
+                        continue;
+                    }
+
+                    var result = await TryAsinAsync(asinFromIsbn, null);
+                    if (result != null)
+                    {
+                        return result;
+                    }
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex) when (ex is not OutOfMemoryException && ex is not StackOverflowException)
+                {
+                    logger.LogWarning(
+                        ex,
+                        "Automatic metadata backfill ISBN→ASIN conversion failed for audiobook {AudiobookId}",
+                        candidate.Id);
+                }
+            }
+
+            return null;
+        }
+
+        private async Task<MetadataAutoBackfillOutcome> ApplyAsync(
+            int audiobookId,
+            string resolvedAsin,
+            AudibleBookMetadata metadata,
+            IImageCacheService? imageCacheService,
+            CancellationToken cancellationToken)
+        {
+            using var scope = scopeFactory.CreateScope();
+            var repository = scope.ServiceProvider.GetRequiredService<IAudiobookRepository>();
+            var audiobook = await repository.GetByIdAsync(audiobookId);
+            if (audiobook == null)
+            {
+                return MetadataAutoBackfillOutcome.Skipped;
+            }
+
+            var now = DateTime.UtcNow;
+            var filledFields = new List<string>(AudiobookBlankFieldBackfill.Apply(audiobook, metadata));
+            var coverMissing = string.IsNullOrWhiteSpace(audiobook.ImageUrl)
+                && !string.IsNullOrWhiteSpace(metadata.ImageUrl);
+
+            audiobook.MetadataBackfillAttemptedAt = now;
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!await repository.UpdateAsync(audiobook))
+            {
+                return MetadataAutoBackfillOutcome.Skipped;
+            }
+
+            if (coverMissing && imageCacheService != null)
+            {
+                var publishedImageUrl = await CacheCoverAsync(audiobook, resolvedAsin, metadata.ImageUrl!, imageCacheService);
+                if (!string.IsNullOrWhiteSpace(publishedImageUrl)
+                    && await repository.TryUpdateImageUrlAsync(
+                        audiobook.Id,
+                        audiobook.ImageUrl,
+                        publishedImageUrl,
+                        CancellationToken.None))
+                {
+                    filledFields.Add(nameof(Audiobook.ImageUrl));
+                }
+            }
+
+            if (filledFields.Count == 0)
+            {
+                logger.LogDebug(
+                    "Automatic metadata backfill: provider knows nothing new for audiobook {AudiobookId}",
+                    audiobookId);
+                return MetadataAutoBackfillOutcome.NothingToFill;
+            }
+
+            logger.LogInformation(
+                "Automatic metadata backfill filled {Fields} for audiobook {AudiobookId} ({Title}) from {Source} ASIN {Asin}",
+                string.Join(", ", filledFields),
+                audiobookId,
+                LogRedaction.SanitizeText(audiobook.Title),
+                metadata.Source ?? "Audible",
+                resolvedAsin);
+            return MetadataAutoBackfillOutcome.Filled;
+        }
+
+        private async Task<string?> CacheCoverAsync(
+            Audiobook audiobook,
+            string resolvedAsin,
+            string imageUrl,
+            IImageCacheService imageCacheService)
+        {
+            try
+            {
+                var libraryImagePath = await imageCacheService.MoveToLibraryStorageAsync(resolvedAsin, imageUrl);
+                return string.IsNullOrWhiteSpace(libraryImagePath)
+                    ? null
+                    : "/" + libraryImagePath.TrimStart('/');
+            }
+            catch (Exception ex) when (ex is IOException
+                or UnauthorizedAccessException
+                or HttpRequestException
+                or TaskCanceledException
+                or InvalidOperationException)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Automatic metadata backfill could not cache the cover for audiobook {AudiobookId}",
+                    audiobook.Id);
+                return null;
+            }
+        }
+    }
+}

--- a/listenarr.infrastructure/Persistence/Migrations/20260904174436_AddMetadataAutoBackfill.Designer.cs
+++ b/listenarr.infrastructure/Persistence/Migrations/20260904174436_AddMetadataAutoBackfill.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Listenarr.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Listenarr.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ListenArrDbContext))]
-    partial class ListenArrDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260904174436_AddMetadataAutoBackfill")]
+    partial class AddMetadataAutoBackfill
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.8");

--- a/listenarr.infrastructure/Persistence/Migrations/20260904174436_AddMetadataAutoBackfill.cs
+++ b/listenarr.infrastructure/Persistence/Migrations/20260904174436_AddMetadataAutoBackfill.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Listenarr.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMetadataAutoBackfill : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "MetadataBackfillAttemptedAt",
+                table: "Audiobooks",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "MetadataAutoBackfillEnabled",
+                table: "ApplicationSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MetadataBackfillAttemptedAt",
+                table: "Audiobooks");
+
+            migrationBuilder.DropColumn(
+                name: "MetadataAutoBackfillEnabled",
+                table: "ApplicationSettings");
+        }
+    }
+}

--- a/listenarr.infrastructure/Persistence/Repositories/AudiobookRepository.MetadataBackfill.cs
+++ b/listenarr.infrastructure/Persistence/Repositories/AudiobookRepository.MetadataBackfill.cs
@@ -1,0 +1,87 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Microsoft.EntityFrameworkCore;
+
+namespace Listenarr.Infrastructure.Persistence.Repositories
+{
+    public partial class AudiobookRepository
+    {
+        public async Task<List<Audiobook>> GetMetadataBackfillCandidatesAsync(
+            int max,
+            DateTime retryBeforeUtc,
+            CancellationToken ct = default)
+        {
+            if (max <= 0)
+            {
+                return new List<Audiobook>();
+            }
+
+            // Only the string columns are queryable here; the JSON list columns
+            // (narrators, genres) are checked in memory by the fill step, which
+            // runs anyway once one of these triggers the lookup.
+            return await _db.Audiobooks
+                .AsNoTracking()
+                .Include(a => a.ExternalIdentifiers)
+                .Where(a => a.Files!.Any())
+                .Where(a => a.MetadataBackfillAttemptedAt == null || a.MetadataBackfillAttemptedAt < retryBeforeUtc)
+                .Where(a => (a.Asin != null && a.Asin != string.Empty)
+                    || a.ExternalIdentifiers!.Any(i =>
+                        i.Type == AudiobookExternalIdentifierType.Asin
+                        || i.Type == AudiobookExternalIdentifierType.Isbn))
+                .Where(a => a.Description == null || a.Description == string.Empty
+                    || a.ImageUrl == null || a.ImageUrl == string.Empty
+                    || a.Publisher == null || a.Publisher == string.Empty
+                    || a.Language == null || a.Language == string.Empty
+                    || a.PublishedDate == null || a.PublishedDate == string.Empty)
+                .OrderBy(a => a.MetadataBackfillAttemptedAt == null ? 0 : 1)
+                .ThenBy(a => a.MetadataBackfillAttemptedAt)
+                .ThenBy(a => a.Id)
+                .Take(max)
+                .ToListAsync(ct);
+        }
+
+        public async Task SetMetadataBackfillAttemptedAtAsync(
+            int audiobookId,
+            DateTime attemptedAtUtc,
+            CancellationToken ct = default)
+        {
+            // Same detached-stub targeted write as SetLastSearchTimeAsync: the
+            // worker holds a sweep-start snapshot and must not re-save it over
+            // concurrent edits, and the stub path also runs on the InMemory
+            // test provider (ExecuteUpdate does not).
+            var tracked = _db.Audiobooks.Local.FirstOrDefault(a => a.Id == audiobookId);
+            if (tracked != null)
+            {
+                _db.Entry(tracked).State = EntityState.Detached;
+            }
+
+            var stub = new Audiobook { Id = audiobookId, MetadataBackfillAttemptedAt = attemptedAtUtc };
+            var entry = _db.Entry(stub);
+            entry.Property(a => a.MetadataBackfillAttemptedAt).IsModified = true;
+
+            try
+            {
+                await _db.SaveChangesAsync(ct);
+            }
+            finally
+            {
+                entry.State = EntityState.Detached;
+            }
+        }
+    }
+}

--- a/tests/Features/Application/Audiobooks/AudiobookBlankFieldBackfillTests.cs
+++ b/tests/Features/Application/Audiobooks/AudiobookBlankFieldBackfillTests.cs
@@ -1,0 +1,161 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Application.Audiobooks.Metadata;
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Application.Audiobooks
+{
+    [Trait("Name", "AudiobookBlankFieldBackfillTests")]
+    [Trait("Category", "Application")]
+    public sealed class AudiobookBlankFieldBackfillTests : BaseTests
+    {
+        private static AudibleBookMetadata FullProviderRecord() => new()
+        {
+            Asin = "B00B5HZGUG",
+            Title = "The Martian (Provider Title)",
+            Subtitle = "A Novel",
+            Description = "Six days ago, astronaut Mark Watney became one of the first people to walk on Mars.",
+            Publisher = "Podium Audio",
+            Language = "english",
+            PublishYear = "2013",
+            PublishedDate = "2013-03-22",
+            Runtime = 653,
+            Authors = new List<string> { "Andy Weir" },
+            Narrators = new List<string> { "R. C. Bray" },
+            Genres = new List<string> { "Science Fiction", "Hard Science Fiction" },
+            Series = "Provider Series",
+            SeriesNumber = "1",
+            SeriesMemberships = new List<AudiobookSeriesMembership>
+            {
+                new() { SeriesName = "Provider Series", SeriesNumber = "1", IsPrimary = true }
+            }
+        };
+
+        [Fact]
+        public void Apply_FillsOnlyBlankFields_AndReportsThem()
+        {
+            var audiobook = new Audiobook
+            {
+                Title = "The Martian",
+                Authors = new List<string> { "Andy Weir" },
+                Narrators = new List<string>(),
+                Language = "  ",
+            };
+
+            var filled = AudiobookBlankFieldBackfill.Apply(audiobook, FullProviderRecord());
+
+            // Populated fields survive untouched.
+            Assert.Equal("The Martian", audiobook.Title);
+            Assert.Equal(new[] { "Andy Weir" }, audiobook.Authors);
+
+            // Blank (null, empty list, whitespace) fields are filled.
+            Assert.Equal("A Novel", audiobook.Subtitle);
+            Assert.StartsWith("Six days ago", audiobook.Description);
+            Assert.Equal("Podium Audio", audiobook.Publisher);
+            Assert.Equal("english", audiobook.Language);
+            Assert.Equal("2013", audiobook.PublishYear);
+            Assert.Equal("2013-03-22", audiobook.PublishedDate);
+            Assert.Equal(653, audiobook.Runtime);
+            Assert.Equal(new[] { "R. C. Bray" }, audiobook.Narrators);
+            Assert.Equal(new[] { "Science Fiction", "Hard Science Fiction" }, audiobook.Genres);
+            Assert.Equal("Provider Series", audiobook.Series);
+            Assert.Equal("1", audiobook.SeriesNumber);
+
+            Assert.DoesNotContain(nameof(Audiobook.Title), filled);
+            Assert.DoesNotContain(nameof(Audiobook.Authors), filled);
+            Assert.Contains(nameof(Audiobook.Description), filled);
+            Assert.Contains(nameof(Audiobook.Narrators), filled);
+            Assert.Contains(nameof(Audiobook.Language), filled);
+            Assert.Contains(nameof(Audiobook.Series), filled);
+        }
+
+        [Fact]
+        public void Apply_CompleteRecord_ChangesNothing()
+        {
+            var audiobook = new Audiobook
+            {
+                Title = "The Martian",
+                Subtitle = "My Subtitle",
+                Description = "My description.",
+                Publisher = "My Publisher",
+                Language = "German",
+                PublishYear = "2014",
+                PublishedDate = "2014-01-01",
+                Runtime = 600,
+                Authors = new List<string> { "Someone Else" },
+                Narrators = new List<string> { "My Narrator" },
+                Genres = new List<string> { "My Genre" },
+                Series = "My Series",
+                SeriesNumber = "3",
+                SeriesMemberships = new List<AudiobookSeriesMembership>
+                {
+                    new() { SeriesName = "My Series", SeriesNumber = "3", IsPrimary = true }
+                }
+            };
+
+            var filled = AudiobookBlankFieldBackfill.Apply(audiobook, FullProviderRecord());
+
+            Assert.Empty(filled);
+            Assert.Equal("My description.", audiobook.Description);
+            Assert.Equal("My Narrator", Assert.Single(audiobook.Narrators!));
+            Assert.Equal("My Series", audiobook.Series);
+            Assert.Equal("3", audiobook.SeriesNumber);
+            Assert.Equal("My Series", Assert.Single(audiobook.SeriesMemberships!).SeriesName);
+        }
+
+        [Fact]
+        public void Apply_ProviderBlanks_NeverBlankTheRecord()
+        {
+            var audiobook = new Audiobook { Title = "Kept", Description = null };
+            var sparse = new AudibleBookMetadata { Title = "   ", Description = "", Narrators = new List<string> { " " } };
+
+            var filled = AudiobookBlankFieldBackfill.Apply(audiobook, sparse);
+
+            Assert.Empty(filled);
+            Assert.Equal("Kept", audiobook.Title);
+            Assert.Null(audiobook.Description);
+            Assert.Null(audiobook.Narrators);
+        }
+
+        [Fact]
+        public void Apply_LegacySingleAuthorNarrator_UsedWhenListsEmpty()
+        {
+            var audiobook = new Audiobook();
+            var legacy = new AudibleBookMetadata { Author = "Solo Author", Narrator = "Solo Narrator" };
+
+            AudiobookBlankFieldBackfill.Apply(audiobook, legacy);
+
+            Assert.Equal("Solo Author", Assert.Single(audiobook.Authors!));
+            Assert.Equal("Solo Narrator", Assert.Single(audiobook.Narrators!));
+        }
+
+        [Fact]
+        public void Apply_ExistingSeriesPlacement_IsNotReplaced()
+        {
+            // A user-chosen series (legacy field only, no memberships) must not be
+            // overridden by the provider's series.
+            var audiobook = new Audiobook { Series = "Hand-Picked Series", SeriesNumber = "7" };
+
+            var filled = AudiobookBlankFieldBackfill.Apply(audiobook, FullProviderRecord());
+
+            Assert.DoesNotContain(nameof(Audiobook.Series), filled);
+            Assert.Equal("Hand-Picked Series", audiobook.Series);
+            Assert.Equal("7", audiobook.SeriesNumber);
+        }
+    }
+}

--- a/tests/Features/Infrastructure/HostedServices/Metadata/MetadataAutoBackfillProcessorTests.cs
+++ b/tests/Features/Infrastructure/HostedServices/Metadata/MetadataAutoBackfillProcessorTests.cs
@@ -1,0 +1,228 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Listenarr.Infrastructure.HostedServices.Metadata;
+using Listenarr.Tests.Builders;
+using Listenarr.Tests.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Listenarr.Tests.Features.Infrastructure.HostedServices.Metadata
+{
+    [Trait("Name", "MetadataAutoBackfillProcessorTests")]
+    [Trait("Category", "Infrastructure")]
+    public sealed class MetadataAutoBackfillProcessorTests : BaseTests
+    {
+        private const string Asin = "B00B5HZGUG";
+
+        private static AudiobookMetadataEnvelope ProviderEnvelope()
+        {
+            var response = new AudibleBookResponseBuilder()
+                .WithAsin(Asin)
+                .WithTitle("The Martian (Provider Title)")
+                .WithRegion("us")
+                .WithAuthor("Andy Weir")
+                .WithNarrator("R. C. Bray")
+                .WithLengthMinutes(653)
+                .WithReleaseDate("2013-03-22")
+                .Build();
+            response.Description = "Six days ago, astronaut Mark Watney became one of the first people to walk on Mars.";
+            response.Publisher = "Podium Audio";
+            response.Language = "english";
+            response.ImageUrl = "https://m.media-amazon.com/images/I/martian.jpg";
+            return new AudiobookMetadataEnvelope(response, "Audible", "https://www.audible.com/pd/" + Asin);
+        }
+
+        private async Task EnableBackfillAsync(bool enabled = true)
+        {
+            var settings = new ApplicationSettingsBuilder().Build();
+            settings.MetadataAutoBackfillEnabled = enabled;
+            await _applicationSettingsRepository.SaveAsync(settings);
+        }
+
+        private async Task<Audiobook> SeedBookWithFileAsync(string tempDirName, Action<Audiobook>? configure = null)
+        {
+            var audioPath = await FileService.GetFileAsync(
+                FileService.GetTempDirectory(tempDirName),
+                "book.m4b",
+                "audio");
+            var audiobook = new AudiobookBuilder()
+                .WithTitle("The Martian")
+                .WithAuthor("Andy Weir")
+                .WithBasePath(Path.GetDirectoryName(audioPath)!)
+                .Build();
+            audiobook.Asin = Asin;
+            configure?.Invoke(audiobook);
+            audiobook = await _audiobookRepository.AddAsync(audiobook);
+            await _audiobookFileRepository.AddAsync(new AudiobookFileBuilder()
+                .WithAudiobook(audiobook)
+                .WithPath(audioPath)
+                .Build());
+            return audiobook;
+        }
+
+        private MetadataAutoBackfillProcessor CreateProcessor() => new(
+            _provider.GetRequiredService<IServiceScopeFactory>(),
+            _provider.GetRequiredService<IAudiobookOperationCoordinator>(),
+            _provider.GetRequiredService<IMoveQueueService>(),
+            NullLogger<MetadataAutoBackfillProcessor>.Instance);
+
+        private async Task<Audiobook> ReloadAsync(int id)
+        {
+            var factory = _provider.GetRequiredService<IDbContextFactory<ListenArrDbContext>>();
+            await using var db = await factory.CreateDbContextAsync();
+            return await db.Audiobooks.AsNoTracking().SingleAsync(a => a.Id == id);
+        }
+
+        [Fact]
+        public async Task RunCycleAsync_FillsBlankFieldsAndCover_LeavesPopulatedFieldsAlone()
+        {
+            var metadataService = new Mock<IAudiobookMetadataService>(MockBehavior.Strict);
+            metadataService
+                .Setup(s => s.GetMetadataAsync(Asin, "us", true))
+                .ReturnsAsync(ProviderEnvelope());
+            var imageCache = new Mock<IImageCacheService>();
+            imageCache
+                .Setup(c => c.MoveToLibraryStorageAsync(Asin, "https://m.media-amazon.com/images/I/martian.jpg"))
+                .ReturnsAsync("images/library/" + Asin + ".jpg");
+            Init(builder => builder
+                .WithSingleton(metadataService.Object)
+                .WithSingleton(imageCache.Object));
+            await EnableBackfillAsync();
+            var audiobook = await SeedBookWithFileAsync("metadata-backfill-fill");
+
+            await CreateProcessor().RunCycleAsync(CancellationToken.None);
+
+            var persisted = await ReloadAsync(audiobook.Id);
+            Assert.Equal("The Martian", persisted.Title);
+            Assert.Equal(new[] { "Andy Weir" }, persisted.Authors);
+            Assert.StartsWith("Six days ago", persisted.Description);
+            Assert.Equal("Podium Audio", persisted.Publisher);
+            Assert.Equal("english", persisted.Language);
+            Assert.Equal("2013", persisted.PublishYear);
+            Assert.Equal("2013-03-22", persisted.PublishedDate);
+            Assert.Equal(653, persisted.Runtime);
+            Assert.Equal(new[] { "R. C. Bray" }, persisted.Narrators);
+            Assert.Equal("/images/library/" + Asin + ".jpg", persisted.ImageUrl);
+            Assert.NotNull(persisted.MetadataBackfillAttemptedAt);
+            metadataService.VerifyAll();
+        }
+
+        [Fact]
+        public async Task RunCycleAsync_SettingDisabled_NeverLooksUp()
+        {
+            var metadataService = new Mock<IAudiobookMetadataService>(MockBehavior.Strict);
+            Init(builder => builder.WithSingleton(metadataService.Object));
+            await EnableBackfillAsync(enabled: false);
+            var audiobook = await SeedBookWithFileAsync("metadata-backfill-disabled");
+
+            await CreateProcessor().RunCycleAsync(CancellationToken.None);
+
+            var persisted = await ReloadAsync(audiobook.Id);
+            Assert.Null(persisted.Description);
+            Assert.Null(persisted.MetadataBackfillAttemptedAt);
+            metadataService.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task RunCycleAsync_BookWithoutFiles_IsNotACandidate()
+        {
+            var metadataService = new Mock<IAudiobookMetadataService>(MockBehavior.Strict);
+            Init(builder => builder.WithSingleton(metadataService.Object));
+            await EnableBackfillAsync();
+            var wishlist = new AudiobookBuilder().WithTitle("Wanted Only").Build();
+            wishlist.Asin = Asin;
+            wishlist = await _audiobookRepository.AddAsync(wishlist);
+
+            await CreateProcessor().RunCycleAsync(CancellationToken.None);
+
+            var persisted = await ReloadAsync(wishlist.Id);
+            Assert.Null(persisted.Description);
+            Assert.Null(persisted.MetadataBackfillAttemptedAt);
+            metadataService.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task RunCycleAsync_CompleteBook_IsNotACandidate()
+        {
+            var metadataService = new Mock<IAudiobookMetadataService>(MockBehavior.Strict);
+            Init(builder => builder.WithSingleton(metadataService.Object));
+            await EnableBackfillAsync();
+            await SeedBookWithFileAsync("metadata-backfill-complete", book =>
+            {
+                book.Description = "Already described.";
+                book.ImageUrl = "/images/library/existing.jpg";
+                book.Publisher = "Existing Publisher";
+                book.Language = "english";
+                book.PublishedDate = "2013-03-22";
+            });
+
+            await CreateProcessor().RunCycleAsync(CancellationToken.None);
+
+            metadataService.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task RunCycleAsync_NoProviderMetadata_MarksAttemptedAndRetriesLater()
+        {
+            var metadataService = new Mock<IAudiobookMetadataService>(MockBehavior.Strict);
+            metadataService
+                .Setup(s => s.GetMetadataAsync(Asin, "us", true))
+                .ReturnsAsync((AudiobookMetadataEnvelope?)null);
+            var asinLookup = new Mock<IAsinLookupService>(MockBehavior.Strict);
+            Init(builder => builder
+                .WithSingleton(metadataService.Object)
+                .WithSingleton(asinLookup.Object));
+            await EnableBackfillAsync();
+            var audiobook = await SeedBookWithFileAsync("metadata-backfill-miss");
+
+            var processor = CreateProcessor();
+            await processor.RunCycleAsync(CancellationToken.None);
+
+            var persisted = await ReloadAsync(audiobook.Id);
+            Assert.Null(persisted.Description);
+            Assert.NotNull(persisted.MetadataBackfillAttemptedAt);
+            metadataService.Verify(s => s.GetMetadataAsync(Asin, "us", true), Times.Once);
+
+            // A second cycle inside the retry window must not hit the provider again.
+            await processor.RunCycleAsync(CancellationToken.None);
+            metadataService.Verify(s => s.GetMetadataAsync(Asin, "us", true), Times.Once);
+            asinLookup.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public async Task RunCycleAsync_UnresolvedMove_SkipsWithoutMarkingAttempted()
+        {
+            var metadataService = new Mock<IAudiobookMetadataService>(MockBehavior.Strict);
+            Init(builder => builder.WithSingleton(metadataService.Object));
+            await EnableBackfillAsync();
+            var audiobook = await SeedBookWithFileAsync("metadata-backfill-move");
+            await MoveJobTestFactory.SeedUnresolvedExecutionAsync(
+                _provider,
+                audiobook.Id,
+                audiobook.BasePath!,
+                Path.Join(FileService.GetTempPath(), $"metadata-backfill-move-target-{Guid.NewGuid():N}"));
+
+            await CreateProcessor().RunCycleAsync(CancellationToken.None);
+
+            var persisted = await ReloadAsync(audiobook.Id);
+            Assert.Null(persisted.Description);
+            Assert.Null(persisted.MetadataBackfillAttemptedAt);
+            metadataService.VerifyNoOtherCalls();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Books that hold files but lack core metadata (description, cover, publisher, language, release date) currently need a manual trip through the per-book metadata rescan or the edit modal. This adds an unattended, **blank-only** backfill worker so a library's gaps close themselves over time.

- New `MetadataAutoBackfillService` hosted worker (Settings → Features → *Fill missing metadata from online sources automatically*, **off by default**). Every 15 minutes it takes up to 25 candidate books, looks each up by its own ASIN (ISBN falls back through `IAsinLookupService`), waits 3 s between lookups, and fills only the fields the record lacks.
- `AudiobookBlankFieldBackfill` (application layer) is the blank-only counterpart of the rescan's overwrite patch: a populated field is never touched, so manual edits and existing series placement survive. Covers are cached into library storage via `IImageCacheService`, same as the rescan.
- `Audiobook.MetadataBackfillAttemptedAt` (new column) lets the worker rotate through candidates and retry provider misses weekly instead of every cycle. Books with an unresolved move are skipped without being stamped.
- Applies under the per-audiobook exclusive lock and the move-queue mutation fence, mirroring `LibraryMetadataRescanWorkflow`.

Candidate query (`GetMetadataBackfillCandidatesAsync`): has files ∧ has ASIN/ISBN identifier ∧ (description ∨ cover ∨ publisher ∨ language ∨ published date blank) ∧ not attempted in the last 7 days; never-attempted first.

## Migration

`20260904174436_AddMetadataAutoBackfill` — scaffolded with `dotnet ef migrations add`. Adds nullable `Audiobooks.MetadataBackfillAttemptedAt` and `ApplicationSettings.MetadataAutoBackfillEnabled` (default false).

## Tests

- `AudiobookBlankFieldBackfillTests` — blank-only semantics (populated fields kept, whitespace/empty treated as blank, provider blanks never blank the record, legacy single author/narrator fallback, existing series placement kept).
- `MetadataAutoBackfillProcessorTests` — fills blanks + cover and leaves populated fields alone; disabled setting never looks up; wishlist (no files) and complete books are not candidates; provider miss stamps the attempt and is not retried within the window; unresolved move skips without stamping.
- FE: `FeaturesSection.spec.ts` covers the new toggle.

Full backend suite run locally; the only failures are the pre-existing `AudiobookContentMoveServiceTests` class, which fails identically on clean `canary` on this macOS host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012A3PhZjAJkCP4Cvo9gC551