### PR TITLE
Fix DbContext concurrency crash in remote-path-mapping reads during polling

### DIFF
--- a/listenarr.infrastructure/Persistence/Repositories/EfRemotePathMappingRepository.cs
+++ b/listenarr.infrastructure/Persistence/Repositories/EfRemotePathMappingRepository.cs
@@ -19,28 +19,37 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Listenarr.Infrastructure.Persistence.Repositories
 {
+    // Uses a context-per-operation via IDbContextFactory rather than a directly-injected
+    // scoped ListenArrDbContext. During download-client polling, path translation fans out
+    // (Task.WhenAll over every queue item) and calls GetByClientIdAsync many times
+    // concurrently; a single shared context (and its one SQLite connection) is not
+    // thread-safe, so concurrent reads tore down an active statement mid-query and poisoned
+    // the pooled connection for every later query (including library search) until restart.
     public class EfRemotePathMappingRepository : IRemotePathMappingRepository
     {
-        private readonly ListenArrDbContext _db;
+        private readonly IDbContextFactory<ListenArrDbContext> _dbFactory;
 
-        public EfRemotePathMappingRepository(ListenArrDbContext db)
+        public EfRemotePathMappingRepository(IDbContextFactory<ListenArrDbContext> dbFactory)
         {
-            _db = db ?? throw new ArgumentNullException(nameof(db));
+            _dbFactory = dbFactory ?? throw new ArgumentNullException(nameof(dbFactory));
         }
 
         public async Task<List<RemotePathMapping>> GetAllAsync(CancellationToken ct = default)
         {
-            return await _db.RemotePathMappings.AsNoTracking().ToListAsync(ct);
+            await using var db = await _dbFactory.CreateDbContextAsync(ct);
+            return await db.RemotePathMappings.AsNoTracking().ToListAsync(ct);
         }
 
         public async Task<RemotePathMapping?> GetByIdAsync(int id, CancellationToken ct = default)
         {
-            return await _db.RemotePathMappings.FindAsync(new object[] { id }, ct);
+            await using var db = await _dbFactory.CreateDbContextAsync(ct);
+            return await db.RemotePathMappings.FindAsync(new object[] { id }, ct);
         }
 
         public async Task<List<RemotePathMapping>> GetByClientIdAsync(string downloadClientId, CancellationToken ct = default)
         {
-            return await _db.RemotePathMappings
+            await using var db = await _dbFactory.CreateDbContextAsync(ct);
+            return await db.RemotePathMappings
                 .AsNoTracking()
                 .Where(m => m.DownloadClientId == downloadClientId)
                 .OrderByDescending(m => m.RemotePath.Length)
@@ -49,25 +58,27 @@ namespace Listenarr.Infrastructure.Persistence.Repositories
 
         public async Task<RemotePathMapping> SaveAsync(RemotePathMapping mapping, CancellationToken ct = default)
         {
-            var existing = await _db.RemotePathMappings.FindAsync(new object[] { mapping.Id }, ct);
+            await using var db = await _dbFactory.CreateDbContextAsync(ct);
+            var existing = await db.RemotePathMappings.FindAsync(new object[] { mapping.Id }, ct);
             if (existing == null)
             {
-                _db.RemotePathMappings.Add(mapping);
+                db.RemotePathMappings.Add(mapping);
             }
             else
             {
-                _db.Entry(existing).CurrentValues.SetValues(mapping);
+                db.Entry(existing).CurrentValues.SetValues(mapping);
             }
-            await _db.SaveChangesAsync(ct);
+            await db.SaveChangesAsync(ct);
             return existing ?? mapping;
         }
 
         public async Task<bool> DeleteAsync(int id, CancellationToken ct = default)
         {
-            var mapping = await _db.RemotePathMappings.FindAsync(new object[] { id }, ct);
+            await using var db = await _dbFactory.CreateDbContextAsync(ct);
+            var mapping = await db.RemotePathMappings.FindAsync(new object[] { id }, ct);
             if (mapping == null) return false;
-            _db.RemotePathMappings.Remove(mapping);
-            await _db.SaveChangesAsync(ct);
+            db.RemotePathMappings.Remove(mapping);
+            await db.SaveChangesAsync(ct);
             return true;
         }
     }

--- a/tests/Features/Infrastructure/Configuration/Paths/RemotePathMappingServiceTests.cs
+++ b/tests/Features/Infrastructure/Configuration/Paths/RemotePathMappingServiceTests.cs
@@ -241,5 +241,30 @@ namespace Listenarr.Tests.Features.Infrastructure.Configuration.Paths
 
             Assert.Equal(Path.Join(localPath, "Author", "book.m4b"), translated);
         }
+
+        [Fact]
+        [Trait("Method", "GetPathMappingByClientAsync")]
+        public async Task GetPathMappingByClientAsync_ConcurrentReads_DoNotShareOneDbContext()
+        {
+            // Regression: download polling fans out many concurrent path translations for one
+            // client. When the repository shared a single scoped DbContext, these concurrent reads
+            // tore down each other's active SQLite statement (poisoning the pooled connection for
+            // every later query, including search). The per-operation IDbContextFactory pattern
+            // makes each read independent, so a burst must complete without an EF/SQLite
+            // concurrency failure.
+            await _remotePathMappingRepository.SaveAsync(new RemotePathMappingBuilder()
+                .WithDownloadClientConfiguration(client)
+                .WithRemotePath("/downloads")
+                .WithLocalPath(FileUtils.GetAbsolutePath("remote-concurrent-imports"))
+                .Build());
+
+            var reads = Enumerable
+                .Range(0, 64)
+                .Select(_ => remotePathMappingService.GetPathMappingByClientAsync(client));
+
+            var results = await Task.WhenAll(reads);
+
+            Assert.All(results, mappings => Assert.Single(mappings));
+        }
     }
 }


### PR DESCRIPTION
Fixes #963.

`EfRemotePathMappingRepository` injected a scoped `ListenArrDbContext` directly and shared it across all reads in a scope. During download polling, `DownloadClientGateway` fans out `Task.WhenAll` over every queue item, each calling `RemotePathMappingService.TranslatePathAsync` several times, so many `GetByClientIdAsync` reads run **concurrently on that one context / SQLite connection**. That tears down an active statement mid-query, poisons the pooled connection, and every later query — including library search — fails until restart.

### Change
Convert the repository to the per-operation `IDbContextFactory<ListenArrDbContext>` pattern already used across the codebase (e.g. `EfDownloadProcessingJobRepository`). Each read/write gets its own short-lived context/connection, so the existing download fan-out is safe as designed. No behavior change.

### Why the suite missed it
Every persistence/concurrency test uses `;Pooling=False`; production leaves pooling on. Added a concurrent-read regression test to `RemotePathMappingServiceTests` (64 parallel `GetPathMappingByClientAsync` for one client), which fails against a shared context and passes with the factory.

### Tests
`RemotePathMapping` suite (21) + `DownloadClientGateway`/`DownloadQueue` (49) green; full build clean.