### PR TITLE
fix(notifications): dispatch webhooks for the triggers the settings screen offers

### DIFF
--- a/listenarr.api/Features/Library/LibraryAddWorkflow.PostCommit.cs
+++ b/listenarr.api/Features/Library/LibraryAddWorkflow.PostCommit.cs
@@ -11,9 +11,6 @@ namespace Listenarr.Api.Features.Library
 
             try
             {
-                using var scope = _scopeFactory.CreateScope();
-                var configService = scope.ServiceProvider.GetRequiredService<IConfigurationService>();
-                var settings = await configService.GetApplicationSettingsAsync();
                 var data = new
                 {
                     id = audiobook.Id,
@@ -27,10 +24,8 @@ namespace Listenarr.Api.Features.Library
                     imageUrl = audiobook.ImageUrl
                 };
                 await _notificationService.SendNotificationAsync(
-                    "book-added",
-                    data,
-                    settings.WebhookUrl,
-                    settings.EnabledNotificationTriggers);
+                    NotificationTriggers.BookAdded,
+                    data);
             }
             catch (Exception ex) when (ex is not OperationCanceledException
                 && ex is not OutOfMemoryException

--- a/listenarr.api/Features/Library/LibraryManualScanWorkflow.cs
+++ b/listenarr.api/Features/Library/LibraryManualScanWorkflow.cs
@@ -249,10 +249,6 @@ namespace Listenarr.Api.Features.Library
 
             try
             {
-                using var notificationScope = _scopeFactory.CreateScope();
-                var configService = notificationScope.ServiceProvider
-                    .GetRequiredService<IConfigurationService>();
-                var settings = await configService.GetApplicationSettingsAsync();
                 var availableData = new
                 {
                     id = audiobook.Id,
@@ -267,10 +263,8 @@ namespace Listenarr.Api.Features.Library
                     totalFiles = updated?.Files?.Count ?? 0
                 };
                 await _notificationService.SendNotificationAsync(
-                    "book-available",
-                    availableData,
-                    settings.WebhookUrl,
-                    settings.EnabledNotificationTriggers);
+                    NotificationTriggers.BookAvailable,
+                    availableData);
             }
             catch (Exception exception) when (exception is not OperationCanceledException
                 && exception is not OutOfMemoryException

--- a/listenarr.application/Audiobooks/Catalog/LibraryAddService.PostCommit.cs
+++ b/listenarr.application/Audiobooks/Catalog/LibraryAddService.PostCommit.cs
@@ -73,7 +73,6 @@ public partial class LibraryAddService
             return;
         }
 
-        var settings = await _configurationService.GetApplicationSettingsAsync();
         var data = new
         {
             id = audiobook.Id,
@@ -88,10 +87,8 @@ public partial class LibraryAddService
         };
 
         await _notificationService.SendNotificationAsync(
-            "book-added",
-            data,
-            settings.WebhookUrl,
-            settings.EnabledNotificationTriggers);
+            NotificationTriggers.BookAdded,
+            data);
     }
 
     private static History CreateHistoryEntry(

--- a/listenarr.application/Downloads/Submission/DownloadService.cs
+++ b/listenarr.application/Downloads/Submission/DownloadService.cs
@@ -384,7 +384,6 @@ namespace Listenarr.Application.Downloads.Submission
                 }
             }
 
-            var settings = await configurationService.GetApplicationSettingsAsync();
             var notificationData = await DownloadNotificationPayloadBuilder.BuildBookDownloadingPayloadAsync(
                 audiobookRepository,
                 audiobookId,
@@ -392,7 +391,7 @@ namespace Listenarr.Application.Downloads.Submission
                 ToSearchResult(candidate, prepared),
                 downloadClient);
 
-            await notificationService.SendNotificationAsync("book-downloading", notificationData, settings.WebhookUrl, settings.EnabledNotificationTriggers);
+            await notificationService.SendNotificationAsync(NotificationTriggers.BookDownloading, notificationData);
 
             // Trigger an immediate realtime queue update so the UI shows the new download right away
             // Add a small delay to allow the download client to process and index the new download

--- a/listenarr.application/Notifications/Contracts/INotificationService.cs
+++ b/listenarr.application/Notifications/Contracts/INotificationService.cs
@@ -26,6 +26,14 @@ namespace Listenarr.Application.Notifications.Contracts
         Task SendSystemNotificationAsync(string title, string message);
 
         /// <summary>
+        /// Sends a notification to every target that subscribes to the trigger: the legacy single
+        /// webhook URL and each enabled entry in the configured webhook list.
+        /// </summary>
+        /// <param name="trigger">The event trigger name, from <see cref="NotificationTriggers"/></param>
+        /// <param name="data">The notification data payload</param>
+        Task SendNotificationAsync(string trigger, object data);
+
+        /// <summary>
         /// Sends a notification to a specific webhook
         /// </summary>
         /// <param name="trigger">The event trigger name</param>

--- a/listenarr.domain/Configuration/NotificationTriggers.cs
+++ b/listenarr.domain/Configuration/NotificationTriggers.cs
@@ -1,0 +1,112 @@
+namespace Listenarr.Domain.Configuration
+{
+    /// <summary>
+    /// The single vocabulary of webhook trigger names.
+    /// </summary>
+    /// <remarks>
+    /// Trigger names are stored as free text on <see cref="WebhookConfiguration.Triggers"/> and on
+    /// <see cref="ApplicationSettings.EnabledNotificationTriggers"/>, and they are compared against the
+    /// name a dispatch site passes. Before this type existed the two ends of that comparison were
+    /// written independently, drifted apart, and an ordinal <c>Contains</c> made the mismatch silent.
+    /// Every subscription check now goes through <see cref="IsEnabled"/> so there is one place where
+    /// the vocabulary is defined and one rule for how names are compared.
+    /// </remarks>
+    public static class NotificationTriggers
+    {
+        /// <summary>An audiobook was added to the library.</summary>
+        public const string BookAdded = "book-added";
+
+        /// <summary>A release was handed to a download client.</summary>
+        public const string BookDownloading = "book-downloading";
+
+        /// <summary>A scan found new files for a monitored audiobook.</summary>
+        public const string BookAvailable = "book-available";
+
+        /// <summary>A download finished processing and its files were imported into the library.</summary>
+        public const string BookCompleted = "book-completed";
+
+        /// <summary>A download failed or was blocked from importing.</summary>
+        public const string DownloadFailed = "Failed";
+
+        /// <summary>A library move job finished relocating an audiobook.</summary>
+        public const string LibraryMoved = "Moved";
+
+        /// <summary>A general system message.</summary>
+        public const string SystemMessage = "System";
+
+        /// <summary>
+        /// The triggers a user can subscribe to from the notification settings screen, in the order
+        /// the screen presents them.
+        /// </summary>
+        public static IReadOnlyList<string> UserSelectable { get; } =
+        [
+            BookAdded,
+            BookDownloading,
+            BookAvailable,
+            BookCompleted
+        ];
+
+        /// <summary>
+        /// Maps every accepted spelling to the canonical name it stands for. Names that only ever
+        /// existed inside the dispatch code are kept here so webhook rows saved against them keep
+        /// working.
+        /// </summary>
+        private static readonly Dictionary<string, string> CanonicalNames =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                [BookAdded] = BookAdded,
+                [BookDownloading] = BookDownloading,
+                [BookAvailable] = BookAvailable,
+                [BookCompleted] = BookCompleted,
+                ["Imported"] = BookCompleted,
+                [DownloadFailed] = DownloadFailed,
+                [LibraryMoved] = LibraryMoved,
+                [SystemMessage] = SystemMessage
+            };
+
+        /// <summary>
+        /// Resolves a stored or dispatched trigger name to its canonical spelling. Unknown names are
+        /// returned trimmed and otherwise unchanged so a hand-edited configuration still matches
+        /// itself.
+        /// </summary>
+        public static string Canonicalize(string? trigger)
+        {
+            if (string.IsNullOrWhiteSpace(trigger))
+            {
+                return string.Empty;
+            }
+
+            var trimmed = trigger.Trim();
+            return CanonicalNames.TryGetValue(trimmed, out var canonical) ? canonical : trimmed;
+        }
+
+        /// <summary>
+        /// Reports whether a subscription list selects a dispatched trigger. Comparison is
+        /// case-insensitive and alias-aware, matching how notification payloads already compare
+        /// trigger names.
+        /// </summary>
+        public static bool IsEnabled(IEnumerable<string>? enabledTriggers, string? trigger)
+        {
+            if (enabledTriggers is null)
+            {
+                return false;
+            }
+
+            var wanted = Canonicalize(trigger);
+            if (wanted.Length == 0)
+            {
+                return false;
+            }
+
+            foreach (var enabled in enabledTriggers)
+            {
+                if (string.Equals(Canonicalize(enabled), wanted, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/listenarr.infrastructure/Library/Moving/MoveJobProcessor.Completion.cs
+++ b/listenarr.infrastructure/Library/Moving/MoveJobProcessor.Completion.cs
@@ -172,27 +172,18 @@ internal partial class MoveJobProcessor
         try
         {
             using var scope = scopeFactory.CreateScope();
-            var configurationService = scope.ServiceProvider
-                .GetRequiredService<IConfigurationService>();
             var notificationService = scope.ServiceProvider
                 .GetRequiredService<INotificationService>();
-            var webhooks = await configurationService.GetWebhookConfigurationsAsync();
-            foreach (var webhook in webhooks.Where(webhook =>
-                webhook.IsEnabled && webhook.Triggers.Contains("Moved")))
-            {
-                await notificationService.SendNotificationAsync(
-                    "Moved",
-                    new
-                    {
-                        context.AudiobookTitle,
-                        Source = context.Source,
-                        Target = context.Target,
-                        context.SourceRetained,
-                        Timestamp = timeProvider.GetUtcNow().UtcDateTime
-                    },
-                    webhook.Url,
-                    webhook.Triggers);
-            }
+            await notificationService.SendNotificationAsync(
+                NotificationTriggers.LibraryMoved,
+                new
+                {
+                    context.AudiobookTitle,
+                    Source = context.Source,
+                    Target = context.Target,
+                    context.SourceRetained,
+                    Timestamp = timeProvider.GetUtcNow().UtcDateTime
+                });
 
             return true;
         }

--- a/listenarr.infrastructure/Library/Scanning/ScanJobProcessor.Notifications.cs
+++ b/listenarr.infrastructure/Library/Scanning/ScanJobProcessor.Notifications.cs
@@ -20,15 +20,13 @@ public partial class ScanJobProcessor
         {
             using var scope = _scopeFactory.CreateScope();
             var notificationService = scope.ServiceProvider.GetService<NotificationService>();
-            var configurationService = scope.ServiceProvider.GetRequiredService<IConfigurationService>();
-            var settings = await configurationService.GetApplicationSettingsAsync();
             if (notificationService == null)
             {
                 return;
             }
 
             await notificationService.SendNotificationAsync(
-                "book-available",
+                NotificationTriggers.BookAvailable,
                 new
                 {
                     id = audiobook.Id,
@@ -41,9 +39,7 @@ public partial class ScanJobProcessor
                     qualityProfileId = audiobook.QualityProfileId,
                     filesImported = createdFiles,
                     totalFiles = 0
-                },
-                settings.WebhookUrl,
-                settings.EnabledNotificationTriggers);
+                });
         }
         catch (Exception exception) when (exception is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
         {

--- a/listenarr.infrastructure/Notifications/Delivery/NotificationService.Dispatch.cs
+++ b/listenarr.infrastructure/Notifications/Delivery/NotificationService.Dispatch.cs
@@ -1,0 +1,80 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using Microsoft.Extensions.Logging;
+
+namespace Listenarr.Infrastructure.Notifications.Delivery
+{
+    public partial class NotificationService : INotificationService
+    {
+        /// <summary>
+        /// Sends a trigger to every notification target that subscribes to it: the legacy single
+        /// webhook URL and each enabled entry in the webhook list the settings screen manages.
+        /// </summary>
+        /// <remarks>
+        /// Call sites used to reach only one of those two sets, which is why a webhook added through
+        /// the settings screen never fired for a library or download event. Anything that emits a
+        /// notification should come through here so both sets are considered once.
+        /// </remarks>
+        public async Task SendNotificationAsync(string trigger, object data)
+        {
+            var settings = await _configurationService.GetApplicationSettingsAsync();
+            if (settings == null)
+            {
+                return;
+            }
+
+            var legacyUrl = settings.WebhookUrl;
+            var legacyDelivered = false;
+            if (!string.IsNullOrWhiteSpace(legacyUrl)
+                && NotificationTriggers.IsEnabled(settings.EnabledNotificationTriggers, trigger))
+            {
+                await SendNotificationAsync(trigger, data, legacyUrl, settings.EnabledNotificationTriggers);
+                legacyDelivered = true;
+            }
+
+            foreach (var webhook in settings.Webhooks ?? [])
+            {
+                if (!webhook.IsEnabled
+                    || string.IsNullOrWhiteSpace(webhook.Url)
+                    || !NotificationTriggers.IsEnabled(webhook.Triggers, trigger))
+                {
+                    continue;
+                }
+
+                if (legacyDelivered && string.Equals(webhook.Url, legacyUrl, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                await SendNotificationAsync(trigger, data, webhook.Url, webhook.Triggers);
+            }
+        }
+
+        private async Task SendNotificationSafelyAsync(string trigger, object data, string failureContext)
+        {
+            try
+            {
+                await SendNotificationAsync(trigger, data);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
+            {
+                _logger.LogDebug(ex, "Sending the {Trigger} notification failed for {Context}", trigger, failureContext);
+            }
+        }
+    }
+}

--- a/listenarr.infrastructure/Notifications/Delivery/NotificationService.Webhooks.cs
+++ b/listenarr.infrastructure/Notifications/Delivery/NotificationService.Webhooks.cs
@@ -17,7 +17,7 @@ namespace Listenarr.Infrastructure.Notifications.Delivery
         /// </summary>
         public async Task SendNotificationAsync(string trigger, object data, string webhookUrl, List<string> enabledTriggers)
         {
-            if (string.IsNullOrWhiteSpace(webhookUrl) || enabledTriggers == null || !enabledTriggers.Contains(trigger))
+            if (string.IsNullOrWhiteSpace(webhookUrl) || !NotificationTriggers.IsEnabled(enabledTriggers, trigger))
                 return;
             var allowPrivateWebhookTargets = AllowPrivateWebhookTargetsForCurrentRequest();
             if (!NotificationDiagnostics.TryValidateWebhookTarget(webhookUrl, out var validationReason, allowPrivateWebhookTargets))

--- a/listenarr.infrastructure/Notifications/Delivery/NotificationService.cs
+++ b/listenarr.infrastructure/Notifications/Delivery/NotificationService.cs
@@ -43,49 +43,27 @@ namespace Listenarr.Infrastructure.Notifications.Delivery
             _httpSender = new NotificationHttpSender(httpClient, httpClient, logger, AllowPrivateWebhookTargetsForCurrentRequest);
         }
 
-        // INotificationService interface stubs — webhook dispatch goes through SendNotificationAsync;
-        // these typed convenience methods delegate to the main webhook loop or no-op.
-        public async Task OnDownloadImportedAsync(Download download)
-        {
-            try
-            {
-                var webhooks = await _configurationService.GetWebhookConfigurationsAsync();
-                foreach (var wh in webhooks.Where(w => w.IsEnabled && w.Triggers.Contains("Imported")))
-                    await SendNotificationAsync("Imported", new { AudiobookTitle = download.Title, Timestamp = DateTime.UtcNow }, wh.Url, wh.Triggers);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
-            {
-                _logger.LogDebug(ex, "SendDownloadCompletedNotificationAsync failed for {Id}", download.Id);
-            }
-        }
+        // Typed convenience methods. Each names the event it stands for in the shared trigger
+        // vocabulary and hands it to the dispatcher, which decides which targets subscribe.
+        // A download reaching Moved is the point where its files have been imported into the
+        // library, so it is what the settings screen offers as "Processing Complete".
+        public Task OnDownloadImportedAsync(Download download)
+            => SendNotificationSafelyAsync(
+                NotificationTriggers.BookCompleted,
+                new { AudiobookTitle = download.Title, Timestamp = DateTime.UtcNow },
+                $"download {download.Id}");
 
-        public async Task OnDownloadFailedAsync(Download download)
-        {
-            try
-            {
-                var webhooks = await _configurationService.GetWebhookConfigurationsAsync();
-                foreach (var wh in webhooks.Where(w => w.IsEnabled && w.Triggers.Contains("Failed")))
-                    await SendNotificationAsync("Failed", new { AudiobookTitle = download.Title, Error = download.ErrorMessage, Timestamp = DateTime.UtcNow }, wh.Url, wh.Triggers);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
-            {
-                _logger.LogDebug(ex, "SendDownloadFailedNotificationAsync failed for {Id}", download.Id);
-            }
-        }
+        public Task OnDownloadFailedAsync(Download download)
+            => SendNotificationSafelyAsync(
+                NotificationTriggers.DownloadFailed,
+                new { AudiobookTitle = download.Title, Error = download.ErrorMessage, Timestamp = DateTime.UtcNow },
+                $"download {download.Id}");
 
-        public async Task SendSystemNotificationAsync(string title, string message)
-        {
-            try
-            {
-                var webhooks = await _configurationService.GetWebhookConfigurationsAsync();
-                foreach (var wh in webhooks.Where(w => w.IsEnabled && w.Triggers.Contains("System")))
-                    await SendNotificationAsync("System", new { Title = title, Message = message, Timestamp = DateTime.UtcNow }, wh.Url, wh.Triggers);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
-            {
-                _logger.LogDebug(ex, "SendSystemNotificationAsync failed");
-            }
-        }
+        public Task SendSystemNotificationAsync(string title, string message)
+            => SendNotificationSafelyAsync(
+                NotificationTriggers.SystemMessage,
+                new { Title = title, Message = message, Timestamp = DateTime.UtcNow },
+                "a system message");
 
         // Compatibility shims removed — callers/tests should use NotificationPayloadBuilder directly.
 

--- a/tests/Features/Api/Features/Library/LibraryController_AddToLibraryTests.cs
+++ b/tests/Features/Api/Features/Library/LibraryController_AddToLibraryTests.cs
@@ -516,9 +516,7 @@ namespace Listenarr.Tests.Features.Api.Features.Library
             notifications
                 .Setup(service => service.SendNotificationAsync(
                     It.IsAny<string>(),
-                    It.IsAny<object>(),
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>>()))
+                    It.IsAny<object>()))
                 .ThrowsAsync(new HttpRequestException("webhook unavailable"));
             await ReinitializeAsync(builder =>
                 builder.WithSingleton<INotificationService>(notifications.Object));
@@ -541,10 +539,8 @@ namespace Listenarr.Tests.Features.Api.Features.Library
             Assert.Equal(audiobook.Id, history.AudiobookId);
             notifications.Verify(
                 service => service.SendNotificationAsync(
-                    "book-added",
-                    It.IsAny<object>(),
-                    It.IsAny<string>(),
-                    It.IsAny<List<string>>()),
+                    NotificationTriggers.BookAdded,
+                    It.IsAny<object>()),
                 Times.Once);
         }
 
@@ -1061,7 +1057,13 @@ namespace Listenarr.Tests.Features.Api.Features.Library
                 .ThrowsAsync(new InvalidOperationException("Injected notification settings outage."));
             await ReinitializeAsync(builder => builder
                 .WithSingleton<IConfigurationService>(configurationService.Object));
+            // The notification service reads the settings it needs, so the outage surfaces there.
             var notificationService = new Mock<INotificationService>(MockBehavior.Strict);
+            notificationService
+                .Setup(service => service.SendNotificationAsync(
+                    NotificationTriggers.BookAdded,
+                    It.IsAny<object>()))
+                .ThrowsAsync(new InvalidOperationException("Injected notification settings outage."));
             var workflow = new LibraryAddWorkflow(
                 _provider.GetRequiredService<IAudiobookRepository>(),
                 _provider.GetRequiredService<IImageCacheService>(),
@@ -1092,6 +1094,11 @@ namespace Listenarr.Tests.Features.Api.Features.Library
             Assert.IsType<OkObjectResult>(result);
             var audiobook = Assert.Single(await _audiobookRepository.GetAllAsync());
             Assert.Single(await _historyRepository.GetByAudiobookIdAsync(audiobook.Id));
+            notificationService.Verify(
+                service => service.SendNotificationAsync(
+                    NotificationTriggers.BookAdded,
+                    It.IsAny<object>()),
+                Times.Once);
             notificationService.VerifyNoOtherCalls();
         }
 

--- a/tests/Features/Infrastructure/Notifications/Delivery/NotificationServiceTests.cs
+++ b/tests/Features/Infrastructure/Notifications/Delivery/NotificationServiceTests.cs
@@ -272,7 +272,11 @@ namespace Listenarr.Tests.Features.Infrastructure.Notifications.Delivery
                 year = "2023"
             };
             var webhookUrl = "https://discord.com/api/webhooks/test";
-            var enabledTriggers = new List<string> { trigger };
+            // Pin the shipped vocabulary rather than echoing the trigger back at the guard.
+            // Building this list from `trigger` made the assertion hold for any name at all,
+            // which is how the two trigger vocabularies drifted apart unnoticed.
+            var enabledTriggers = NotificationTriggers.UserSelectable.ToList();
+            Assert.Contains(trigger, enabledTriggers);
 
             // Mock HttpClient to capture the posted content
             string? capturedJson = null;
@@ -388,7 +392,11 @@ namespace Listenarr.Tests.Features.Infrastructure.Notifications.Delivery
         {
             var trigger = "book-added";
             var webhookUrl = "http://127.0.0.1:4545/webhook";
-            var enabledTriggers = new List<string> { trigger };
+            // Pin the shipped vocabulary rather than echoing the trigger back at the guard.
+            // Building this list from `trigger` made the assertion hold for any name at all,
+            // which is how the two trigger vocabularies drifted apart unnoticed.
+            var enabledTriggers = NotificationTriggers.UserSelectable.ToList();
+            Assert.Contains(trigger, enabledTriggers);
             var data = new { title = "Local Webhook Book" };
 
             HttpRequestMessage? capturedRequest = null;
@@ -452,7 +460,11 @@ namespace Listenarr.Tests.Features.Infrastructure.Notifications.Delivery
                 imageUrl = "https://listenarr.example.com/api/v1/images/BATTACH.jpg"
             };
             var webhookUrl = "https://discord.com/api/webhooks/test-attach";
-            var enabledTriggers = new List<string> { trigger };
+            // Pin the shipped vocabulary rather than echoing the trigger back at the guard.
+            // Building this list from `trigger` made the assertion hold for any name at all,
+            // which is how the two trigger vocabularies drifted apart unnoticed.
+            var enabledTriggers = NotificationTriggers.UserSelectable.ToList();
+            Assert.Contains(trigger, enabledTriggers);
 
             var capturedBodies = new List<string>();
 

--- a/tests/Features/Infrastructure/Notifications/Delivery/WebhookTriggerDispatchTests.cs
+++ b/tests/Features/Infrastructure/Notifications/Delivery/WebhookTriggerDispatchTests.cs
@@ -1,0 +1,352 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+using System.Net;
+using System.Text.RegularExpressions;
+using Listenarr.Tests.Common;
+
+namespace Listenarr.Tests.Features.Infrastructure.Notifications.Delivery
+{
+    /// <summary>
+    /// Covers the subscription check that decides whether a configured webhook hears about an event.
+    /// </summary>
+    /// <remarks>
+    /// The settings screen writes trigger names onto a webhook, and the dispatch code compares those
+    /// names against the ones it emits. Those two ends were written independently and shared nothing,
+    /// so every webhook added through the settings screen was silently inert. The tests here assert
+    /// against the shipped vocabulary rather than against a name the test itself supplies, because a
+    /// test that feeds a trigger name in and reads the same name back cannot observe that drift.
+    /// </remarks>
+    [Trait("Name", "WebhookTriggerDispatchTests")]
+    [Trait("Category", "Notifications")]
+    public sealed class WebhookTriggerDispatchTests : BaseTests
+    {
+        private const string WebhookUrl = "https://hooks.notification-target.example/inbound";
+        private const string SecondWebhookUrl = "https://hooks.other-target.example/inbound";
+
+        public static TheoryData<string> UserSelectableTriggers()
+        {
+            var data = new TheoryData<string>();
+            foreach (var trigger in NotificationTriggers.UserSelectable)
+            {
+                data.Add(trigger);
+            }
+
+            return data;
+        }
+
+        [Theory]
+        [MemberData(nameof(UserSelectableTriggers))]
+        public async Task WebhookSubscribedThroughTheSettingsScreen_ReceivesTheMatchingEvent(string trigger)
+        {
+            using var probe = DispatchProbe.ForWebhook(trigger);
+
+            await probe.Service.SendNotificationAsync(trigger, new { title = "A Synthetic Audiobook" });
+
+            Assert.Equal(
+                [WebhookUrl],
+                probe.PostedUrls);
+        }
+
+        [Fact]
+        public async Task ImportedDownload_ReachesAWebhookSubscribedToProcessingComplete()
+        {
+            using var probe = DispatchProbe.ForWebhook(NotificationTriggers.BookCompleted);
+
+            await probe.Service.OnDownloadImportedAsync(ImportedDownload());
+
+            Assert.Equal(
+                [WebhookUrl],
+                probe.PostedUrls);
+        }
+
+        [Fact]
+        public async Task ImportedDownload_StillReachesAWebhookSavedAgainstTheOlderInternalName()
+        {
+            using var probe = DispatchProbe.ForWebhook("Imported");
+
+            await probe.Service.OnDownloadImportedAsync(ImportedDownload());
+
+            Assert.Equal(
+                [WebhookUrl],
+                probe.PostedUrls);
+        }
+
+        [Fact]
+        public async Task FailedDownload_ReachesAWebhookSubscribedToTheFailureTrigger()
+        {
+            using var probe = DispatchProbe.ForWebhook(NotificationTriggers.DownloadFailed);
+
+            await probe.Service.OnDownloadFailedAsync(FailedDownload());
+
+            Assert.Equal(
+                [WebhookUrl],
+                probe.PostedUrls);
+        }
+
+        [Fact]
+        public async Task WebhookSubscribedToADifferentTrigger_HearsNothing()
+        {
+            using var probe = DispatchProbe.ForWebhook(NotificationTriggers.BookAdded);
+
+            await probe.Service.SendNotificationAsync(
+                NotificationTriggers.BookDownloading,
+                new { title = "A Synthetic Audiobook" });
+
+            Assert.Empty(probe.PostedUrls);
+        }
+
+        [Fact]
+        public async Task DisabledWebhook_HearsNothing()
+        {
+            using var probe = DispatchProbe.ForWebhook(NotificationTriggers.BookAdded, isEnabled: false);
+
+            await probe.Service.SendNotificationAsync(
+                NotificationTriggers.BookAdded,
+                new { title = "A Synthetic Audiobook" });
+
+            Assert.Empty(probe.PostedUrls);
+        }
+
+        [Fact]
+        public async Task StoredTriggerCasing_DoesNotDecideWhetherAWebhookFires()
+        {
+            using var probe = DispatchProbe.ForWebhook("Book-Added");
+
+            await probe.Service.SendNotificationAsync(
+                NotificationTriggers.BookAdded,
+                new { title = "A Synthetic Audiobook" });
+
+            Assert.Equal(
+                [WebhookUrl],
+                probe.PostedUrls);
+        }
+
+        [Fact]
+        public async Task EveryMatchingWebhookIsSent_AndTheLegacyTargetIsNotSentTwice()
+        {
+            var settings = new ApplicationSettings
+            {
+                WebhookUrl = WebhookUrl,
+                EnabledNotificationTriggers = [.. NotificationTriggers.UserSelectable],
+                Webhooks =
+                [
+                    // Same URL as the legacy single-webhook setting: one event, one delivery.
+                    NewWebhook(WebhookUrl, NotificationTriggers.BookAdded),
+                    NewWebhook(SecondWebhookUrl, NotificationTriggers.BookAdded)
+                ]
+            };
+
+            using var probe = new DispatchProbe(settings);
+
+            await probe.Service.SendNotificationAsync(
+                NotificationTriggers.BookAdded,
+                new { title = "A Synthetic Audiobook" });
+
+            Assert.Equal(
+                [WebhookUrl, SecondWebhookUrl],
+                probe.PostedUrls);
+        }
+
+        [Fact]
+        public void DefaultEnabledTriggers_AreExactlyTheUserSelectableVocabulary()
+        {
+            Assert.Equal(
+                NotificationTriggers.UserSelectable,
+                new ApplicationSettings().EnabledNotificationTriggers);
+        }
+
+        [Fact]
+        public void SettingsScreenOffersExactlyTheTriggersTheBackendCanDispatch()
+        {
+            var source = File.ReadAllText(Path.Join(
+                TestUtils.FindRepositoryRoot(),
+                "fe",
+                "src",
+                "views",
+                "settings",
+                "NotificationsTab.vue"));
+
+            var checkboxLoop = Regex.Match(
+                source,
+                @"v-for=""t in \[(?<triggers>[^\]]*)\]""",
+                RegexOptions.None,
+                TimeSpan.FromSeconds(5));
+            Assert.True(
+                checkboxLoop.Success,
+                "The trigger checkbox list could not be found in NotificationsTab.vue. "
+                + "If the markup moved, point this test at its new home rather than deleting it: "
+                + "it is the only thing tying the names the screen offers to the names the backend dispatches.");
+
+            var offered = Regex
+                .Matches(
+                    checkboxLoop.Groups["triggers"].Value,
+                    @"'(?<trigger>[^']+)'",
+                    RegexOptions.None,
+                    TimeSpan.FromSeconds(5))
+                .Select(match => match.Groups["trigger"].Value)
+                .ToArray();
+
+            Assert.Equal(NotificationTriggers.UserSelectable, offered);
+        }
+
+        [Fact]
+        public void EveryUserSelectableTrigger_IsEmittedBySomeProductionCallSite()
+        {
+            var repositoryRoot = TestUtils.FindRepositoryRoot();
+            var vocabularyDefinition = Path.Join(
+                repositoryRoot,
+                "listenarr.domain",
+                "Configuration",
+                "NotificationTriggers.cs");
+            var productionSources = new[]
+                {
+                    "listenarr.domain",
+                    "listenarr.application",
+                    "listenarr.infrastructure",
+                    "listenarr.api"
+                }
+                .SelectMany(project => Directory.EnumerateFiles(
+                    Path.Join(repositoryRoot, project),
+                    "*.cs",
+                    SearchOption.AllDirectories))
+                .Where(file => !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                .Where(file => !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                .Where(file => !string.Equals(file, vocabularyDefinition, StringComparison.Ordinal))
+                .Select(File.ReadAllText)
+                .ToArray();
+
+            var memberNames = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [NotificationTriggers.BookAdded] = nameof(NotificationTriggers.BookAdded),
+                [NotificationTriggers.BookDownloading] = nameof(NotificationTriggers.BookDownloading),
+                [NotificationTriggers.BookAvailable] = nameof(NotificationTriggers.BookAvailable),
+                [NotificationTriggers.BookCompleted] = nameof(NotificationTriggers.BookCompleted)
+            };
+
+            var unemitted = NotificationTriggers.UserSelectable
+                .Where(trigger => !productionSources.Any(source =>
+                    source.Contains($"{nameof(NotificationTriggers)}.{memberNames[trigger]}", StringComparison.Ordinal)))
+                .ToArray();
+
+            Assert.True(
+                unemitted.Length == 0,
+                "The settings screen lets a user subscribe to these triggers, but no production code emits them, "
+                + "so the checkbox can never do anything: "
+                + string.Join(", ", unemitted));
+        }
+
+        private static Download ImportedDownload()
+            => new()
+            {
+                Id = "download-imported",
+                Title = "A Synthetic Audiobook"
+            };
+
+        private static Download FailedDownload()
+            => new()
+            {
+                Id = "download-failed",
+                Title = "A Synthetic Audiobook",
+                ErrorMessage = "The synthetic download client refused the release"
+            };
+
+        private static WebhookConfiguration NewWebhook(string url, params string[] triggers)
+            => new()
+            {
+                Name = "Test target",
+                Url = url,
+                Type = "Zapier",
+                Triggers = [.. triggers],
+                IsEnabled = true
+            };
+
+        /// <summary>
+        /// A <see cref="NotificationService"/> wired to a captured transport, so a test can count the
+        /// outbound requests an event actually produced.
+        /// </summary>
+        private sealed class DispatchProbe : IDisposable
+        {
+            private readonly HttpClient _httpClient;
+            private readonly List<Uri> _postedUrls = [];
+
+            public DispatchProbe(ApplicationSettings settings)
+            {
+                var handler = new Mock<HttpMessageHandler>();
+                handler
+                    .Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.IsAny<HttpRequestMessage>(),
+                        ItExpr.IsAny<CancellationToken>())
+                    .Callback<HttpRequestMessage, CancellationToken>((request, _) =>
+                    {
+                        if (request.Method == HttpMethod.Post && request.RequestUri != null)
+                        {
+                            _postedUrls.Add(request.RequestUri);
+                        }
+                    })
+                    .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK));
+
+                var configurationService = new Mock<IConfigurationService>();
+                configurationService
+                    .Setup(service => service.GetApplicationSettingsAsync())
+                    .ReturnsAsync(settings);
+                configurationService
+                    .Setup(service => service.GetWebhookConfigurationsAsync())
+                    .ReturnsAsync(settings.Webhooks ?? []);
+                configurationService
+                    .Setup(service => service.GetStartupConfigAsync())
+                    .ReturnsAsync(new StartupConfig());
+
+                _httpClient = new HttpClient(handler.Object);
+                Service = new NotificationService(
+                    _httpClient,
+                    Mock.Of<ILogger<NotificationService>>(),
+                    configurationService.Object,
+                    new NotificationPayloadBuilderAdapter(),
+                    Mock.Of<IRequestContextAccessor>());
+            }
+
+            public NotificationService Service { get; }
+
+            /// <summary>Every URL that received an outbound POST, in delivery order.</summary>
+            public IReadOnlyList<string> PostedUrls
+                => [.. _postedUrls.Select(uri => uri.ToString())];
+
+            public static DispatchProbe ForWebhook(string storedTrigger, bool isEnabled = true)
+                => new(new ApplicationSettings
+                {
+                    WebhookUrl = string.Empty,
+                    EnabledNotificationTriggers = [],
+                    Webhooks =
+                    [
+                        new WebhookConfiguration
+                        {
+                            Name = "Test target",
+                            Url = WebhookUrl,
+                            Type = "Zapier",
+                            Triggers = [storedTrigger],
+                            IsEnabled = isEnabled
+                        }
+                    ]
+                });
+
+            public void Dispose() => _httpClient.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #872.

A webhook configured in Settings > Notifications never fired for a real event, for two independent reasons. Fixing either alone leaves the feature broken.

**Vocabulary.** The settings screen writes `book-added`, `book-downloading`, `book-available` and `book-completed` onto `WebhookConfiguration.Triggers`. The dispatch guard read `Imported`, `Failed`, `System` and `Moved`. No overlap, so the guard never passed.

**Reach.** The five call sites emitting the kebab names posted only to the legacy singular `settings.WebhookUrl` and never iterated `settings.Webhooks`. So even with the vocabularies reconciled, three of the four checkboxes would still have delivered nothing.

The four kebab names become canonical. They are the settings default, the migration default, what `NotificationPayloadBuilder.Attachments.cs` already compares against, and what the production call sites emit, so this direction moves the fewest live values. Comparison is case-insensitive and alias-aware, so a row storing the literal `Imported` still fires.

`book-completed` gets a real emitter by mapping to the existing `Imported` event, which fires when a download reaches `DownloadStatus.Moved` and is what the UI labels "Processing Complete". No call site was invented. `Moved` is deliberately not mapped there too, since it is the library relocation job and collapsing the two would double-fire and mislabel.

**Narrower than the issue described.** #872 said option 2 also retires the legacy `WebhookUrl`. This does not, because that is a design call rather than part of the defect.

**Behaviour change.** Dispatch is unified, so an install with a legacy `WebhookUrl` stored will also start receiving `book-completed`, where before that target got three events. A URL that is both the legacy target and a configured row receives one delivery, not two, and there is a test for that.

Tests cover each UI-settable trigger producing exactly one outbound request for its event, an unsubscribed and a disabled webhook staying silent, and stored casing not deciding whether a webhook fires. Three existing `NotificationServiceTests` cases built the enabled-trigger list from the same variable they passed as the trigger, so they passed whatever the vocabulary was. Those are repaired to pin the real vocabulary.

Worked through with Claude Code at my direction. The claims above were checked by running them rather than by reading, and I reviewed this before posting.
