### PR TITLE
fix(search): an indexer's HTTP timeout no longer aborts the whole search

### DIFF
--- a/listenarr.application/Common/HttpClientTimeoutClassifier.cs
+++ b/listenarr.application/Common/HttpClientTimeoutClassifier.cs
@@ -1,0 +1,36 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Listenarr.Application.Common
+{
+    /// <summary>
+    /// Tells an <see cref="HttpClient.Timeout"/> expiry apart from cooperative cancellation.
+    /// Since .NET 5 the client reports its own timeout as a <see cref="TaskCanceledException"/>
+    /// whose inner exception is a <see cref="TimeoutException"/> — the same base type the
+    /// repository's <c>when (ex is not OperationCanceledException)</c> clauses deliberately let
+    /// through, so an unhandled timeout otherwise aborts the whole operation instead of just the
+    /// one slow call.
+    /// </summary>
+    public static class HttpClientTimeoutClassifier
+    {
+        public static bool IsHttpClientTimeout(Exception exception)
+        {
+            return exception is TaskCanceledException && exception.InnerException is TimeoutException;
+        }
+    }
+}

--- a/listenarr.application/Search/Indexers/Common/IndexerSearchWorkflow.cs
+++ b/listenarr.application/Search/Indexers/Common/IndexerSearchWorkflow.cs
@@ -16,6 +16,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+using Listenarr.Application.Common;
 using Microsoft.Extensions.Logging;
 
 namespace Listenarr.Application.Search.Indexers.Common;
@@ -227,6 +228,17 @@ public class IndexerSearchWorkflow
             }
 
             return providerResults;
+        }
+        catch (OperationCanceledException ex) when (HttpClientTimeoutClassifier.IsHttpClientTimeout(ex))
+        {
+            // HttpClient.Timeout surfaces as a TaskCanceledException, which the
+            // "is not OperationCanceledException" clauses up the whole call chain let
+            // through — so one slow indexer used to abort the entire search (live: a
+            // 60s TorrentDownload response turned a Wanted-page search into a 500 and
+            // discarded the three indexers that had already answered). Nobody cancelled
+            // this search; it is a per-indexer failure like any other.
+            _logger.LogWarning("Indexer {Name} timed out; continuing with the other indexers", indexer.Name);
+            return new List<IndexerSearchResult>();
         }
         catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
         {

--- a/listenarr.infrastructure/Search/Providers/Torznab/TorznabNewznabSearchProvider.cs
+++ b/listenarr.infrastructure/Search/Providers/Torznab/TorznabNewznabSearchProvider.cs
@@ -73,6 +73,15 @@ public partial class TorznabNewznabSearchProvider : IIndexerSearchProvider
             _logger.LogInformation("Indexer {Name} returned {Count} results", indexer.Name, results.Count);
             return results;
         }
+        catch (OperationCanceledException ex) when (HttpClientTimeoutClassifier.IsHttpClientTimeout(ex))
+        {
+            // The client's own timeout, not a caller cancelling: report it as this
+            // indexer's failure so the fan-out keeps the other indexers' results.
+            _logger.LogWarning(
+                "Indexer {Name} did not answer within {TimeoutSeconds}s; treating as no results",
+                indexer.Name, _httpClient.Timeout.TotalSeconds);
+            return new List<IndexerSearchResult>();
+        }
         catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException && ex is not StackOverflowException)
         {
             _logger.LogError(ex, "Error searching Torznab/Newznab indexer {Name}", indexer.Name);

--- a/tests/Features/Application/Search/IndexerSearchWorkflowTimeoutTests.cs
+++ b/tests/Features/Application/Search/IndexerSearchWorkflowTimeoutTests.cs
@@ -1,0 +1,129 @@
+/*
+ * Listenarr - Audiobook Management System
+ * Copyright (C) 2024-2026 Listenarr Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+using Listenarr.Tests.Common;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Listenarr.Tests.Features.Application.Search
+{
+    /// <summary>
+    /// An HttpClient.Timeout expiry is a TaskCanceledException — the one exception type the
+    /// repository's catch clauses deliberately let through. Before the classifier, a single
+    /// slow indexer aborted the whole fan-out (live: a 60s TorrentDownload answer turned a
+    /// Wanted-page search into a 500 and discarded three indexers' results).
+    /// </summary>
+    [Trait("Name", "IndexerSearchWorkflowTimeoutTests")]
+    [Trait("Category", "Search")]
+    public class IndexerSearchWorkflowTimeoutTests : BaseTests
+    {
+        private sealed class StubProvider : IIndexerSearchProvider
+        {
+            public string IndexerType => "Torznab";
+
+            public Task<List<IndexerSearchResult>> SearchAsync(Indexer indexer, string query, string? category = null, SearchRequest? request = null)
+            {
+                return indexer.Name switch
+                {
+                    "Slow" => throw new TaskCanceledException(
+                        "The request was canceled due to the configured HttpClient.Timeout of 60 seconds elapsing.",
+                        new TimeoutException()),
+                    "Cancelled" => throw new OperationCanceledException(),
+                    _ => Task.FromResult(new List<IndexerSearchResult>
+                    {
+                        new() { Title = $"{indexer.Name} hit", Source = indexer.Name }
+                    })
+                };
+            }
+        }
+
+        private sealed class HangingHandler : HttpMessageHandler
+        {
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                await Task.Delay(Timeout.Infinite, cancellationToken);
+                throw new InvalidOperationException("unreachable");
+            }
+        }
+
+        private static Indexer TorznabIndexer(string name) => new()
+        {
+            Id = name.Length,
+            Name = name,
+            Type = "Torrent",
+            Implementation = "Torznab",
+            Url = "http://localhost:9/api",
+            IsEnabled = true
+        };
+
+        private static IndexerSearchWorkflow CreateWorkflow(params Indexer[] enabled)
+        {
+            var repository = new Mock<IIndexerRepository>();
+            repository
+                .Setup(r => r.GetEnabledAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(enabled.ToList());
+
+            return new IndexerSearchWorkflow(
+                new HttpClient(),
+                Mock.Of<IConfigurationService>(),
+                repository.Object,
+                new IIndexerSearchProvider[] { new StubProvider() },
+                new IndexerAdditionalSettingsParser(NullLogger<IndexerAdditionalSettingsParser>.Instance),
+                NullLogger<IndexerSearchWorkflow>.Instance);
+        }
+
+        [Fact]
+        public async Task SearchIndexersAsync_IndexerHttpTimeout_KeepsTheOtherIndexersResults()
+        {
+            var workflow = CreateWorkflow(TorznabIndexer("Slow"), TorznabIndexer("Fast"));
+
+            var results = await workflow.SearchIndexersAsync("some book", isAutomaticSearch: true);
+
+            var only = Assert.Single(results);
+            Assert.Equal("Fast", only.Source);
+        }
+
+        [Fact]
+        public async Task SearchIndexersAsync_CooperativeCancellation_StillPropagates()
+        {
+            var workflow = CreateWorkflow(TorznabIndexer("Cancelled"), TorznabIndexer("Fast"));
+
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => workflow.SearchIndexersAsync("some book", isAutomaticSearch: true));
+        }
+
+        [Fact]
+        public async Task TorznabProvider_HttpClientTimeout_ReturnsNoResultsInsteadOfThrowing()
+        {
+            using var httpClient = new HttpClient(new HangingHandler()) { Timeout = TimeSpan.FromMilliseconds(100) };
+            var provider = new TorznabNewznabSearchProvider(httpClient, NullLogger<TorznabNewznabSearchProvider>.Instance);
+
+            var results = await provider.SearchAsync(TorznabIndexer("Slow"), "some book", "3030");
+
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public void HttpClientTimeoutClassifier_OnlyMatchesTheClientTimeoutShape()
+        {
+            Assert.True(HttpClientTimeoutClassifier.IsHttpClientTimeout(new TaskCanceledException("t", new TimeoutException())));
+            Assert.False(HttpClientTimeoutClassifier.IsHttpClientTimeout(new TaskCanceledException("t")));
+            Assert.False(HttpClientTimeoutClassifier.IsHttpClientTimeout(new OperationCanceledException()));
+            Assert.False(HttpClientTimeoutClassifier.IsHttpClientTimeout(new TimeoutException()));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`HttpClient.Timeout` surfaces as a `TaskCanceledException` (inner `TimeoutException`). Every `catch (Exception ex) when (ex is not OperationCanceledException …)` clause in the indexer call chain deliberately lets that type through, so one slow indexer escapes the per-indexer catch, tears through `Task.WhenAll` and `SearchService`, and turns the request into an unhandled 500 — discarding the results the other indexers had already returned.

Live case: a Torznab indexer that normally answers in ~1s occasionally took 28–60s. On the 60s expiry a Wanted-page `search-and-download` failed with *"The request was canceled due to the configured HttpClient.Timeout of 60 seconds elapsing"* although three of four indexers had answered.

## Fix

- `HttpClientTimeoutClassifier` (application/Common) tells the client-timeout shape (`TaskCanceledException` + inner `TimeoutException`) apart from cooperative cancellation.
- `IndexerSearchWorkflow.SearchIndexerAsync` and `TorznabNewznabSearchProvider.SearchAsync` treat that shape as the indexer's own failure (warning + no results) so the fan-out keeps the other indexers' results. A genuine cancellation still propagates.

## Tests

`IndexerSearchWorkflowTimeoutTests`: a timing-out indexer next to a healthy one yields the healthy one's results; a real `OperationCanceledException` still propagates; the Torznab provider returns empty on an `HttpClient.Timeout`; classifier shape checks. Plus `BackendArchitectureTests` and the existing Torznab parsing / SearchService tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJkHHURUTS2m1QGHwn7xsC